### PR TITLE
feat: lint title if more than 1 commit exists

### DIFF
--- a/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
+++ b/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
@@ -10,7 +10,7 @@ exports['ConventionalCommitLint sets a "failure" context on PR, if commits fail 
   "name": "conventionalcommits.org",
   "output": {
     "title": "Commit message did not follow Conventional Commits",
-    "summary": "Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nRun `git reset --soft HEAD~1 && git commit .` to amend your message.",
+    "summary": "Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nRun `git commit --amend` and edit your message to match Conventional Commit guidelines.",
     "text": ":x: linting errors for \"*Fix all the bugs*\"\n* subject may not be empty\n* type may not be empty\n\n\n"
   }
 }
@@ -27,7 +27,7 @@ exports['ConventionalCommitLint PR With Multiple Commits has an invalid pull req
   "name": "conventionalcommits.org",
   "output": {
     "title": "Commit message did not follow Conventional Commits",
-    "summary": "Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nRun `git reset --soft HEAD~3 && git commit .` to amend your message.",
+    "summary": "Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nedit your pull request title to match Conventional Commit guidelines.",
     "text": ":x: linting errors for \"*this is not a conventional commit*\"\n* subject may not be empty\n* type may not be empty\n\n\n"
   }
 }

--- a/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
+++ b/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
@@ -14,3 +14,20 @@ exports['ConventionalCommitLint sets a "failure" context on PR, if commits fail 
     "text": ":x: linting errors for \"*Fix all the bugs*\"\n* subject may not be empty\n* type may not be empty\n\n\n"
   }
 }
+
+exports['ConventionalCommitLint PR With Multiple Commits has a valid pull request title 1'] = {
+  "name": "conventionalcommits.org",
+  "conclusion": "success",
+  "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+}
+
+exports['ConventionalCommitLint PR With Multiple Commits has an invalid pull request title 1'] = {
+  "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "conclusion": "failure",
+  "name": "conventionalcommits.org",
+  "output": {
+    "title": "Commit message did not follow Conventional Commits",
+    "summary": "Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nRun `git reset --soft HEAD~3 && git commit .` to amend your message.",
+    "text": ":x: linting errors for \"*this is not a conventional commit*\"\n* subject may not be empty\n* type may not be empty\n\n\n"
+  }
+}

--- a/packages/conventional-commit-lint/package.json
+++ b/packages/conventional-commit-lint/package.json
@@ -27,7 +27,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "@commitlint/config-conventional": "^8.0.0",
+    "@commitlint/config-conventional": "^8.1.0",
     "@commitlint/lint": "^8.0.0",
     "@octokit/rest": "^16.28.3",
     "gcf-utils": "^0.4.1",

--- a/packages/conventional-commit-lint/src/conventional-commit-lint.ts
+++ b/packages/conventional-commit-lint/src/conventional-commit-lint.ts
@@ -84,13 +84,19 @@ export = (app: Application) => {
     });
 
     if (lintError) {
+      let summary = `Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\n`;
+      if (commits.length === 1) {
+        summary += 'Run `git commit --amend` and edit your message to match Conventional Commit guidelines.'
+      } else {
+        summary += 'edit your pull request title to match Conventional Commit guidelines.';
+      }
       checkParams = context.repo({
         head_sha: commits[commits.length - 1].sha,
         conclusion: 'failure' as Conclusion,
         name: 'conventionalcommits.org',
         output: {
           title: 'Commit message did not follow Conventional Commits',
-          summary: `Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nRun \`git reset --soft HEAD~${commits.length} && git commit .\` to amend your message.`,
+          summary,
           text,
         },
       });

--- a/packages/conventional-commit-lint/src/conventional-commit-lint.ts
+++ b/packages/conventional-commit-lint/src/conventional-commit-lint.ts
@@ -86,9 +86,11 @@ export = (app: Application) => {
     if (lintError) {
       let summary = `Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\n`;
       if (commits.length === 1) {
-        summary += 'Run `git commit --amend` and edit your message to match Conventional Commit guidelines.'
+        summary +=
+          'Run `git commit --amend` and edit your message to match Conventional Commit guidelines.';
       } else {
-        summary += 'edit your pull request title to match Conventional Commit guidelines.';
+        summary +=
+          'edit your pull request title to match Conventional Commit guidelines.';
       }
       checkParams = context.repo({
         head_sha: commits[commits.length - 1].sha,

--- a/packages/conventional-commit-lint/test/fixtures/pull_request_synchronize_invalid_title.json
+++ b/packages/conventional-commit-lint/test/fixtures/pull_request_synchronize_invalid_title.json
@@ -12,7 +12,7 @@
     "number": 11,
     "state": "open",
     "locked": false,
-    "title": "blerg!: this is a conventional commit",
+    "title": "this is not a conventional commit",
     "user": {
       "login": "bcoe",
       "id": 194609,

--- a/packages/gcf-utils/src/bin/genkey.ts
+++ b/packages/gcf-utils/src/bin/genkey.ts
@@ -25,131 +25,138 @@ import { Base64 } from 'js-base64';
 import { Options } from 'probot';
 import * as tmp from 'tmp';
 
-let argv = yargs
-    .command('gen', "Create and upload a client key.", (yargs: Argv) => {
-        return yargs.option('keyfile', {
-            describe: "The path to the .pem keyfile",
-            type: 'string',
-            default: "key.pem",
-        }).option('verbose', {
-            alias: 'v',
-            default: false,
-            type: 'boolean'
-        }).option('project', {
-            describe: 'Name of GCP project',
-            alias: 'p',
-            type: 'string',
-            demand: true
-        }).option('location', {
-            alias: 'l',
-            desription: 'Keyring location',
-            type: 'string',
-            default: 'global'
-        }).option('bot', {
-            alias: 'b',
-            type: 'string',
-            description: 'Name of the bot'
-        }).option('bucket', {
-            alias: 'bu',
-            type: 'string',
-            description: 'Name of the Bucket'
-        }).option('id', {
-            alias: 'i',
-            type: 'string',
-            description: 'ID of the GitHub Application'
-        }).option('secret', {
-            alias: 's',
-            type: 'string',
-            description: 'Webhook Secret of the GitHub Application'
-        });
-    }).argv;
+const argv = yargs.command(
+  'gen',
+  'Create and upload a client key.',
+  (yargs: Argv) => {
+    return yargs
+      .option('keyfile', {
+        describe: 'The path to the .pem keyfile',
+        type: 'string',
+        default: 'key.pem',
+      })
+      .option('verbose', {
+        alias: 'v',
+        default: false,
+        type: 'boolean',
+      })
+      .option('project', {
+        describe: 'Name of GCP project',
+        alias: 'p',
+        type: 'string',
+        demand: true,
+      })
+      .option('location', {
+        alias: 'l',
+        desription: 'Keyring location',
+        type: 'string',
+        default: 'global',
+      })
+      .option('bot', {
+        alias: 'b',
+        type: 'string',
+        description: 'Name of the bot',
+      })
+      .option('bucket', {
+        alias: 'bu',
+        type: 'string',
+        description: 'Name of the Bucket',
+      })
+      .option('id', {
+        alias: 'i',
+        type: 'string',
+        description: 'ID of the GitHub Application',
+      })
+      .option('secret', {
+        alias: 's',
+        type: 'string',
+        description: 'Webhook Secret of the GitHub Application',
+      });
+  }
+).argv;
 
-
-const keyfile: string = argv.keyfile as string || 'key.pem';
+const keyfile: string = (argv.keyfile as string) || 'key.pem';
 const project: string = argv.project as string;
-const location: string = argv.location as string || 'global';
-const keyring: string = argv.keyring as string || 'probot-keys';
+const location: string = (argv.location as string) || 'global';
+const keyring: string = (argv.keyring as string) || 'probot-keys';
 const bucketName: string = argv.bucket as string;
 const botname: string = argv.bot as string;
 const webhookSecret: string = argv.secret as string;
 const id: number = argv.id as number;
 
-
 if (!project) {
-    console.error('Project name is required');
-    yargs.showHelp();
-    process.exit(1);
+  console.error('Project name is required');
+  yargs.showHelp();
+  process.exit(1);
 }
 if (!botname) {
-    console.error('Name of the bot is required');
-    yargs.showHelp();
-    process.exit(1);
+  console.error('Name of the bot is required');
+  yargs.showHelp();
+  process.exit(1);
 }
 if (!webhookSecret) {
-    console.error('Webhook secret is required');
-    yargs.showHelp();
-    process.exit(1);
+  console.error('Webhook secret is required');
+  yargs.showHelp();
+  process.exit(1);
 }
 if (!id) {
-    console.error('GitHub Application ID is required');
-    yargs.showHelp();
-    process.exit(1);
+  console.error('GitHub Application ID is required');
+  yargs.showHelp();
+  process.exit(1);
 }
 if (!bucketName) {
-    console.error('Bucket Name is required');
-    yargs.showHelp();
-    process.exit(1);
+  console.error('Bucket Name is required');
+  yargs.showHelp();
+  process.exit(1);
 }
 
-let keyContent: string = '';
+let keyContent = '';
 try {
-    keyContent = fs.readFileSync(keyfile, 'utf8');
+  keyContent = fs.readFileSync(keyfile, 'utf8');
 } catch (e) {
-    console.log(`Error reading file: ${keyfile}`);
-    process.exit(1);
+  console.log(`Error reading file: ${keyfile}`);
+  process.exit(1);
 }
 
-let blob: Options = {
-    cert: keyContent,
-    id: id,
-    secret: webhookSecret
-}
+const blob: Options = {
+  cert: keyContent,
+  id,
+  secret: webhookSecret,
+};
 
 async function run() {
-    let encblob: Buffer = Buffer.from('');
-    try {
-        const opts = project ? { projectId: project } as KMS.v1.KeyManagementServiceClient.ConfigurationObject : undefined;
+  let encblob: Buffer = Buffer.from('');
+  try {
+    const opts = project
+      ? ({
+          projectId: project,
+        } as KMS.v1.KeyManagementServiceClient.ConfigurationObject)
+      : undefined;
 
-        const kmsclient = new KMS.KeyManagementServiceClient(opts);
+    const kmsclient = new KMS.KeyManagementServiceClient(opts);
 
-        const name = kmsclient.cryptoKeyPath(
-            project,
-            location,
-            keyring,
-            botname
-        );
+    const name = kmsclient.cryptoKeyPath(project, location, keyring, botname);
 
-        let plaintext = Base64.encode(JSON.stringify(blob));
-        const [kmsresult] = await kmsclient.encrypt({ name, plaintext: plaintext });
-        encblob = kmsresult.ciphertext;
+    const plaintext = Base64.encode(JSON.stringify(blob));
+    const [kmsresult] = await kmsclient.encrypt({ name, plaintext });
+    encblob = kmsresult.ciphertext;
+  } catch (e) {
+    console.error('Got an error encrypting the blob');
+    console.error(e);
+    process.exit(1);
+  }
 
-    } catch (e) {
-        console.error('Got an error encrypting the blob');
-        console.error(e);
-        process.exit(1);
-    }
+  const options = project ? ({ project } as StorageOptions) : undefined;
+  const storage = new Storage(options);
 
-    const options = (project) ? { project } as StorageOptions : undefined;
-    const storage = new Storage(options);
+  const tmpobj = tmp.dirSync();
+  console.log('Dir: ', tmpobj.name);
 
-    let tmpobj = tmp.dirSync();
-    console.log('Dir: ', tmpobj.name);
+  const fileName = path.join(tmpobj.name, botname);
 
-    const fileName = path.join(tmpobj.name, botname);
+  fs.writeFileSync(fileName, encblob);
 
-    fs.writeFileSync(fileName, encblob);
-
-    await storage.bucket(bucketName).upload(fileName);
-    tmpobj.removeCallback();
+  await storage.bucket(bucketName).upload(fileName);
+  tmpobj.removeCallback();
 }
 run();


### PR DESCRIPTION
A couple changes to make the commit lint bot a bit less of a pain:

1. if more than one commit exists on the PR,  we now lint the title rather than all commits.
1. we support the new `!` syntax on a commit title.
1. we no longer enforce a set of types (since this goes against the goals of conventionalcommits.org, which aims to be mellow).