### PR TITLE
fix: don't enforce ALLOWED_COPYRIGHT_HOLDERS on updates (yet)

### DIFF
--- a/packages/header-checker-lint/__snapshots__/header-checker-lint.js
+++ b/packages/header-checker-lint/__snapshots__/header-checker-lint.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 exports['HeaderCheckerLint opened pull request sets a "failure" context on PR, if new source file is missing license 1'] = {
   "name": "header-check",
   "conclusion": "failure",
@@ -124,13 +125,8 @@ exports['HeaderCheckerLint updated pull request sets a "failure" context on PR, 
   }
 }
 
-exports['HeaderCheckerLint updated pull request sets a "failure" context on PR, if the source file has an invalid copyright holder 1'] = {
+exports['HeaderCheckerLint updated pull request sets a "success" context on PR, on modified file with invalid copyright header 1'] = {
   "name": "header-check",
-  "conclusion": "failure",
-  "head_sha": "87139750cdcf551e8fe8d90c129527a4f358321c",
-  "output": {
-    "title": "Invalid or missing license headers detected.",
-    "summary": "Some new files are missing headers",
-    "text": "`oauth2_http/java/com/google/auth/http/InvalidCopyright.java` has an invalid copyright holder: `Invalid Holder`"
-  }
+  "conclusion": "success",
+  "head_sha": "87139750cdcf551e8fe8d90c129527a4f358321c"
 }

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -134,14 +134,16 @@ export = (app: Application) => {
         continue;
       }
 
-      if (!ALLOWED_COPYRIGHT_HOLDERS.includes(detectedLicense.copyright)) {
-        lintError = true;
-        failureMessages.push(
-          `\`${file.filename}\` has an invalid copyright holder: \`${detectedLicense.copyright}\``
-        );
-      }
-
       if (file.status === 'added') {
+        // TODO: fix the licenses in all existing codebases so that we don't
+        // get bitten by this rule in every PR.
+        if (!ALLOWED_COPYRIGHT_HOLDERS.includes(detectedLicense.copyright)) {
+          lintError = true;
+          failureMessages.push(
+            `\`${file.filename}\` has an invalid copyright holder: \`${detectedLicense.copyright}\``
+          );
+        }
+
         // for new files, ensure the license year is the current year for new
         // files
         const currentYear = new Date().getFullYear();

--- a/packages/header-checker-lint/test/header-checker-lint.ts
+++ b/packages/header-checker-lint/test/header-checker-lint.ts
@@ -310,7 +310,7 @@ describe('HeaderCheckerLint', () => {
       requests.done();
     });
 
-    it('sets a "failure" context on PR, if the source file has an invalid copyright holder', async () => {
+    it('sets a "success" context on PR, on modified file with invalid copyright header', async () => {
       const invalidFiles = require(resolve(
         fixturesPath,
         './invalid_copyright_modified'


### PR DESCRIPTION
We have _a lot_ of copyright holder stanzas that are slightly off (it's creating busy work for every PR today).

Let's only apply this logic for new files that are added for now.