### PR TITLE
feat: add header-checker-lint options file

### DIFF
--- a/packages/header-checker-lint/README.md
+++ b/packages/header-checker-lint/README.md
@@ -15,10 +15,10 @@ with the following options:
 
 | Name | Description | Type | Default |
 |----- | ----------- | ---- | ------- |
-| `allowed_copyright_holders` | List of allowed copyright holders | `string[]` | `[]` |
-| `allowed_license` | The allowed license. This is **not** currently validated. | "Apache-2.0", "MIT | any |
-| `source_file_extensions` | List of file extensions that will be treated as source files | `string[]` | `["ts", "js", "java"]` |
-| `ignore_files` | List of files to ignore. These values will be treated as path globs | `string[]` | `[]` |
+| `allowedCopyrightHolders` | List of allowed copyright holders | `string[]` | `[]` |
+| `allowedLicenses` | The allowed licenses. | `string[]` | `["Apache-2.0", "MIT"]` |
+| `ignoreFiles` | List of files to ignore. These values will be treated as path globs | `string[]` | `[]` |
+| `sourceFileExtensions` | List of file extensions that will be treated as source files | `string[]` | `["ts", "js", "java"]` |
 
 ## Development
 

--- a/packages/header-checker-lint/README.md
+++ b/packages/header-checker-lint/README.md
@@ -1,9 +1,28 @@
 # header-checker-lint
 
-> A GitHub App built with [Probot](https://github.com/probot/probot) that ensures source files
-contain a valid license header.
+> A GitHub App built with [Probot][probot] that ensures source files contain a
+valid license header.
 
-## Setup
+## Installation
+
+You can install this bot [from GitHub][github-app-link].
+
+### Configuration
+
+To configure the bot, you can create a configuration file:
+`.bots/header-checker-lint.json`. The contents of this file define a JSON object
+with the following options:
+
+| Name | Description | Type | Default |
+|----- | ----------- | ---- | ------- |
+| `allowed_copyright_holders` | List of allowed copyright holders | `string[]` | `[]` |
+| `allowed_license` | The allowed license. This is **not** currently validated. | "Apache-2.0", "MIT | any |
+| `source_file_extensions` | List of file extensions that will be treated as source files | `string[]` | `["ts", "js", "java"]` |
+| `ignore_files` | List of files to ignore. These values will be treated as path globs | `string[]` | `[]` |
+
+## Development
+
+### Setup
 
 ```sh
 # Install dependencies
@@ -13,12 +32,12 @@ npm install
 npm start
 ```
 
-## Testing
+### Testing
 
-This bot uses [nock](https://www.npmjs.com/package/nock) for mocking requests
-to GitHub, and [snap-shot-it](https://www.npmjs.com/package/snap-shot-it) for capturing
-responses; This allows updates to the API surface to be treated as a visual diff,
-rather than tediously asserting against each field.
+This bot uses [nock][nock] for mocking requests
+to GitHub, and [snap-shot-it][snap-shot-it] for capturing responses; This allows
+updates to the API surface to be treated as a visual diff, rather than tediously
+asserting against each field.
 
 Running tests:
 
@@ -32,12 +51,19 @@ To update snapshots:
 npm run test:snap
 ```
 
-## Contributing
+### Contributing
 
-If you have suggestions for how header-checker-lint could be improved, or want to report a bug, open an issue! We'd love all and any contributions.
+If you have suggestions for how header-checker-lint could be improved, or want
+to report a bug, open an issue! We'd love all and any contributions.
 
-For more, check out the [Contributing Guide](CONTRIBUTING.md).
+For more, check out the [Contributing Guide][contributing-guide].
 
 ## License
 
 Apache 2.0 © 2019 Google Inc.
+
+[probot]: https://github.com/probot/probot
+[github-app-link]: https://github.com/apps/license-header-lint-gcf
+[nock]: https://www.npmjs.com/package/nock
+[snap-shot-it]: https://www.npmjs.com/package/snap-shot-it
+[contributing-guide]: https://github.com/googleapis/repo-automation-bots/blob/master/CONTRIBUTING.md

--- a/packages/header-checker-lint/__snapshots__/header-checker-lint.js
+++ b/packages/header-checker-lint/__snapshots__/header-checker-lint.js
@@ -1,19 +1,3 @@
-/**
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 exports['HeaderCheckerLint opened pull request sets a "failure" context on PR, if new source file is missing license 1'] = {
   "name": "header-check",
   "conclusion": "failure",
@@ -126,6 +110,12 @@ exports['HeaderCheckerLint updated pull request sets a "failure" context on PR, 
 }
 
 exports['HeaderCheckerLint updated pull request sets a "success" context on PR, on modified file with invalid copyright header 1'] = {
+  "name": "header-check",
+  "conclusion": "success",
+  "head_sha": "87139750cdcf551e8fe8d90c129527a4f358321c"
+}
+
+exports['HeaderCheckerLint opened pull request reads a custom configuration file 1'] = {
   "name": "header-check",
   "conclusion": "success",
   "head_sha": "87139750cdcf551e8fe8d90c129527a4f358321c"

--- a/packages/header-checker-lint/__snapshots__/header-checker-lint.js
+++ b/packages/header-checker-lint/__snapshots__/header-checker-lint.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 exports['HeaderCheckerLint opened pull request sets a "failure" context on PR, if new source file is missing license 1'] = {
   "name": "header-check",
   "conclusion": "failure",

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -47,6 +47,7 @@ interface ConfigurationOptions {
   sourceFileExtensions: string[];
 }
 
+const WELL_KNOWN_CONFIGURATION_FILE = '.bots/header-checker-lint.json';
 const DEFAULT_CONFIGURATION: ConfigurationOptions = {
   allowedCopyrightHolders: ['Google LLC'],
   allowedLicenses: ['Apache-2.0', 'MIT'],
@@ -151,7 +152,7 @@ export = (app: Application) => {
     }
     const files: PullsListFilesResponseItem[] = filesResponse.data;
     const configuration = await Configuration.fromGitHub(
-      '.bots/header-checker-lint.json',
+      WELL_KNOWN_CONFIGURATION_FILE,
       context.payload.pull_request.head.repo.owner.login,
       context.payload.pull_request.head.repo.name,
       context.payload.pull_request.head.ref,

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -39,15 +39,21 @@ interface LicenseHeader {
   year?: number;
 }
 
-const SOURCE_FILE_TYPES = ['ts', 'js', 'java'];
-
-function isSourceFile(file: string): boolean {
-  const extension = file.substring(file.lastIndexOf('.') + 1);
-  return SOURCE_FILE_TYPES.includes(extension);
+interface Configuration {
+  allowedCopyrightHolders: string[],
+  allowedLicenses: LicenseType[],
+  ignoreFiles: string[],
+  sourceFileExtensions: string[],
 }
 
+const DEFAULT_CONFIGURATION: Configuration = {
+  allowedCopyrightHolders: ['Google LLC'],
+  allowedLicenses: ['Apache-2.0', 'MIT'],
+  ignoreFiles: [],
+  sourceFileExtensions: ['ts', 'js', 'java'],
+};
+
 const COPYRIGHT_REGEX = new RegExp('Copyright (\\d{4}) (.*)$');
-const ALLOWED_COPYRIGHT_HOLDERS = ['Google LLC'];
 const APACHE2_REGEX = new RegExp(
   'Licensed under the Apache License, Version 2.0'
 );
@@ -73,6 +79,19 @@ function detectLicenseHeader(contents: string): LicenseHeader {
   return license;
 }
 
+function isSourceFile(file: string, config: Configuration): boolean {
+  const extension = file.substring(file.lastIndexOf('.') + 1);
+  return config.sourceFileExtensions.includes(extension);
+}
+
+function allowedLicense(license: LicenseType, config: Configuration): boolean {
+  return config.allowedLicenses.includes(license);
+}
+
+function allowedCopyrightHolder(copyrightHolder: string, config: Configuration): boolean {
+  return config.allowedCopyrightHolders.includes(copyrightHolder);
+}
+
 export = (app: Application) => {
   app.on('pull_request', async context => {
     // List pull request files for the given PR
@@ -93,6 +112,7 @@ export = (app: Application) => {
       return;
     }
     const files: PullsListFilesResponseItem[] = filesResponse.data;
+    const configuration = DEFAULT_CONFIGURATION;
 
     let lintError = false;
     const failureMessages: string[] = [];
@@ -101,7 +121,7 @@ export = (app: Application) => {
     for (let i = 0; files[i] !== undefined; i++) {
       const file = files[i];
 
-      if (!isSourceFile(file.filename)) {
+      if (!isSourceFile(file.filename, configuration)) {
         app.log.info('ignoring non-source file: ' + file.filename);
         continue;
       }
@@ -118,7 +138,7 @@ export = (app: Application) => {
 
       const detectedLicense = detectLicenseHeader(fileContents);
 
-      if (!detectedLicense.type) {
+      if (!allowedLicense(detectedLicense.type, configuration)) {
         lintError = true;
         failureMessages.push(
           `\`${file.filename}\` is missing a valid license header.`
@@ -137,7 +157,7 @@ export = (app: Application) => {
       if (file.status === 'added') {
         // TODO: fix the licenses in all existing codebases so that we don't
         // get bitten by this rule in every PR.
-        if (!ALLOWED_COPYRIGHT_HOLDERS.includes(detectedLicense.copyright)) {
+        if (!allowedCopyrightHolder(detectedLicense.copyright, configuration)) {
           lintError = true;
           failureMessages.push(
             `\`${file.filename}\` has an invalid copyright holder: \`${detectedLicense.copyright}\``

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -68,25 +68,26 @@ class Configuration {
     ref: string,
     github: GitHubAPI
   ): Promise<Configuration> {
-    const response = await github.repos.getContents({
-      owner,
-      repo,
-      ref,
-      path,
-    });
-
-    if (response.status === 200) {
-      const fileContents = Buffer.from(
-        response.data.content,
-        'base64'
-      ).toString('utf8');
-      return new Configuration({
-        ...DEFAULT_CONFIGURATION,
-        ...JSON.parse(fileContents),
+    return github.repos
+      .getContents({
+        owner,
+        repo,
+        ref,
+        path,
+      })
+      .then(response => {
+        const fileContents = Buffer.from(
+          response.data.content,
+          'base64'
+        ).toString('utf8');
+        return new Configuration({
+          ...DEFAULT_CONFIGURATION,
+          ...JSON.parse(fileContents),
+        });
+      })
+      .catch(() => {
+        return new Configuration(DEFAULT_CONFIGURATION);
       });
-    }
-
-    return new Configuration(DEFAULT_CONFIGURATION);
   }
 
   isSourceFile(file: string): boolean {

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -69,26 +69,24 @@ class Configuration {
     ref: string,
     github: GitHubAPI
   ): Promise<Configuration> {
-    return github.repos
-      .getContents({
+    try {
+      const response = await github.repos.getContents({
         owner,
         repo,
         ref,
         path,
-      })
-      .then(response => {
-        const fileContents = Buffer.from(
-          response.data.content,
-          'base64'
-        ).toString('utf8');
-        return new Configuration({
-          ...DEFAULT_CONFIGURATION,
-          ...JSON.parse(fileContents),
-        });
-      })
-      .catch(() => {
-        return new Configuration(DEFAULT_CONFIGURATION);
       });
+      const fileContents = Buffer.from(
+        response.data.content,
+        'base64'
+      ).toString('utf8');
+      return new Configuration({
+        ...DEFAULT_CONFIGURATION,
+        ...JSON.parse(fileContents),
+      });
+    } catch (_) {
+      return new Configuration(DEFAULT_CONFIGURATION);
+    }
   }
 
   isSourceFile(file: string): boolean {

--- a/packages/header-checker-lint/test/fixtures/config_copyright_holder.json
+++ b/packages/header-checker-lint/test/fixtures/config_copyright_holder.json
@@ -1,0 +1,18 @@
+{
+  "name": "header-checker-lint.json",
+  "path": ".bots/header-checker-lint.json",
+  "sha": "1bf8d34fb32a4a2c0d56a648b92093df3635a0c7",
+  "size": 65,
+  "url": "https://api.github.com/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test",
+  "html_url": "https://github.com/chingor13/google-auth-library-java/blob/header-check-test/.bots/header-checker-lint.json",
+  "git_url": "https://api.github.com/repos/chingor13/google-auth-library-java/git/blobs/1bf8d34fb32a4a2c0d56a648b92093df3635a0c7",
+  "download_url": "https://raw.githubusercontent.com/chingor13/google-auth-library-java/header-check-test/.bots/header-checker-lint.json",
+  "type": "file",
+  "content": "ewogICJhbGxvd2VkQ29weXJpZ2h0SG9sZGVycyI6IFsiSW52YWxpZCBIb2xk\nZXIiLCAiR29vZ2xlIExMQyJdCn0=\n",
+  "encoding": "base64",
+  "_links": {
+      "self": "https://api.github.com/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test",
+      "git": "https://api.github.com/repos/chingor13/google-auth-library-java/git/blobs/1bf8d34fb32a4a2c0d56a648b92093df3635a0c7",
+      "html": "https://github.com/chingor13/google-auth-library-java/blob/header-check-test/.bots/header-checker-lint.json"
+  }
+}

--- a/packages/header-checker-lint/test/header-checker-lint.ts
+++ b/packages/header-checker-lint/test/header-checker-lint.ts
@@ -66,6 +66,10 @@ describe('HeaderCheckerLint', () => {
       const blob = require(resolve(fixturesPath, './missing_license'));
       const requests = nock('https://api.github.com')
         .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
+        .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )
         .reply(200, invalidFiles)
@@ -91,6 +95,10 @@ describe('HeaderCheckerLint', () => {
       const blob = require(resolve(fixturesPath, './missing_license'));
       const requests = nock('https://api.github.com')
         .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
+        .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )
         .reply(200, invalidFiles)
@@ -112,6 +120,10 @@ describe('HeaderCheckerLint', () => {
       const invalidFiles = require(resolve(fixturesPath, './wrong_year_added'));
       const blob = require(resolve(fixturesPath, './wrong_year'));
       const requests = nock('https://api.github.com')
+        .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
         .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )
@@ -138,6 +150,10 @@ describe('HeaderCheckerLint', () => {
       const blob = require(resolve(fixturesPath, './missing_copyright'));
       const requests = nock('https://api.github.com')
         .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
+        .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )
         .reply(200, invalidFiles)
@@ -163,6 +179,10 @@ describe('HeaderCheckerLint', () => {
       const blob = require(resolve(fixturesPath, './invalid_copyright'));
       const requests = nock('https://api.github.com')
         .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
+        .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )
         .reply(200, invalidFiles)
@@ -187,6 +207,10 @@ describe('HeaderCheckerLint', () => {
       ));
       const blob = require(resolve(fixturesPath, './valid_license'));
       const requests = nock('https://api.github.com')
+        .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
         .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )
@@ -221,6 +245,10 @@ describe('HeaderCheckerLint', () => {
       const blob = require(resolve(fixturesPath, './missing_license'));
       const requests = nock('https://api.github.com')
         .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
+        .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )
         .reply(200, invalidFiles)
@@ -246,6 +274,10 @@ describe('HeaderCheckerLint', () => {
       const blob = require(resolve(fixturesPath, './missing_license'));
       const requests = nock('https://api.github.com')
         .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
+        .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )
         .reply(200, invalidFiles)
@@ -267,6 +299,10 @@ describe('HeaderCheckerLint', () => {
       const invalidFiles = require(resolve(fixturesPath, './wrong_year_added'));
       const blob = require(resolve(fixturesPath, './wrong_year'));
       const requests = nock('https://api.github.com')
+        .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
         .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )
@@ -293,6 +329,10 @@ describe('HeaderCheckerLint', () => {
       const blob = require(resolve(fixturesPath, './missing_copyright'));
       const requests = nock('https://api.github.com')
         .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
+        .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )
         .reply(200, invalidFiles)
@@ -318,6 +358,10 @@ describe('HeaderCheckerLint', () => {
       const blob = require(resolve(fixturesPath, './invalid_copyright'));
       const requests = nock('https://api.github.com')
         .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
+        .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )
         .reply(200, invalidFiles)
@@ -342,6 +386,10 @@ describe('HeaderCheckerLint', () => {
       ));
       const blob = require(resolve(fixturesPath, './valid_license'));
       const requests = nock('https://api.github.com')
+        .get(
+          '/repos/chingor13/google-auth-library-java/contents/.bots/header-checker-lint.json?ref=header-check-test'
+        )
+        .reply(404)
         .get(
           '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
         )

--- a/packages/header-checker-lint/test/header-checker-lint.ts
+++ b/packages/header-checker-lint/test/header-checker-lint.ts
@@ -201,7 +201,10 @@ describe('HeaderCheckerLint', () => {
     });
 
     it('reads a custom configuration file', async () => {
-      const customConfig = require(resolve(fixturesPath, './config_copyright_holder'));
+      const customConfig = require(resolve(
+        fixturesPath,
+        './config_copyright_holder'
+      ));
       const invalidFiles = require(resolve(
         fixturesPath,
         './invalid_copyright_added'


### PR DESCRIPTION
The bot now reads a `.bots/header-checker-lint.json` file for configuration. If available, it will set the override the default configuration with values from this json file. If not available, it will use the default configuration.