### PR TITLE
fix: add minimatch dependencies to header-checker-lint

### DIFF
--- a/packages/header-checker-lint/package.json
+++ b/packages/header-checker-lint/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@octokit/rest": "^16.28.3",
     "gcf-utils": "^0.6.0",
+    "minimatch": "^3.0.4",
     "probot": "^9.3.0"
   },
   "devDependencies": {
@@ -36,6 +37,7 @@
     "@types/express": "^4.17.0",
     "@types/ioredis": "^4.0.13",
     "@types/lru-cache": "^5.1.0",
+    "@types/minimatch": "^3.0.3",
     "@types/mocha": "^5.2.7",
     "@types/nock": "^10.0.3",
     "@types/node": "^12.6.1",


### PR DESCRIPTION
Fixes #40 