### PR TITLE
fix: copyright detection

### DIFF
--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -17,6 +17,11 @@
 import { Application } from 'probot';
 import { GitHubAPI } from 'probot/lib/github';
 import {
+  LicenseHeader,
+  LicenseType,
+  detectLicenseHeader,
+} from './header-parser';
+import {
   ChecksCreateParams,
   PullsListFilesResponse,
   PullsListFilesResponseItem,
@@ -32,14 +37,6 @@ type Conclusion =
   | 'timed_out'
   | 'action_required'
   | undefined;
-
-type LicenseType = 'Apache-2.0' | 'MIT' | 'BSD-3' | undefined;
-
-interface LicenseHeader {
-  copyright?: string;
-  type?: LicenseType;
-  year?: number;
-}
 
 interface ConfigurationOptions {
   allowedCopyrightHolders: string[];
@@ -112,37 +109,6 @@ class Configuration {
   allowedCopyrightHolder(copyrightHolder: string): boolean {
     return this.options.allowedCopyrightHolders.includes(copyrightHolder);
   }
-}
-
-const COPYRIGHT_REGEX = /\s*([*#]|\/\/) \s*Copyright (\d{4}) ([\w\s]+)\.?$/;
-const APACHE2_REGEX = new RegExp(
-  'Licensed under the Apache License, Version 2.0'
-);
-const BSD3_REGEX = new RegExp(
-  'Redistribution and use in source and binary forms, with or without'
-);
-const MIT_REGEX = new RegExp('Permission is hereby granted, free of charge,');
-
-// super naive - iterate over lines and use regex
-// TODO: look for the header in comments only
-function detectLicenseHeader(contents: string): LicenseHeader {
-  const license: LicenseHeader = {};
-  contents.split('\n').forEach(line => {
-    const match = line.match(COPYRIGHT_REGEX);
-    if (match) {
-      license.year = Number(match[2]);
-      license.copyright = match[3];
-    }
-
-    if (line.match(APACHE2_REGEX)) {
-      license.type = 'Apache-2.0';
-    } else if (line.match(MIT_REGEX)) {
-      license.type = 'MIT';
-    } else if (line.match(BSD3_REGEX)) {
-      license.type = 'BSD-3';
-    }
-  });
-  return license;
 }
 
 export = (app: Application) => {

--- a/packages/header-checker-lint/src/header-parser.ts
+++ b/packages/header-checker-lint/src/header-parser.ts
@@ -22,7 +22,7 @@ export interface LicenseHeader {
   year?: number;
 }
 
-const COPYRIGHT_REGEX = /\s*([*#]|\/\/) \s*Copyright (\d{4}) ([\w\s]+)\.?$/;
+const COPYRIGHT_REGEX = /\s*([*#]|\/\/) \s*Copyright (\d{4}) ([\w\s]+)\.?/;
 const APACHE2_REGEX = new RegExp(
   'Licensed under the Apache License, Version 2.0'
 );

--- a/packages/header-checker-lint/src/header-parser.ts
+++ b/packages/header-checker-lint/src/header-parser.ts
@@ -35,7 +35,7 @@ const MIT_REGEX = new RegExp('Permission is hereby granted, free of charge,');
 // TODO: look for the header in comments only
 export function detectLicenseHeader(contents: string): LicenseHeader {
   const license: LicenseHeader = {};
-  contents.split('\n').forEach(line => {
+  contents.split(/\r?\n/).forEach(line => {
     const match = line.match(COPYRIGHT_REGEX);
     if (match) {
       license.year = Number(match[2]);

--- a/packages/header-checker-lint/src/header-parser.ts
+++ b/packages/header-checker-lint/src/header-parser.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type LicenseType = 'Apache-2.0' | 'MIT' | 'BSD-3' | undefined;
+
+export interface LicenseHeader {
+  copyright?: string;
+  type?: LicenseType;
+  year?: number;
+}
+
+const COPYRIGHT_REGEX = /\s*([*#]|\/\/) \s*Copyright (\d{4}) ([\w\s]+)\.?$/;
+const APACHE2_REGEX = new RegExp(
+  'Licensed under the Apache License, Version 2.0'
+);
+const BSD3_REGEX = new RegExp(
+  'Redistribution and use in source and binary forms, with or without'
+);
+const MIT_REGEX = new RegExp('Permission is hereby granted, free of charge,');
+
+// super naive - iterate over lines and use regex
+// TODO: look for the header in comments only
+export function detectLicenseHeader(contents: string): LicenseHeader {
+  const license: LicenseHeader = {};
+  contents.split('\n').forEach(line => {
+    const match = line.match(COPYRIGHT_REGEX);
+    if (match) {
+      license.year = Number(match[2]);
+      license.copyright = match[3];
+    }
+
+    if (line.match(APACHE2_REGEX)) {
+      license.type = 'Apache-2.0';
+    } else if (line.match(MIT_REGEX)) {
+      license.type = 'MIT';
+    } else if (line.match(BSD3_REGEX)) {
+      license.type = 'BSD-3';
+    }
+  });
+  return license;
+}

--- a/packages/header-checker-lint/test/fixtures/bash-style-header.txt
+++ b/packages/header-checker-lint/test/fixtures/bash-style-header.txt
@@ -1,0 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+stuff here

--- a/packages/header-checker-lint/test/fixtures/c-style-header-all-rights.txt
+++ b/packages/header-checker-lint/test/fixtures/c-style-header-all-rights.txt
@@ -13,3 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+stuff here

--- a/packages/header-checker-lint/test/fixtures/c-style-header-extended.txt
+++ b/packages/header-checker-lint/test/fixtures/c-style-header-extended.txt
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/packages/header-checker-lint/test/fixtures/c-style-header.txt
+++ b/packages/header-checker-lint/test/fixtures/c-style-header.txt
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+stuff here

--- a/packages/header-checker-lint/test/fixtures/inline-java-style-header.txt
+++ b/packages/header-checker-lint/test/fixtures/inline-java-style-header.txt
@@ -1,0 +1,14 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+stuff here

--- a/packages/header-checker-lint/test/header-parser.ts
+++ b/packages/header-checker-lint/test/header-parser.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { detectLicenseHeader } from '../src/header-parser';
+
+import { resolve } from 'path';
+import fs from 'fs';
+import assert from 'assert';
+
+const fixturesPath = resolve(__dirname, '../../test/fixtures');
+
+describe('detectLicenseHeader', () => {
+  it('should handle c-style comments', async () => {
+    const contents = fs.readFileSync(
+      resolve(fixturesPath, './c-style-header.txt'),
+      'utf-8'
+    );
+    const header = detectLicenseHeader(contents);
+    assert.strictEqual(header.copyright, 'Google LLC');
+    assert.strictEqual(header.year, 2019);
+    assert.strictEqual(header.type, 'Apache-2.0');
+  });
+
+  it('should handle c-style extended comments', async () => {
+    const contents = fs.readFileSync(
+      resolve(fixturesPath, './c-style-header-extended.txt'),
+      'utf-8'
+    );
+    const header = detectLicenseHeader(contents);
+    assert.strictEqual(header.copyright, 'Google LLC. All Rights Reserved.');
+    assert.strictEqual(header.year, 2019);
+    assert.strictEqual(header.type, 'Apache-2.0');
+  });
+
+  it('should handle bash-style comments', async () => {
+    const contents = fs.readFileSync(
+      resolve(fixturesPath, './bash-style-header.txt'),
+      'utf-8'
+    );
+    const header = detectLicenseHeader(contents);
+    assert.strictEqual(header.copyright, 'Google LLC');
+    assert.strictEqual(header.year, 2019);
+    assert.strictEqual(header.type, 'Apache-2.0');
+  });
+});

--- a/packages/header-checker-lint/test/header-parser.ts
+++ b/packages/header-checker-lint/test/header-parser.ts
@@ -34,13 +34,13 @@ describe('detectLicenseHeader', () => {
     assert.strictEqual(header.type, 'Apache-2.0');
   });
 
-  it('should handle c-style extended comments', async () => {
+  it('should handle c-style all rights reserved comments', async () => {
     const contents = fs.readFileSync(
-      resolve(fixturesPath, './c-style-header-extended.txt'),
+      resolve(fixturesPath, './c-style-header-all-rights.txt'),
       'utf-8'
     );
     const header = detectLicenseHeader(contents);
-    assert.strictEqual(header.copyright, 'Google LLC. All Rights Reserved.');
+    assert.strictEqual(header.copyright, 'Google LLC');
     assert.strictEqual(header.year, 2019);
     assert.strictEqual(header.type, 'Apache-2.0');
   });
@@ -48,6 +48,17 @@ describe('detectLicenseHeader', () => {
   it('should handle bash-style comments', async () => {
     const contents = fs.readFileSync(
       resolve(fixturesPath, './bash-style-header.txt'),
+      'utf-8'
+    );
+    const header = detectLicenseHeader(contents);
+    assert.strictEqual(header.copyright, 'Google LLC');
+    assert.strictEqual(header.year, 2019);
+    assert.strictEqual(header.type, 'Apache-2.0');
+  });
+
+  it('should handle inline java-style comments', async () => {
+    const contents = fs.readFileSync(
+      resolve(fixturesPath, './inline-java-style-header.txt'),
       'utf-8'
     );
     const header = detectLicenseHeader(contents);


### PR DESCRIPTION
The header format with `All Rights Reserved.` fails to match the current regex.

` * Copyright 2019 Google LLC. All Rights Reserved.`