### PR TITLE
fix: release-please bot entrypoint name

### DIFF
--- a/packages/release-please/src/app.ts
+++ b/packages/release-please/src/app.ts
@@ -18,4 +18,4 @@ import { GCFBootstrapper } from 'gcf-utils';
 import appFn from './release-please';
 
 const bootstrap = new GCFBootstrapper();
-module.exports.header_checker_lint = bootstrap.gcf(appFn);
+module.exports.release_please = bootstrap.gcf(appFn);


### PR DESCRIPTION
This fixes the deployment to allow the cloud function bootstrapper to find this function.