### PR TITLE
fix(cloudbuild): increase build timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -79,3 +79,7 @@ steps:
       - "$_KEY_LOCATION" 
       - "$_KEY_RING" 
       - "$_FUNCTION_REGION"
+# Each function can take ~2 minutes to deploy.
+# This means at 5 functions, we will run out 
+# at the 10 minute mark. Increase to 20.
+timeout: 1200s


### PR DESCRIPTION
Builds default to 10 minutes. If each function takes ~2 minutes to deploy, we will  hit the timeout at 5 functions. 

Increase timeout to 20 minutes
