### PR TITLE
chore(deps): update release-please to 2.10.1

### DIFF
--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -29,7 +29,7 @@
     "@octokit/rest": "16.28.3",
     "gcf-utils": "^1.0.0",
     "probot": "9.4.0",
-    "release-please": "^2.9.0"
+    "release-please": "^2.10.1"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.6",


### PR DESCRIPTION
Not sure why renovate doesn't update these packages.
