### PR TITLE
refactor: we can trust that @octokit/rest exists

### DIFF
--- a/packages/blunderbuss/package.json
+++ b/packages/blunderbuss/package.json
@@ -27,7 +27,6 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "@octokit/rest": "16.28.3",
     "gcf-utils": "^1.0.0",
     "probot": "9.4.0"
   },

--- a/packages/conventional-commit-lint/package.json
+++ b/packages/conventional-commit-lint/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@commitlint/config-conventional": "^8.1.0",
     "@commitlint/lint": "^8.0.0",
-    "@octokit/rest": "16.28.3",
     "gcf-utils": "^1.0.0",
     "probot": "9.4.0"
   },

--- a/packages/header-checker-lint/package.json
+++ b/packages/header-checker-lint/package.json
@@ -26,7 +26,6 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "@octokit/rest": "16.28.3",
     "gcf-utils": "^1.0.0",
     "minimatch": "^3.0.4",
     "probot": "9.4.0"

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -77,7 +77,7 @@ class Configuration {
         repo,
         ref,
         path,
-      })).data as {content?: string};
+      })).data as { content?: string };
       const fileContents = Buffer.from(
         response.content || '',
         'base64'

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -72,14 +72,14 @@ class Configuration {
     github: GitHubAPI
   ): Promise<Configuration> {
     try {
-      const response = await github.repos.getContents({
+      const response = (await github.repos.getContents({
         owner,
         repo,
         ref,
         path,
-      });
+      })).data as {content?: string};
       const fileContents = Buffer.from(
-        response.data.content,
+        response.content || '',
         'base64'
       ).toString('utf8');
       return new Configuration({

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -26,7 +26,6 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "@octokit/rest": "16.28.3",
     "gcf-utils": "^1.0.0",
     "probot": "9.4.0",
     "release-please": "^2.10.1"


### PR DESCRIPTION
`probot` is guaranteed to pull `@octokit` into our dependency graph, so there's no need to explicitly install it.

This should prevent the two octokit versions from getting out of sync.

fixes https://github.com/googleapis/repo-automation-bots/issues/91