### PR TITLE
fix(trusted-contribution): use kokoro:run instead of kokoro:force-run

### DIFF
--- a/packages/trusted-contribution/src/trusted-contribution.ts
+++ b/packages/trusted-contribution/src/trusted-contribution.ts
@@ -47,7 +47,7 @@ export = (app: Application) => {
       if (isTrustedContribution(PR_AUTHOR)) {
         const issuesAddLabelsParams = context.repo({
           issue_number: context.payload.pull_request.number,
-          labels: ['kokoro:force-run'],
+          labels: ['kokoro:run'],
         });
 
         await context.github.issues.addLabels(issuesAddLabelsParams);


### PR DESCRIPTION
It's possible there are jobs that need `force`, but the the repos I've seen have all worked with `kokoro:run`. Can switch back if this doesn't work as expected.