### PR TITLE
feat(serverless-scheduler-proxy): add PubSub Support

### DIFF
--- a/scripts/cron-deploy.sh
+++ b/scripts/cron-deploy.sh
@@ -52,7 +52,7 @@ for f in *; do
                     gcloud beta scheduler jobs create http "$functionname" \
                             --schedule "$schedule" \
                             --http-method=POST \
-                            --uri="$proxyurl" \
+                            --uri="$proxyurl/v0/cron" \
                             --oidc-service-account-email="$SCHEDULER_SERVICE_ACCOUNT_EMAIL" \
                             --oidc-token-audience="$proxyurl" \
                             --message-body="{\"Name\": \"$(functionname)\", \"Type\" : \"function\", \"Location\": \"$FUNCTION_REGION\"}" \

--- a/serverless-scheduler-proxy/README.md
+++ b/serverless-scheduler-proxy/README.md
@@ -31,3 +31,20 @@ gcloud beta run services add-iam-policy-binding serverless-scheduler-proxy \
 ```bash
 gcloud app create --region=REGION
 ```
+
+1. Enable your project to create Cloud Pub/Sub authentication tokens.
+```bash
+gcloud projects add-iam-policy-binding PROJECT-ID \
+     --member=serviceAccount:service-PROJECT-NUMBER@gcp-sa-pubsub.iam.gserviceaccount.com \
+     --role=roles/iam.serviceAccountTokenCreator
+```
+
+## Create a PubSub Subscription
+
+To use a PubSub Topic/Subscription with this proxy, it must be made with the proper Service Account
+
+```bash
+gcloud beta pubsub subscriptions create cloudRunSubscription --topic TOPICNAME \
+   --push-endpoint=SERVICE-URL/v0/pubsub \
+   --push-auth-service-account=serverless-proxy-cron@PROJECT-ID.iam.gserviceaccount.com
+```

--- a/serverless-scheduler-proxy/main.go
+++ b/serverless-scheduler-proxy/main.go
@@ -68,7 +68,8 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/v0", botCronProxy(cfg))
+	mux.Handle("/v0/cron", botCronProxy(cfg))
+	mux.Handle("/v0/pubsub", botPubSubProxy(cfg))
 
 	addr := ":" + port
 	log.Printf("starting to listen on %s", addr)
@@ -88,51 +89,82 @@ func main() {
 
 func rewriteBotCronURL(c botConfig) func(*http.Request) {
 	return func(req *http.Request) {
-
-		var bodyBytes []byte
-		if req.Body != nil {
-			bodyBytes, _ = ioutil.ReadAll(req.Body)
-			req.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
-		} else {
-			log.Println("request had no body")
-		}
-
-		var pay reqPayload
-		json.Unmarshal(bodyBytes, &pay)
-
-		u := req.URL.String()
-		req.URL.Scheme = "https"
-
-		// Explicitly remove UserAgent header
-		req.Header.Del("user-agent")
-
-		newHost := fmt.Sprintf("%v-%v.cloudfunctions.net", pay.Location, c.project)
-
-		req.Host = newHost
-		req.URL.Host = newHost
-		req.URL.Path = fmt.Sprintf("/%v", pay.Name)
-
-		key, err := getBotSecret(req.Context(), c, pay.Name)
-		if err != nil {
-			log.Printf("error getting bot secret: %v", err)
-		}
-
-		// Make a hmac sig
-		signer := hmac.New(sha1.New, key)
-		signer.Write(bodyBytes)
-
-		req.Header.Add("x-hub-signature", base64.StdEncoding.EncodeToString(signer.Sum(nil)))
 		req.Header.Add("x-github-event", "schedule.repository")
-		req.Header.Add("x-github-delivery", uuid.New().String())
-
-		log.Printf("rewrote url: %s into %s", u, req.URL)
+		parser := func(bodyBytes []byte) (string, string) {
+			var pay reqPayload
+			json.Unmarshal(bodyBytes, &pay)
+			return pay.Name, pay.Location
+		}
+		rewriteBotURL(c, parser, req)
 	}
+}
+
+func rewriteBotPubSubURL(c botConfig) func(*http.Request) {
+	return func(req *http.Request) {
+		req.Header.Add("x-github-event", "pubsub.message")
+		parser := func(bodyBytes []byte) (string, string) {
+			var pay PubSubMessage
+			json.Unmarshal(bodyBytes, &pay)
+			log.Printf("handling pubsub message for subscription: %v\n", pay.Subscription)
+
+			var msg RepoAutomationPubSubMessage
+			json.Unmarshal(pay.Message.Data, &msg)
+			log.Printf("pubsub message for bot: %v in %v\n", msg.BotName, msg.Location)
+			return msg.BotName, msg.Location
+		}
+		rewriteBotURL(c, parser, req)
+	}
+}
+
+func rewriteBotURL(c botConfig, parser func([]byte) (string, string), req *http.Request) {
+
+	var bodyBytes []byte
+	if req.Body != nil {
+		bodyBytes, _ = ioutil.ReadAll(req.Body)
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+	} else {
+		log.Println("request had no body")
+	}
+
+	botName, botLocation := parser(bodyBytes)
+
+	u := req.URL.String()
+	req.URL.Scheme = "https"
+
+	// Explicitly remove UserAgent header
+	req.Header.Del("user-agent")
+
+	newHost := fmt.Sprintf("%v-%v.cloudfunctions.net", botLocation, c.project)
+
+	req.Host = newHost
+	req.URL.Host = newHost
+	req.URL.Path = fmt.Sprintf("/%v", botName)
+
+	key, err := getBotSecret(req.Context(), c, botName)
+	if err != nil {
+		log.Printf("error getting bot secret: %v", err)
+	}
+
+	// Make a hmac sig
+	signer := hmac.New(sha1.New, key)
+	signer.Write(bodyBytes)
+
+	req.Header.Add("x-hub-signature", base64.StdEncoding.EncodeToString(signer.Sum(nil)))
+	req.Header.Add("x-github-delivery", uuid.New().String())
+
+	log.Printf("rewrote url: %s into %s", u, req.URL)
 }
 
 // botCronProxy returns a reverse proxy to the specified bot.
 func botCronProxy(cfg botConfig) http.HandlerFunc {
 	return (&httputil.ReverseProxy{
 		Director: rewriteBotCronURL(cfg),
+	}).ServeHTTP
+}
+
+func botPubSubProxy(cfg botConfig) http.HandlerFunc {
+	return (&httputil.ReverseProxy{
+		Director: rewriteBotPubSubURL(cfg),
 	}).ServeHTTP
 }
 
@@ -189,4 +221,21 @@ func getBotSecret(ctx context.Context, b botConfig, botName string) ([]byte, err
 	}
 
 	return resp.Plaintext, nil
+}
+
+// RepoAutomationPubSubMessage represents
+// THe data recieved from a PubSubMessage
+type RepoAutomationPubSubMessage struct {
+	BotName  string `json:"botname"`           // Name of Bot
+	Location string `json:"location"`          // Region where bot lives
+	Payload  []byte `json:"payload,omitempty"` // Data in the message
+}
+
+// PubSubMessage is the payload of a Pub/Sub event.
+type PubSubMessage struct {
+	Message struct {
+		Data []byte `json:"data,omitempty"`
+		ID   string `json:"id"`
+	} `json:"message"`
+	Subscription string `json:"subscription"`
 }


### PR DESCRIPTION
There are some cases where an external source needs to trigger a Bot to
interact with GitHub (such as Kokoro).

This moves the "v0" URL (which used to support cron) to "v0/cron" and
adds a new URL handler at "v0/pubsub" to handle incoming PubSub
messages.

Fixes #98 
