### PR TITLE
fix: address issues with loading labels

### DIFF
--- a/packages/label-sync/test/test.ts
+++ b/packages/label-sync/test/test.ts
@@ -32,11 +32,11 @@ const newLabels = require('../../src/labels.json') as {
 const repos = require('../../test/fixtures/repos.json');
 
 function nockLabelList() {
-  return nock('https://github.com')
+  return nock('https://api.github.com')
     .get(
-      '/googleapis/repo-automation-bots/blob/master/packages/label-sync/src/labels.json'
+      '/repos/googleapis/repo-automation-bots/contents/packages/label-sync/src/labels.json'
     )
-    .reply(200, newLabels);
+    .reply(200, {content: Buffer.from(JSON.stringify(newLabels), 'utf8')});
 }
 
 function nockFetchOldLabels(labels: Array<{}>) {
@@ -63,6 +63,7 @@ function nockLabelUpdate(name: string) {
     .patch(`/repos/Codertocat/Hello-World/labels/${encodeURI(name)}`)
     .reply(200);
 }
+
 
 function nockRepoList() {
   return nock('https://raw.githubusercontent.com')


### PR DESCRIPTION
@sofisl and I tested this against an actual repo, we found a couple bugs in the process:

1. requesting `https://github.com/googleapis/repo-automation-bots/blob/master/packages/label-sync/src/labels.json'` did not work (returned a 404 I believe); we switched to using the API.
2. `Promise.all()` created a race condition where deletion and creation could potentially happen in conjunction; I switched the logic to being synchronous for the time being (I think for how many labels we have, and how frequently this will run, this is a reasonable decision for the time being).
