### PR TITLE
fix: allow BSD license

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -134,15 +134,15 @@
 			}
 		},
 		"@lerna/add": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.17.0.tgz",
-			"integrity": "sha512-On98kKbYRfUGYzCb2MUWCZyUmwNl1Acbd66CM+hDSrYEPZ7W3uq56Tfya6De+cHGOPWWNWoss3C0ZyKILXpjAA==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.18.4.tgz",
+			"integrity": "sha512-R+9RmYrSbcmnmaFL2aB0HJtTq95ePEa0FMS4r4NnA7Xw07l5buVBPOfxv6P8kFrVvIcNpaa7S0Eo/KkbycMhKA==",
 			"dev": true,
 			"requires": {
 				"@evocateur/pacote": "^9.6.3",
-				"@lerna/bootstrap": "3.17.0",
-				"@lerna/command": "3.16.5",
-				"@lerna/filter-options": "3.16.5",
+				"@lerna/bootstrap": "3.18.4",
+				"@lerna/command": "3.18.0",
+				"@lerna/filter-options": "3.18.4",
 				"@lerna/npm-conf": "3.16.0",
 				"@lerna/validation-error": "3.13.0",
 				"dedent": "^0.7.0",
@@ -160,20 +160,20 @@
 			}
 		},
 		"@lerna/bootstrap": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.17.0.tgz",
-			"integrity": "sha512-2wQEwEtzU1UP7ZuzHtjJPgFxWXY5OectT+sjIFrJDE7C9n9nbAkL9MI/IM2X3RbgRK+sIxbhEqyb9o+0Yfzk1A==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.18.4.tgz",
+			"integrity": "sha512-mvqMyionPSqhbeGhoUQYEBTgbJ47LkONHfQ1AKBET0fJOjIZf6x0pWC17KvfCjsiE017325ySLKDH23z1Kb9ww==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.16.5",
-				"@lerna/filter-options": "3.16.5",
+				"@lerna/command": "3.18.0",
+				"@lerna/filter-options": "3.18.4",
 				"@lerna/has-npm-version": "3.16.5",
 				"@lerna/npm-install": "3.16.5",
-				"@lerna/package-graph": "3.16.0",
+				"@lerna/package-graph": "3.18.0",
 				"@lerna/pulse-till-done": "3.13.0",
 				"@lerna/rimraf-dir": "3.16.5",
 				"@lerna/run-lifecycle": "3.16.2",
-				"@lerna/run-topologically": "3.16.0",
+				"@lerna/run-topologically": "3.18.0",
 				"@lerna/symlink-binary": "3.17.0",
 				"@lerna/symlink-dependencies": "3.17.0",
 				"@lerna/validation-error": "3.13.0",
@@ -199,16 +199,15 @@
 			}
 		},
 		"@lerna/changed": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.16.5.tgz",
-			"integrity": "sha512-Sj66BK/QyYv7YxAQrFg6H+7X68OnSKsVVyTMKtfIFkj1t8ey67DNav0Y14AGNQq+CX0CtaiA0ZybC0KJcjtMDQ==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.18.4.tgz",
+			"integrity": "sha512-Ui4UsneDk9gCuJRfTpR5js+Ctt9Je+j+3Q4z7H7HhBn6WeWDTp6FBGJZ7SfrBCdQ47EKK27Mr95LbJ4I77xFfQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/collect-updates": "3.16.5",
-				"@lerna/command": "3.16.5",
-				"@lerna/listable": "3.16.0",
-				"@lerna/output": "3.13.0",
-				"@lerna/version": "3.16.5"
+				"@lerna/collect-updates": "3.18.0",
+				"@lerna/command": "3.18.0",
+				"@lerna/listable": "3.18.4",
+				"@lerna/output": "3.13.0"
 			}
 		},
 		"@lerna/check-working-tree": {
@@ -234,13 +233,13 @@
 			}
 		},
 		"@lerna/clean": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.16.5.tgz",
-			"integrity": "sha512-PT//BXS11bf+lHF3LYVw+24/Rxk+vXBqZIsx8p1+ICia/lYXlxUgF90IQFGAT0OTu82j014VgozggoI+C3eLWw==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.18.4.tgz",
+			"integrity": "sha512-puuL0sBHIv3Tvq8cdu3kCGfRpdsXuaDGIRha33GVmRPfMBi2GN8nPPysVyWmP99PfgfafO6eT5R3jqXjvASAZA==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.16.5",
-				"@lerna/filter-options": "3.16.5",
+				"@lerna/command": "3.18.0",
+				"@lerna/filter-options": "3.18.4",
 				"@lerna/prompt": "3.13.0",
 				"@lerna/pulse-till-done": "3.13.0",
 				"@lerna/rimraf-dir": "3.16.5",
@@ -250,176 +249,15 @@
 			}
 		},
 		"@lerna/cli": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz",
-			"integrity": "sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.18.0.tgz",
+			"integrity": "sha512-AwDyfGx7fxJgeaZllEuyJ9LZ6Tdv9yqRD9RX762yCJu+PCAFvB9bp6OYuRSGli7QQgM0CuOYnSg4xVNOmuGKDA==",
 			"dev": true,
 			"requires": {
 				"@lerna/global-options": "3.13.0",
 				"dedent": "^0.7.0",
 				"npmlog": "^4.1.2",
-				"yargs": "^12.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"cliui": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"get-caller-file": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-					"dev": true
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-							"dev": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-							"dev": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						}
-					}
-				},
-				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
+				"yargs": "^14.2.0"
 			}
 		},
 		"@lerna/collect-uncommitted": {
@@ -435,9 +273,9 @@
 			}
 		},
 		"@lerna/collect-updates": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.16.5.tgz",
-			"integrity": "sha512-JWeN/ghfQ0llfPtUWtNSHRCqAncHGF0hznsTVqxCoQ3j8GacgYaBLfC3FsUfTnUm8BQ1pi7prAclMoBvfmMwyQ==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.18.0.tgz",
+			"integrity": "sha512-LJMKgWsE/var1RSvpKDIxS8eJ7POADEc0HM3FQiTpEczhP6aZfv9x3wlDjaHpZm9MxJyQilqxZcasRANmRcNgw==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
@@ -448,14 +286,14 @@
 			}
 		},
 		"@lerna/command": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.16.5.tgz",
-			"integrity": "sha512-sXv+a+ljEfW6aEKxmnv3rLbbWpDQi3IVdDoezCATkbqMYUssZGz43UwUVuaYikViB86SLBbtprFrVcZBaqAfCQ==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.18.0.tgz",
+			"integrity": "sha512-JQ0TGzuZc9Ky8xtwtSLywuvmkU8X62NTUT3rMNrUykIkOxBaO+tE0O98u2yo/9BYOeTRji9IsjKZEl5i9Qt0xQ==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
-				"@lerna/package-graph": "3.16.0",
-				"@lerna/project": "3.16.0",
+				"@lerna/package-graph": "3.18.0",
+				"@lerna/project": "3.18.0",
 				"@lerna/validation-error": "3.13.0",
 				"@lerna/write-log-file": "3.13.0",
 				"dedent": "^0.7.0",
@@ -493,14 +331,14 @@
 			}
 		},
 		"@lerna/create": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.16.5.tgz",
-			"integrity": "sha512-eScA3iNhjeVAaaNDaVVmsupM4Sulmr4AQVPEfNUN+f6aU7KuvBwbe0Nh46xtQhgNTcSSWj9pmO2IisTrzq4ezA==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.18.0.tgz",
+			"integrity": "sha512-y9oS7ND5T13c+cCTJHa2Y9in02ppzyjsNynVWFuS40eIzZ3z058d9+3qSBt1nkbbQlVyfLoP6+bZPsjyzap5ig==",
 			"dev": true,
 			"requires": {
 				"@evocateur/pacote": "^9.6.3",
 				"@lerna/child-process": "3.16.5",
-				"@lerna/command": "3.16.5",
+				"@lerna/command": "3.18.0",
 				"@lerna/npm-conf": "3.16.0",
 				"@lerna/validation-error": "3.13.0",
 				"camelcase": "^5.0.0",
@@ -548,46 +386,48 @@
 			}
 		},
 		"@lerna/diff": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.16.5.tgz",
-			"integrity": "sha512-19Nchn4Yem/FyNqXSMzv3RP3/jRBTpu1i/Z/nCrt5lA0D2fFv9uCh9aE2XnzqZ0r7qiGJZNOMax/TIOqq3KtFA==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.18.0.tgz",
+			"integrity": "sha512-3iLNlpurc2nV9k22w8ini2Zjm2UPo3xtQgWyqdA6eJjvge0+5AlNAWfPoV6cV+Hc1xDbJD2YDSFpZPJ1ZGilRw==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
-				"@lerna/command": "3.16.5",
+				"@lerna/command": "3.18.0",
 				"@lerna/validation-error": "3.13.0",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/exec": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.16.5.tgz",
-			"integrity": "sha512-z7ceaYr3B9Zzmf5TlPulMNOKhsq6emzWSuiTX57eMWCnVfqDt34dM89HredJwFAmxLSlhqHuGQOhwyOaEY7+2g==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.18.4.tgz",
+			"integrity": "sha512-BpBFxyCQXcfess9Nmj/OwQ9e1IhzPzNxqF5JK7dPIjko5oBn5Hm2EWVAcgUGSHKPZGLiOWPu3Wx/C92NtDBS1w==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
-				"@lerna/command": "3.16.5",
-				"@lerna/filter-options": "3.16.5",
-				"@lerna/run-topologically": "3.16.0",
+				"@lerna/command": "3.18.0",
+				"@lerna/filter-options": "3.18.4",
+				"@lerna/run-topologically": "3.18.0",
 				"@lerna/validation-error": "3.13.0",
 				"p-map": "^2.1.0"
 			}
 		},
 		"@lerna/filter-options": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.16.5.tgz",
-			"integrity": "sha512-PnkrDPJHvQ3k19JFG8jJVasVbZhg+Ckg5u9aVA254T3BSA2CT7MtXjB+snS76npe83170zII0iYufDUY4rhm0A==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.18.4.tgz",
+			"integrity": "sha512-4giVQD6tauRwweO/322LP2gfVDOVrt/xN4khkXyfkJDfcsZziFXq+668otD9KSLL8Ps+To4Fah3XbK0MoNuEvA==",
 			"dev": true,
 			"requires": {
-				"@lerna/collect-updates": "3.16.5",
-				"@lerna/filter-packages": "3.16.0",
-				"dedent": "^0.7.0"
+				"@lerna/collect-updates": "3.18.0",
+				"@lerna/filter-packages": "3.18.0",
+				"dedent": "^0.7.0",
+				"figgy-pudding": "^3.5.1",
+				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/filter-packages": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.16.0.tgz",
-			"integrity": "sha512-eGFzQTx0ogkGDCnbTuXqssryR6ilp8+dcXt6B+aq1MaqL/vOJRZyqMm4TY3CUOUnzZCi9S2WWyMw3PnAJOF+kg==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.18.0.tgz",
+			"integrity": "sha512-6/0pMM04bCHNATIOkouuYmPg6KH3VkPCIgTfQmdkPJTullERyEQfNUKikrefjxo1vHOoCACDpy65JYyKiAbdwQ==",
 			"dev": true,
 			"requires": {
 				"@lerna/validation-error": "3.13.0",
@@ -664,13 +504,13 @@
 			}
 		},
 		"@lerna/import": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.16.5.tgz",
-			"integrity": "sha512-n5zy9zeNziS/jex/rHiw7YSpnsfGYXBLv4RSm0gnKouV+dvKocUd139S0oHJG3oQgL+B6anZpR/3ajxz4QcZ4w==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.18.0.tgz",
+			"integrity": "sha512-2pYIkkBTZsEdccfc+dPsKZeSw3tBzKSyl0b2lGrfmNX2Y41qqOzsJCyI1WO1uvEIP8aOaLy4hPpqRIBe4ee7hw==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
-				"@lerna/command": "3.16.5",
+				"@lerna/command": "3.18.0",
 				"@lerna/prompt": "3.13.0",
 				"@lerna/pulse-till-done": "3.13.0",
 				"@lerna/validation-error": "3.13.0",
@@ -680,50 +520,50 @@
 			}
 		},
 		"@lerna/init": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.16.5.tgz",
-			"integrity": "sha512-K8JtSHbPxR5pZHJ0GUXGhMdx+E/pDnbp8JbTUkEkLCyRHp3C0VFAtINJ+ysSpObleTFivA1xrgwqG8JbgI213Q==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.18.0.tgz",
+			"integrity": "sha512-/vHpmXkMlSaJaq25v5K13mcs/2L7E32O6dSsEkHaZCDRiV2BOqsZng9jjbE/4ynfsWfLLlU9ZcydwG72C3I+mQ==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
-				"@lerna/command": "3.16.5",
+				"@lerna/command": "3.18.0",
 				"fs-extra": "^8.1.0",
 				"p-map": "^2.1.0",
 				"write-json-file": "^3.2.0"
 			}
 		},
 		"@lerna/link": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.17.0.tgz",
-			"integrity": "sha512-eh8+mAH74ndxigBQIW5jXO1md8jpTzpzHHiRwCoetRr3QM2oLgYbWczZDViCdWV4R4J6BLbyp3Jh64cob+leyA==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.18.0.tgz",
+			"integrity": "sha512-FbbIpH0EpsC+dpAbvxCoF3cn7F1MAyJjEa5Lh3XkDGATOlinMFuKCbmX0NLpOPQZ5zghvrui97cx+jz5F2IlHw==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.16.5",
-				"@lerna/package-graph": "3.16.0",
+				"@lerna/command": "3.18.0",
+				"@lerna/package-graph": "3.18.0",
 				"@lerna/symlink-dependencies": "3.17.0",
 				"p-map": "^2.1.0",
 				"slash": "^2.0.0"
 			}
 		},
 		"@lerna/list": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.16.5.tgz",
-			"integrity": "sha512-HJgJigTyIvLOWvdW5++Ewam+owk2aNPg/niqqIaV90OtzsEd55Cqb2ziIWdFLRFLYPu66HHhJOXBnGfP1uNl9A==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.18.4.tgz",
+			"integrity": "sha512-bgtlhAwhjHOTLq0iIuPs30abeuLbwZvVB60Ym8kPp+chh939obKU3vy2KMyX+Gpxf8pzuQG+k986YXcUBvXVsw==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.16.5",
-				"@lerna/filter-options": "3.16.5",
-				"@lerna/listable": "3.16.0",
+				"@lerna/command": "3.18.0",
+				"@lerna/filter-options": "3.18.4",
+				"@lerna/listable": "3.18.4",
 				"@lerna/output": "3.13.0"
 			}
 		},
 		"@lerna/listable": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.16.0.tgz",
-			"integrity": "sha512-mtdAT2EEECqrJSDm/aXlOUFr1MRE4p6hppzY//Klp05CogQy6uGaKk+iKG5yyCLaOXFFZvG4HfO11CmoGSDWzw==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.18.4.tgz",
+			"integrity": "sha512-EKSsnST5k3dZfw+UTwBH1/sHQ1YfgjYjGxXCabyn55mMgc2GjoDekODMYzZ1TNF2NNy6RgIZ24X2JI8G22nZUw==",
 			"dev": true,
 			"requires": {
-				"@lerna/query-graph": "3.16.0",
+				"@lerna/query-graph": "3.18.0",
 				"chalk": "^2.3.1",
 				"columnify": "^1.5.4"
 			}
@@ -751,9 +591,9 @@
 			}
 		},
 		"@lerna/npm-dist-tag": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.16.0.tgz",
-			"integrity": "sha512-MQrBkqJJB9+eNphuj9w90QPMOs4NQXMuSRk9NqzeFunOmdDopPCV0Q7IThSxEuWnhJ2n3B7G0vWUP7tNMPdqIQ==",
+			"version": "3.18.1",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.18.1.tgz",
+			"integrity": "sha512-vWkZh2T/O9OjPLDrba0BTWO7ug/C3sCwjw7Qyk1aEbxMBXB/eEJPqirwJTWT+EtRJQYB01ky3K8ZFOhElVyjLw==",
 			"dev": true,
 			"requires": {
 				"@evocateur/npm-registry-fetch": "^4.0.0",
@@ -868,9 +708,9 @@
 			}
 		},
 		"@lerna/package-graph": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.16.0.tgz",
-			"integrity": "sha512-A2mum/gNbv7zCtAwJqoxzqv89As73OQNK2MgSX1SHWya46qoxO9a9Z2c5lOFQ8UFN5ZxqWMfFYXRCz7qzwmFXw==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.18.0.tgz",
+			"integrity": "sha512-BLYDHO5ihPh20i3zoXfLZ5ZWDCrPuGANgVhl7k5pCmRj90LCvT+C7V3zrw70fErGAfvkcYepMqxD+oBrAYwquQ==",
 			"dev": true,
 			"requires": {
 				"@lerna/prerelease-id-from-version": "3.16.0",
@@ -906,9 +746,9 @@
 			}
 		},
 		"@lerna/project": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.16.0.tgz",
-			"integrity": "sha512-NrKcKK1EqXqhrGvslz6Q36+ZHuK3zlDhGdghRqnxDcHxMPT01NgLcmsnymmQ+gjMljuLRmvKYYCuHrknzX8VrA==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.18.0.tgz",
+			"integrity": "sha512-+LDwvdAp0BurOAWmeHE3uuticsq9hNxBI0+FMHiIai8jrygpJGahaQrBYWpwbshbQyVLeQgx3+YJdW2TbEdFWA==",
 			"dev": true,
 			"requires": {
 				"@lerna/package": "3.16.0",
@@ -951,9 +791,9 @@
 			}
 		},
 		"@lerna/publish": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.16.5.tgz",
-			"integrity": "sha512-gJzvzeOWj0d4+RWCAcCyvFXN246Dwl2WpOLtWKwdFUC3fz+tvCI7FO8moPbaJt6EqYRMDaoeqVQnIrSeisbZDw==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.18.4.tgz",
+			"integrity": "sha512-Q+MqM5DUZvk+uT6hdEyO3khXET6LwED0YEuCu8fRwtHad03HkZ9i8PtTY5h8Sn6D6RCyCOlHTuf8O0KKAUy3ow==",
 			"dev": true,
 			"requires": {
 				"@evocateur/libnpmaccess": "^3.1.2",
@@ -961,12 +801,12 @@
 				"@evocateur/pacote": "^9.6.3",
 				"@lerna/check-working-tree": "3.16.5",
 				"@lerna/child-process": "3.16.5",
-				"@lerna/collect-updates": "3.16.5",
-				"@lerna/command": "3.16.5",
+				"@lerna/collect-updates": "3.18.0",
+				"@lerna/command": "3.18.0",
 				"@lerna/describe-ref": "3.16.5",
 				"@lerna/log-packed": "3.16.0",
 				"@lerna/npm-conf": "3.16.0",
-				"@lerna/npm-dist-tag": "3.16.0",
+				"@lerna/npm-dist-tag": "3.18.1",
 				"@lerna/npm-publish": "3.16.2",
 				"@lerna/otplease": "3.16.0",
 				"@lerna/output": "3.13.0",
@@ -975,9 +815,9 @@
 				"@lerna/prompt": "3.13.0",
 				"@lerna/pulse-till-done": "3.13.0",
 				"@lerna/run-lifecycle": "3.16.2",
-				"@lerna/run-topologically": "3.16.0",
+				"@lerna/run-topologically": "3.18.0",
 				"@lerna/validation-error": "3.13.0",
-				"@lerna/version": "3.16.5",
+				"@lerna/version": "3.18.4",
 				"figgy-pudding": "^3.5.1",
 				"fs-extra": "^8.1.0",
 				"npm-package-arg": "^6.1.0",
@@ -1006,12 +846,12 @@
 			}
 		},
 		"@lerna/query-graph": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.16.0.tgz",
-			"integrity": "sha512-p0RO+xmHDO95ChJdWkcy9TNLysLkoDARXeRHzY5U54VCwl3Ot/2q8fMCVlA5UeGXDutEyyByl3URqEpcQCWI7Q==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.18.0.tgz",
+			"integrity": "sha512-fgUhLx6V0jDuKZaKj562jkuuhrfVcjl5sscdfttJ8dXNVADfDz76nzzwLY0ZU7/0m69jDedohn5Fx5p7hDEVEg==",
 			"dev": true,
 			"requires": {
-				"@lerna/package-graph": "3.16.0",
+				"@lerna/package-graph": "3.18.0",
 				"figgy-pudding": "^3.5.1"
 			}
 		},
@@ -1056,16 +896,16 @@
 			}
 		},
 		"@lerna/run": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.16.5.tgz",
-			"integrity": "sha512-sORjqiGJvbLhax/QE9IfTKsvUGfNDu8bUkxxhnbxYu0tGhgWhiPzRVZ564QG9zQ6D23CGd/wQ0AHyrsRPulbzQ==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.18.4.tgz",
+			"integrity": "sha512-u2ZNO2fVk5kVEpbpn4DLJZZxZ08LFnIFuaXJMAhxvOgvm12ZF2rabA9kZc3NXp5+DedG5nHHgyoyLVVbStKzBA==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.16.5",
-				"@lerna/filter-options": "3.16.5",
+				"@lerna/command": "3.18.0",
+				"@lerna/filter-options": "3.18.4",
 				"@lerna/npm-run-script": "3.16.5",
 				"@lerna/output": "3.13.0",
-				"@lerna/run-topologically": "3.16.0",
+				"@lerna/run-topologically": "3.18.0",
 				"@lerna/timer": "3.13.0",
 				"@lerna/validation-error": "3.13.0",
 				"p-map": "^2.1.0"
@@ -1084,12 +924,12 @@
 			}
 		},
 		"@lerna/run-topologically": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.16.0.tgz",
-			"integrity": "sha512-4Hlpv4zDtKWa5Z0tPkeu0sK+bxZEKgkNESMGmWrUCNfj7xwvAJurcraK8+a2Y0TFYwf0qjSLY/MzX+ZbJA3Cgw==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.18.0.tgz",
+			"integrity": "sha512-lrfEewwuUMC3ioxf9Z9NdHUakN6ihekcPfdYbzR2slmdbjYKmIA5srkWdrK8NwOpQCAuekpOovH2s8X3FGEopg==",
 			"dev": true,
 			"requires": {
-				"@lerna/query-graph": "3.16.0",
+				"@lerna/query-graph": "3.18.0",
 				"figgy-pudding": "^3.5.1",
 				"p-queue": "^4.0.0"
 			}
@@ -1137,15 +977,15 @@
 			}
 		},
 		"@lerna/version": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.16.5.tgz",
-			"integrity": "sha512-GHwIqC6rLldpn7e4P/Ms+ygu9nC/1UJidpaBa6qhvuXlIaqJuFKdQGHTXfuvCBUS+/LTA3Cb9cQZgob9aocOkA==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.18.4.tgz",
+			"integrity": "sha512-+gR9H89qSP8iqzNi4tRVQUbWlFMOlhbY6+5TXkP72Ibb/z87O+C46DBqizSMVaPQYdSYjS1c9Xfa1oOhEWxGaw==",
 			"dev": true,
 			"requires": {
 				"@lerna/check-working-tree": "3.16.5",
 				"@lerna/child-process": "3.16.5",
-				"@lerna/collect-updates": "3.16.5",
-				"@lerna/command": "3.16.5",
+				"@lerna/collect-updates": "3.18.0",
+				"@lerna/command": "3.18.0",
 				"@lerna/conventional-commits": "3.16.4",
 				"@lerna/github-client": "3.16.5",
 				"@lerna/gitlab-client": "3.15.0",
@@ -1153,10 +993,11 @@
 				"@lerna/prerelease-id-from-version": "3.16.0",
 				"@lerna/prompt": "3.13.0",
 				"@lerna/run-lifecycle": "3.16.2",
-				"@lerna/run-topologically": "3.16.0",
+				"@lerna/run-topologically": "3.18.0",
 				"@lerna/validation-error": "3.13.0",
 				"chalk": "^2.3.1",
 				"dedent": "^0.7.0",
+				"load-json-file": "^5.3.0",
 				"minimatch": "^3.0.4",
 				"npmlog": "^4.1.2",
 				"p-map": "^2.1.0",
@@ -1165,9 +1006,23 @@
 				"p-waterfall": "^1.0.0",
 				"semver": "^6.2.0",
 				"slash": "^2.0.0",
-				"temp-write": "^3.4.0"
+				"temp-write": "^3.4.0",
+				"write-json-file": "^3.2.0"
 			},
 			"dependencies": {
+				"load-json-file": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+					"integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.15",
+						"parse-json": "^4.0.0",
+						"pify": "^4.0.1",
+						"strip-bom": "^3.0.0",
+						"type-fest": "^0.3.0"
+					}
+				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1203,11 +1058,12 @@
 			"dev": true
 		},
 		"@octokit/endpoint": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.4.0.tgz",
-			"integrity": "sha512-DWTNgEKg5KXzvNjKTzcFTnkZiL7te6pQxxumvxPjyjDpcY5V3xzywnNu1WVqySY3Ct1flF/kAoyDdZos6acq3Q==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
+			"integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
 			"dev": true,
 			"requires": {
+				"@octokit/types": "^2.0.0",
 				"is-plain-object": "^3.0.0",
 				"universal-user-agent": "^4.0.0"
 			},
@@ -1236,13 +1092,14 @@
 			"dev": true
 		},
 		"@octokit/request": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.1.0.tgz",
-			"integrity": "sha512-I15T9PwjFs4tbWyhtFU2Kq7WDPidYMvRB7spmxoQRZfxSmiqullG+Nz+KbSmpkfnlvHwTr1e31R5WReFRKMXjg==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
+			"integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
 			"dev": true,
 			"requires": {
-				"@octokit/endpoint": "^5.1.0",
+				"@octokit/endpoint": "^5.5.0",
 				"@octokit/request-error": "^1.0.1",
+				"@octokit/types": "^2.0.0",
 				"deprecation": "^2.0.0",
 				"is-plain-object": "^3.0.0",
 				"node-fetch": "^2.3.0",
@@ -1268,22 +1125,23 @@
 			}
 		},
 		"@octokit/request-error": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.4.tgz",
-			"integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.0.tgz",
+			"integrity": "sha512-DNBhROBYjjV/I9n7A8kVkmQNkqFAMem90dSxqvPq57e2hBr7mNTX98y3R2zDpqMQHVRpBDjsvsfIGgBzy+4PAg==",
 			"dev": true,
 			"requires": {
+				"@octokit/types": "^2.0.0",
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.33.0",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.33.0.tgz",
-			"integrity": "sha512-t4jMR+odsfooQwmHiREoTQixVTX2DfdbSaO+lKrW9R5XBuk0DW+5T/JdfwtxAGUAHgvDDpWY/NVVDfEPTzxD6g==",
+			"version": "16.35.0",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.35.0.tgz",
+			"integrity": "sha512-9ShFqYWo0CLoGYhA1FdtdykJuMzS/9H6vSbbQWDX4pWr4p9v+15MsH/wpd/3fIU+tSxylaNO48+PIHqOkBRx3w==",
 			"dev": true,
 			"requires": {
-				"@octokit/request": "^5.0.0",
+				"@octokit/request": "^5.2.0",
 				"@octokit/request-error": "^1.0.2",
 				"atob-lite": "^2.0.0",
 				"before-after-hook": "^2.0.0",
@@ -1295,6 +1153,15 @@
 				"octokit-pagination-methods": "^1.1.0",
 				"once": "^1.4.0",
 				"universal-user-agent": "^4.0.0"
+			}
+		},
+		"@octokit/types": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.0.1.tgz",
+			"integrity": "sha512-YDYgV6nCzdGdOm7wy43Ce8SQ3M5DMKegB8E5sTB/1xrxOdo2yS/KgUgML2N2ZGD621mkbdrAglwTyA4NDOlFFA==",
+			"dev": true,
+			"requires": {
+				"@types/node": ">= 8"
 			}
 		},
 		"@types/events": {
@@ -1333,9 +1200,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.7.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-			"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==",
+			"version": "12.12.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
+			"integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
 			"dev": true
 		},
 		"@zkochan/cmd-shim": {
@@ -1653,9 +1520,9 @@
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
-			"integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -1728,9 +1595,9 @@
 			"dev": true
 		},
 		"c8": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/c8/-/c8-6.0.0.tgz",
-			"integrity": "sha512-3T0PTOtKW0VxHoY77fDz2wQiFamYUWHpD2rRaJhzmhwoRaULXuN+7jdIHxx6yoL0dTa6tuwvZK1luYTkMlEkvA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/c8/-/c8-6.0.1.tgz",
+			"integrity": "sha512-L1ddSA1fVsRTzEVrQyt+28h+5+E/Ej4MzzQYFCHgnt5g8gcwdB9nF2BZJjpJa+tVddVyOAmx/vlBSoLHC7+Opg==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
@@ -2022,9 +1889,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
 		"compare-func": {
@@ -2089,9 +1956,9 @@
 			"dev": true
 		},
 		"conventional-changelog-angular": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.5.tgz",
-			"integrity": "sha512-RrkdWnL/TVyWV1ayWmSsrWorsTDqjL/VwG5ZSEneBQrd65ONcfeA1cW7FLtNweQyMiKOyriCMTKRSlk18DjTrw==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.6.tgz",
+			"integrity": "sha512-QDEmLa+7qdhVIv8sFZfVxU1VSyVvnXPsxq8Vam49mKUcO1Z8VTLEJk9uI21uiJUsnmm0I4Hrsdc9TgkOQo9WSA==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
@@ -2190,15 +2057,15 @@
 			}
 		},
 		"conventional-changelog-preset-loader": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.2.0.tgz",
-			"integrity": "sha512-zXB+5vF7D5Y3Cb/rJfSyCCvFphCVmF8mFqOdncX3BmjZwAtGAPfYrBcT225udilCKvBbHgyzgxqz2GWDB5xShQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.0.tgz",
+			"integrity": "sha512-/rHb32J2EJnEXeK4NpDgMaAVTFZS3o1ExmjKMtYVgIC4MQn0vkNSbYpdGRotkfGGRWiqk3Ri3FBkiZGbAfIfOQ==",
 			"dev": true
 		},
 		"conventional-changelog-writer": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.9.tgz",
-			"integrity": "sha512-2Y3QfiAM37WvDMjkVNaRtZgxVzWKj73HE61YQ/95T53yle+CRwTVSl6Gbv/lWVKXeZcM5af9n9TDVf0k7Xh+cw==",
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.10.tgz",
+			"integrity": "sha512-vtO9vBAVh7XnSpGLTB1BOGgsGTz1MdvFjzbSXLrtapWCHWwuVOZFgwdLhlS0MaXwlF1dksWdEb6tnr42Ie2INw==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
@@ -2206,7 +2073,7 @@
 				"dateformat": "^3.0.0",
 				"handlebars": "^4.4.0",
 				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.2.1",
+				"lodash": "^4.17.15",
 				"meow": "^4.0.0",
 				"semver": "^6.0.0",
 				"split": "^1.0.0",
@@ -2241,14 +2108,14 @@
 			}
 		},
 		"conventional-commits-parser": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.5.tgz",
-			"integrity": "sha512-qVz9+5JwdJzsbt7JbJ6P7NOXBGt8CyLFJYSjKAuPSgO+5UGfcsbk9EMR+lI8Unlvx6qwIc2YDJlrGIfay2ehNA==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.7.tgz",
+			"integrity": "sha512-4mx/FRC92z0yIiXGyRVYQFhn0jWDwvxnj2UuLaUi3hJSG4Thall6GXA8YOPHQK2qvotciJandJIVmuSvLgDLbQ==",
 			"dev": true,
 			"requires": {
 				"JSONStream": "^1.0.4",
-				"is-text-path": "^2.0.0",
-				"lodash": "^4.2.1",
+				"is-text-path": "^1.0.1",
+				"lodash": "^4.17.15",
 				"meow": "^4.0.0",
 				"split2": "^2.0.0",
 				"through2": "^3.0.0",
@@ -2308,9 +2175,9 @@
 			}
 		},
 		"convert-source-map": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
@@ -2677,9 +2544,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-			"integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.0",
@@ -2695,9 +2562,9 @@
 			}
 		},
 		"es-to-primitive": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
 			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
@@ -2893,17 +2760,6 @@
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
 				"tmp": "^0.0.33"
-			},
-			"dependencies": {
-				"tmp": {
-					"version": "0.0.33",
-					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-					"dev": true,
-					"requires": {
-						"os-tmpdir": "~1.0.2"
-					}
-				}
 			}
 		},
 		"extglob": {
@@ -3558,9 +3414,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -3603,15 +3459,15 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-			"integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+			"integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -3729,9 +3585,9 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
-			"integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
 				"agent-base": "^4.3.0",
@@ -3910,12 +3766,6 @@
 					}
 				}
 			}
-		},
-		"invert-kv": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-			"dev": true
 		},
 		"ip": {
 			"version": "1.1.5",
@@ -4138,12 +3988,12 @@
 			}
 		},
 		"is-text-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
-			"integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"dev": true,
 			"requires": {
-				"text-extensions": "^2.0.0"
+				"text-extensions": "^1.0.0"
 			}
 		},
 		"is-typedarray": {
@@ -4287,36 +4137,27 @@
 			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 			"dev": true
 		},
-		"lcid": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-			"dev": true,
-			"requires": {
-				"invert-kv": "^2.0.0"
-			}
-		},
 		"lerna": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.17.0.tgz",
-			"integrity": "sha512-rU3YU1MLN+yy1YZzhaEl8h50d8HtIeBKIQ/ZxmmTqDprIvvWT2AZyDt/9EvoWlirCfdKT/G6Hs63O6sFuDef9g==",
+			"version": "3.18.4",
+			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.18.4.tgz",
+			"integrity": "sha512-DiU53cvMxaU07Bj2HwBwUQ2O3c/ORNq/QwKj1vGJH4vSkZSTUxPryp2baSNlt8PmnLNXOVpw0vOTRkEF+6n/cA==",
 			"dev": true,
 			"requires": {
-				"@lerna/add": "3.17.0",
-				"@lerna/bootstrap": "3.17.0",
-				"@lerna/changed": "3.16.5",
-				"@lerna/clean": "3.16.5",
-				"@lerna/cli": "3.13.0",
-				"@lerna/create": "3.16.5",
-				"@lerna/diff": "3.16.5",
-				"@lerna/exec": "3.16.5",
-				"@lerna/import": "3.16.5",
-				"@lerna/init": "3.16.5",
-				"@lerna/link": "3.17.0",
-				"@lerna/list": "3.16.5",
-				"@lerna/publish": "3.16.5",
-				"@lerna/run": "3.16.5",
-				"@lerna/version": "3.16.5",
+				"@lerna/add": "3.18.4",
+				"@lerna/bootstrap": "3.18.4",
+				"@lerna/changed": "3.18.4",
+				"@lerna/clean": "3.18.4",
+				"@lerna/cli": "3.18.0",
+				"@lerna/create": "3.18.0",
+				"@lerna/diff": "3.18.0",
+				"@lerna/exec": "3.18.4",
+				"@lerna/import": "3.18.0",
+				"@lerna/init": "3.18.0",
+				"@lerna/link": "3.18.0",
+				"@lerna/list": "3.18.4",
+				"@lerna/publish": "3.18.4",
+				"@lerna/run": "3.18.4",
+				"@lerna/version": "3.18.4",
 				"import-local": "^2.0.0",
 				"npmlog": "^4.1.2"
 			}
@@ -4453,31 +4294,22 @@
 			}
 		},
 		"make-fetch-happen": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.0.tgz",
-			"integrity": "sha512-nFr/vpL1Jc60etMVKeaLOqfGjMMb3tAHFVJWxHOFCFS04Zmd7kGlMxo0l1tzfhoQje0/UPnd0X8OeGUiXXnfPA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.1.tgz",
+			"integrity": "sha512-b4dfaMvUDR67zxUq1+GN7Ke9rH5WvGRmoHuMH7l+gmUCR2tCXFP6mpeJ9Dp+jB6z8mShRopSf1vLRBhRs8Cu5w==",
 			"dev": true,
 			"requires": {
 				"agentkeepalive": "^3.4.1",
 				"cacache": "^12.0.0",
 				"http-cache-semantics": "^3.8.1",
 				"http-proxy-agent": "^2.1.0",
-				"https-proxy-agent": "^2.2.1",
+				"https-proxy-agent": "^2.2.3",
 				"lru-cache": "^5.1.1",
 				"mississippi": "^3.0.0",
 				"node-fetch-npm": "^2.0.2",
 				"promise-retry": "^1.1.1",
 				"socks-proxy-agent": "^4.0.0",
 				"ssri": "^6.0.0"
-			}
-		},
-		"map-age-cleaner": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-			"dev": true,
-			"requires": {
-				"p-defer": "^1.0.0"
 			}
 		},
 		"map-cache": {
@@ -4499,25 +4331,6 @@
 			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
-			}
-		},
-		"mem": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-			"dev": true,
-			"requires": {
-				"map-age-cleaner": "^0.1.1",
-				"mimic-fn": "^2.0.0",
-				"p-is-promise": "^2.0.0"
-			},
-			"dependencies": {
-				"mimic-fn": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-					"dev": true
-				}
 			}
 		},
 		"meow": {
@@ -4644,18 +4457,18 @@
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+			"integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"version": "2.1.25",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+			"integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.40.0"
+				"mime-db": "1.42.0"
 			}
 		},
 		"mimic-fn": {
@@ -5134,9 +4947,9 @@
 			}
 		},
 		"object-inspect": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
 			"dev": true
 		},
 		"object-keys": {
@@ -5237,17 +5050,6 @@
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true
 		},
-		"os-locale": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-			"dev": true,
-			"requires": {
-				"execa": "^1.0.0",
-				"lcid": "^2.0.0",
-				"mem": "^4.0.0"
-			}
-		},
 		"os-name": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -5274,22 +5076,10 @@
 				"os-tmpdir": "^1.0.0"
 			}
 		},
-		"p-defer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-			"dev": true
-		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
-		},
-		"p-is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
 			"dev": true
 		},
 		"p-limit": {
@@ -5672,9 +5462,9 @@
 			}
 		},
 		"read-cmd-shim": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.4.tgz",
-			"integrity": "sha512-Pqpl3qJ/QdOIjRYA0q5DND/gLvGOfpIz/fYVDGYpOXfW/lFrIttmLsBnd6IkyK10+JHU9zhsaudfvrQTBB9YFQ==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
+			"integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2"
@@ -6069,9 +5859,9 @@
 			"dev": true
 		},
 		"smart-buffer": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
-			"integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
 			"dev": true
 		},
 		"smee-client": {
@@ -6216,13 +6006,13 @@
 			}
 		},
 		"socks": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
-			"integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+			"integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
 			"dev": true,
 			"requires": {
-				"ip": "^1.1.5",
-				"smart-buffer": "4.0.2"
+				"ip": "1.1.5",
+				"smart-buffer": "^4.1.0"
 			}
 		},
 		"socks-proxy-agent": {
@@ -6586,9 +6376,9 @@
 			}
 		},
 		"text-extensions": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
-			"integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
 			"dev": true
 		},
 		"thenify": {
@@ -6623,6 +6413,15 @@
 			"requires": {
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
+			}
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "~1.0.2"
 			}
 		},
 		"to-object-path": {
@@ -6740,13 +6539,13 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
-			"integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
+			"version": "3.6.9",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+			"integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"commander": "2.20.0",
+				"commander": "~2.20.3",
 				"source-map": "~0.6.1"
 			}
 		},
@@ -6970,9 +6769,9 @@
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-			"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
 			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",

--- a/packages/header-checker-lint/README.md
+++ b/packages/header-checker-lint/README.md
@@ -16,7 +16,7 @@ with the following options:
 | Name | Description | Type | Default |
 |----- | ----------- | ---- | ------- |
 | `allowedCopyrightHolders` | List of allowed copyright holders | `string[]` | `[]` |
-| `allowedLicenses` | The allowed licenses. | `string[]` | `["Apache-2.0", "MIT"]` |
+| `allowedLicenses` | The allowed licenses. | `string[]` | `["Apache-2.0", "MIT", "BSD-3"]` |
 | `ignoreFiles` | List of files to ignore. These values will be treated as path globs | `string[]` | `[]` |
 | `sourceFileExtensions` | List of file extensions that will be treated as source files | `string[]` | `["ts", "js", "java"]` |
 

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -72,12 +72,14 @@ class Configuration {
     github: GitHubAPI
   ): Promise<Configuration> {
     try {
-      const response = (await github.repos.getContents({
-        owner,
-        repo,
-        ref,
-        path,
-      })).data as { content?: string };
+      const response = (
+        await github.repos.getContents({
+          owner,
+          repo,
+          ref,
+          path,
+        })
+      ).data as { content?: string };
       const fileContents = Buffer.from(
         response.content || '',
         'base64'

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -48,7 +48,7 @@ interface ConfigurationOptions {
 const WELL_KNOWN_CONFIGURATION_FILE = '.bots/header-checker-lint.json';
 const DEFAULT_CONFIGURATION: ConfigurationOptions = {
   allowedCopyrightHolders: ['Google LLC'],
-  allowedLicenses: ['Apache-2.0', 'MIT'],
+  allowedLicenses: ['Apache-2.0', 'MIT', 'BSD-3'],
   ignoreFiles: [],
   sourceFileExtensions: ['ts', 'js', 'java'],
 };

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -114,7 +114,7 @@ export = (app: Application) => {
 
     const remoteConfiguration: ConfigurationOptions | null = (await context.config(
       WELL_KNOWN_CONFIGURATION_FILE
-    )) as (ConfigurationOptions | null);
+    )) as ConfigurationOptions | null;
 
     // If no configuration is specified,
     if (!remoteConfiguration) {
@@ -173,7 +173,7 @@ export = (app: Application) => {
 
     const remoteConfiguration = (await context.config(
       WELL_KNOWN_CONFIGURATION_FILE
-    )) as (ConfigurationOptions | null);
+    )) as ConfigurationOptions | null;
 
     // If no configuration is specified,
     if (!remoteConfiguration) {


### PR DESCRIPTION
[google-gax](https://github.com/googleapis/gax-nodejs) was originally released with BSD license, so the bot constantly feels unhappy about its sources. Let's allow BSD since it's an approved license as well.
