### PR TITLE
fix: functionname is variable not bin

### DIFF
--- a/scripts/cron-deploy.sh
+++ b/scripts/cron-deploy.sh
@@ -55,7 +55,7 @@ for f in *; do
                             --uri="$proxyurl" \
                             --oidc-service-account-email="$SCHEDULER_SERVICE_ACCOUNT_EMAIL" \
                             --oidc-token-audience="$proxyurl" \
-                            --message-body="{\"Name\": \"$(functionname)\", \"Type\" : \"function\", \"Location\": \"$FUNCTION_REGION\"}" \
+                            --message-body="{\"Name\": \"$functionname\", \"Type\" : \"function\", \"Location\": \"$FUNCTION_REGION\"}" \
                             --headers=Content-Type=application/json
                 fi
             fi


### PR DESCRIPTION
`functionname` was being invoked as a bin, rather than as a variable.