### PR TITLE
fix: proxyurl should have /v0 suffix for posts

### DIFF
--- a/scripts/cron-deploy.sh
+++ b/scripts/cron-deploy.sh
@@ -52,7 +52,7 @@ for f in *; do
                     gcloud beta scheduler jobs create http "$functionname" \
                             --schedule "$schedule" \
                             --http-method=POST \
-                            --uri="$proxyurl" \
+                            --uri="$proxyurl/v0" \
                             --oidc-service-account-email="$SCHEDULER_SERVICE_ACCOUNT_EMAIL" \
                             --oidc-token-audience="$proxyurl" \
                             --message-body="{\"Name\": \"$functionname\", \"Type\" : \"function\", \"Location\": \"$FUNCTION_REGION\"}" \

--- a/scripts/cron-deploy.sh
+++ b/scripts/cron-deploy.sh
@@ -46,7 +46,8 @@ for f in *; do
                 schedule=$(cat "$fx")
                 if gcloud beta scheduler jobs describe "$functionname" 2>/dev/null; then
                     # We have an existing job. Update the schedule
-                    gcloud beta scheduler jobs update "$functionname" --schedule "$schedule"
+                    gcloud beta scheduler jobs update http "$functionname" --schedule "$schedule" \
+                            --uri="$proxyurl/v0"
                     else
                     # Make a cloud scheduler job
                     gcloud beta scheduler jobs create http "$functionname" \


### PR DESCRIPTION
I noticed our functioning scheduler URL has a `/0` suffix.