### PR TITLE
fix: credentials should not be base64 encoded when stored

### DIFF
--- a/packages/gcf-utils/src/bin/genkey.ts
+++ b/packages/gcf-utils/src/bin/genkey.ts
@@ -135,7 +135,7 @@ async function run() {
 
   const name = kmsclient.cryptoKeyPath(project, location, keyring, botname);
 
-  const plaintext = Buffer.from(Base64.encode(JSON.stringify(blob)), 'utf-8');
+  const plaintext = Buffer.from(JSON.stringify(blob), 'utf-8');
   const [kmsresult] = await kmsclient.encrypt({ name, plaintext });
   encblob = kmsresult.ciphertext;
 


### PR DESCRIPTION
Our older credential files are not base64 encoded at rest, the current iteration of the `genkey.ts` tool seems to store the credentials encoded, which leads to failures loading the credentials.