### PR TITLE
fix: slight changes to payload format, based on testing

### DIFF
--- a/packages/buildcop/package-lock.json
+++ b/packages/buildcop/package-lock.json
@@ -1823,9 +1823,9 @@
       }
     },
     "gcf-utils": {
-      "version": "1.3.0-beta.1",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-1.3.0-beta.1.tgz",
-      "integrity": "sha512-202eYEAE7B5bnBBkxReM5LikFHWfyYnhCkLPLZ5dNSOJdflbu4vOpSwiq6Hcdc62do8V34Ow2/loDWl01GCVvw==",
+      "version": "1.3.0-beta.4",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-1.3.0-beta.4.tgz",
+      "integrity": "sha512-3iy5krN/Kt6FQUskhiuiA0iDar5n4bqOkmPY7K7uVQzV7w5Fm2lmDITewUw6y3iC+ipC9PJMQSxx2agR69fprw==",
       "requires": {
         "@google-cloud/kms": "^1.1.1",
         "@google-cloud/storage": "^4.0.0",

--- a/packages/buildcop/package-lock.json
+++ b/packages/buildcop/package-lock.json
@@ -63,9 +63,9 @@
       }
     },
     "@google-cloud/common": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-2.2.3.tgz",
-      "integrity": "sha512-lvw54mGKn8VqVIy2NzAk0l5fntBFX4UwQhHk6HaqkyCQ7WBl5oz4XhzKMtMilozF/3ObPcDogqwuyEWyZ6rnQQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-2.2.5.tgz",
+      "integrity": "sha512-Iw6LJj7V8XEVFDORCHC/I+YVmK98KmZSa8z10O4h2Wpkzlk/Sjj8Ruz4QJHawj7GwuWjQQ47O2Z4JECXf1S3ag==",
       "requires": {
         "@google-cloud/projectify": "^1.0.0",
         "@google-cloud/promisify": "^1.0.0",
@@ -87,23 +87,23 @@
       }
     },
     "@google-cloud/paginator": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-2.0.2.tgz",
-      "integrity": "sha512-PCddVtZWvw0iZ3BLIsCXMBQvxUcS9O5CgfHBu8Zd8T3DCiML+oQED1odsbl3CQ9d3RrvBaj+eIh7Dv12D15PbA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-2.0.3.tgz",
+      "integrity": "sha512-kp/pkb2p/p0d8/SKUu4mOq8+HGwF8NPzHWkj+VKrIPQPyMRw8deZtrO/OcSiy9C/7bpfU5Txah5ltUNfPkgEXg==",
       "requires": {
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
       }
     },
     "@google-cloud/projectify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.2.tgz",
-      "integrity": "sha512-WnkGxvk4U1kAJpoS/Ehk+3MZXVW+XHHhwc/QyD6G8Za4xml3Fv+NRn/bYffl1TxSg+gE0N0mj9Shgc7e8+fl8A=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.4.tgz",
+      "integrity": "sha512-ZdzQUN02eRsmTKfBj9FDL0KNDIFNjBn/d6tHQmA/+FImH5DO6ZV8E7FzxMgAUiVAUq41RFAkb25p1oHOZ8psfg=="
     },
     "@google-cloud/promisify": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.3.tgz",
-      "integrity": "sha512-Rufgfl3TnkIil3CjsH33Q6093zeoVqyqCdvtvgHuCqRJxCZYfaVPIyr8JViMeLTD4Ja630pRKKZVSjKggoVbNg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.4.tgz",
+      "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ=="
     },
     "@google-cloud/storage": {
       "version": "4.1.3",
@@ -147,9 +147,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.6.13.tgz",
-      "integrity": "sha512-fxkxS+sEtYdfR0ifqgCTqBe4jZ5PvlvgcaYpzwgMqz+b18uUdPmp5eRQN+qbbJg2ZMUcgItA8OWIvAobW3PDng==",
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.6.15.tgz",
+      "integrity": "sha512-BFK5YMu8JILedibo0nr3NYM0ZC5hCZuXtzk10wEUp3d3pH11PjdvTfN1yEJ0VsfBY5Gtp3WOQ+t7Byq0NzH/iQ==",
       "requires": {
         "semver": "^6.2.0"
       }
@@ -385,8 +385,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/connect": {
       "version": "3.4.32",
@@ -554,12 +553,14 @@
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1007,6 +1008,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
       "requires": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -1031,6 +1033,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1038,7 +1041,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1240,9 +1244,9 @@
       }
     },
     "date-and-time": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.11.0.tgz",
-      "integrity": "sha512-VyzhHurex4wlg9oMszn7O+kxHchphWjzDn7Mv0WfkFKI6hSNOQePpTBFGsnRakvLNzQKXqPBAVV8DOxUGtUxqA=="
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.11.1.tgz",
+      "integrity": "sha512-+1JkWME+UWRpCfvE1T0Vfbw629Ego0IcfHH0qtP4KhAXs7IJT2qsg1hNePqZhyD8Wby46HlW393lSL5PZSzDsA=="
     },
     "debug": {
       "version": "3.2.6",
@@ -1451,7 +1455,8 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -1806,9 +1811,9 @@
       "dev": true
     },
     "gaxios": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.1.0.tgz",
-      "integrity": "sha512-Gtpb5sdQmb82sgVkT2GnS2n+Kx4dlFwbeMYcDlD395aEvsLCSQXJJcHt7oJ2LrGxDEAeiOkK79Zv2A8Pzt6CFg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.2.0.tgz",
+      "integrity": "sha512-54Y7s3yvtEO9CZ0yBVQHI5fzS7TzkjlnuLdDEkeyL1SNYMv877VofvA56E/C3dvj3rS7GFiyMWl833Qrr+nrkg==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -1818,31 +1823,33 @@
       }
     },
     "gcf-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-1.1.0.tgz",
-      "integrity": "sha512-0Al2kLNkOde0ZT91z5mQWHEmtswHld9hOL5z92lbA4zwuzorzi16kDd6xLoNAceGLDEHonDaf/x3DzCDGXshbg==",
+      "version": "1.3.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-1.3.0-beta.1.tgz",
+      "integrity": "sha512-202eYEAE7B5bnBBkxReM5LikFHWfyYnhCkLPLZ5dNSOJdflbu4vOpSwiq6Hcdc62do8V34Ow2/loDWl01GCVvw==",
       "requires": {
         "@google-cloud/kms": "^1.1.1",
         "@google-cloud/storage": "^4.0.0",
+        "@octokit/plugin-enterprise-compatibility": "1.2.1",
+        "gaxios": "^2.1.0",
         "js-base64": "^2.5.1",
         "probot": "9.6.4",
         "tmp": "^0.1.0",
-        "yargs": "^14.0.0"
+        "yargs": "^15.0.0"
       }
     },
     "gcp-metadata": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.2.2.tgz",
-      "integrity": "sha512-vR7kcJMCYJG/mYWp/a1OszdOqnLB/XW1GorWW1hc1lWVNL26L497zypWb9cG0CYDQ4Bl1Wk0+fSZFFjwJlTQgQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.3.0.tgz",
+      "integrity": "sha512-uO3P/aByOQmoDu5bOYBODHmD1oDCZw7/R8SYY0MdmMQSZVEmeTSxmiM1vwde+YHYSpkaQnAAMAIZuOqLvgfp/Q==",
       "requires": {
         "gaxios": "^2.1.0",
         "json-bigint": "^0.3.0"
       }
     },
     "gcs-resumable-upload": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-2.3.1.tgz",
-      "integrity": "sha512-zEO7L+jz99VznQsbsF7vFTnIFbSu+CjdJqt5htnjIrfsp5j+QCVBvbbKdqpaTfCPzpUPYj1Q9O9DhIh/8newfA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-2.3.2.tgz",
+      "integrity": "sha512-OPS0iAmPCV+r7PziOIhyxmQOzsazFCy76yYDOS/Z80O/7cuny1KMfqDQa2T0jLaL8EreTU7EMZG5pUuqBKgzHA==",
       "requires": {
         "abort-controller": "^3.0.0",
         "configstore": "^5.0.0",
@@ -1894,9 +1901,9 @@
       }
     },
     "google-auth-library": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.6.0.tgz",
-      "integrity": "sha512-/niyGtZWDA4LJcvrdmKsZa8a20yQxtOSUTRokyWfgOn8AiVLXY0Ef2WaE3I7fK37IghRmMFhuywGEEPGXyY8EA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.7.0.tgz",
+      "integrity": "sha512-uclMldsQNf64Qr67O8TINdnqbU/Ixv81WryX+sF9g7uP0igJ98aCR/uU399u1ABLa53LNsyji+bo+bP8/iL9dA==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -1909,9 +1916,9 @@
       }
     },
     "google-gax": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-1.11.2.tgz",
-      "integrity": "sha512-NWdIenM/F/SLIaQLBP5Fxsva+vgZ38sO9KR/Vj36APQceTzAVimn7i0jYUrxBv77uov4xZzwcORzTuqp0eE4WQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-1.12.0.tgz",
+      "integrity": "sha512-BeeoxVO6y9K20gUsexUwptutd0PfrTItrA02JWwwstlBIOAcvgFp86MHWufQsnrkPVhxBjHXq65aIkSejtJjDg==",
       "requires": {
         "@grpc/grpc-js": "^0.6.12",
         "@grpc/proto-loader": "^0.5.1",
@@ -2148,26 +2155,26 @@
       }
     },
     "http-proxy-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-3.0.0.tgz",
+      "integrity": "sha512-uGuJaBWQWDQCJI5ip0d/VTYZW0nRrlLWXA4A7P1jrsa+f77rW2yXz315oBt6zGCF6l8C2tlMxY7ffULCj+5FhA==",
       "requires": {
-        "agent-base": "4",
-        "debug": "3.1.0"
+        "agent-base": "5",
+        "debug": "4"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
+        "agent-base": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
         }
       }
     },
@@ -2384,7 +2391,8 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-installed-globally": {
       "version": "0.1.0",
@@ -3543,9 +3551,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.6.tgz",
-          "integrity": "sha512-0a2X6cgN3RdPBL2MIlR6Lt0KlM7fOFsutuXcdglcOq6WvLnYXgPQSh0Mx6tO1KCAE8MxbHSOSTWDoUxRq+l3DA=="
+          "version": "10.17.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.12.tgz",
+          "integrity": "sha512-SSB4O9/0NVv5mbQ5/MabnAyFfcpVFRVIJj1TZkG21HHgwXQGjosiQB3SBWC9pMCMUTNpWL9gUe//9mFFPQAdKw=="
         }
       }
     },
@@ -4237,14 +4245,15 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "string-width": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -4283,6 +4292,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^4.1.0"
       }
@@ -4349,15 +4359,39 @@
       }
     },
     "teeny-request": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-5.3.1.tgz",
-      "integrity": "sha512-hnUeun3xryzv92FbrnprltcdeDfSVaGFBlFPRvKJ2fO/ioQx9N0aSUbbXSfTO+ArRXine1gSWdWFWcgfrggWXw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-5.3.3.tgz",
+      "integrity": "sha512-t5RRd5xK9ku05x6U5kclFHNpy/cLSNdClcZ2USKQZYcDz4hWux7+2N1eRmuZ+hWNtnkp2RTf9zl8urlSGR5Smg==",
       "requires": {
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^3.0.0",
+        "http-proxy-agent": "^3.0.0",
+        "https-proxy-agent": "^4.0.0",
         "node-fetch": "^2.2.0",
         "stream-events": "^1.0.5",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+          "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+          "requires": {
+            "agent-base": "5",
+            "debug": "4"
+          }
+        }
       }
     },
     "term-size": {
@@ -5016,6 +5050,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -5067,27 +5102,134 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
-      "version": "14.2.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",
-      "integrity": "sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.0.2.tgz",
+      "integrity": "sha512-GH/X/hYt+x5hOat4LMnCqMd8r5Cv78heOMIJn1hr7QPPBqfeC6p89Y78+WB9yGDvfpCvgasfmWLzNzEioOUD9Q==",
       "requires": {
-        "cliui": "^5.0.0",
+        "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
+        "find-up": "^4.1.0",
         "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
         "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
+        "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^15.0.0"
+        "yargs-parser": "^16.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+          "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
       }
     },
     "yargs-parser": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
-      "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/packages/buildcop/package-lock.json
+++ b/packages/buildcop/package-lock.json
@@ -1823,9 +1823,9 @@
       }
     },
     "gcf-utils": {
-      "version": "1.3.0-beta.4",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-1.3.0-beta.4.tgz",
-      "integrity": "sha512-3iy5krN/Kt6FQUskhiuiA0iDar5n4bqOkmPY7K7uVQzV7w5Fm2lmDITewUw6y3iC+ipC9PJMQSxx2agR69fprw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-1.3.0.tgz",
+      "integrity": "sha512-yK0OWfqIADcsaUOryqZL5WrHrjGo9ml2EaA6M5PatLVfLNZjkGr66u218IL2HSFhY9R5aMo2DC49Nd+ZcLVXIw==",
       "requires": {
         "@google-cloud/kms": "^1.1.1",
         "@google-cloud/storage": "^4.0.0",
@@ -3551,9 +3551,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.12",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.12.tgz",
-          "integrity": "sha512-SSB4O9/0NVv5mbQ5/MabnAyFfcpVFRVIJj1TZkG21HHgwXQGjosiQB3SBWC9pMCMUTNpWL9gUe//9mFFPQAdKw=="
+          "version": "10.17.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg=="
         }
       }
     },

--- a/packages/buildcop/package.json
+++ b/packages/buildcop/package.json
@@ -26,7 +26,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "^1.3.0-beta.1",
+    "gcf-utils": "^1.3.0-beta.4",
     "probot": "9.6.4",
     "xml-js": "^1.6.11"
   },

--- a/packages/buildcop/package.json
+++ b/packages/buildcop/package.json
@@ -26,7 +26,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "^1.3.0-beta.4",
+    "gcf-utils": "^1.3.0",
     "probot": "9.6.4",
     "xml-js": "^1.6.11"
   },

--- a/packages/buildcop/package.json
+++ b/packages/buildcop/package.json
@@ -26,7 +26,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "1.1.0",
+    "gcf-utils": "^1.3.0-beta.1",
     "probot": "9.6.4",
     "xml-js": "^1.6.11"
   },

--- a/packages/buildcop/src/app.ts
+++ b/packages/buildcop/src/app.ts
@@ -15,7 +15,7 @@
  */
 
 import { GCFBootstrapper } from 'gcf-utils';
-import appFn from './buildcop';
+import { buildcop } from './buildcop';
 
 const bootstrap = new GCFBootstrapper();
-module.exports.buildcop = bootstrap.gcf(appFn);
+module.exports.buildcop = bootstrap.gcf(buildcop);

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -57,18 +57,14 @@ interface PubSubContext {
   github: GitHubAPI;
   log: LoggerWithTarget;
   payload: {
-    message: {
-      data: string; // base64 encoded value with {payload: BuildCopPayload}.
-    };
-  };
+    payload: BuildCopPayload
+  }
 }
 
 export function buildcop(app: Application) {
   app.on('pubsub.message', async (context: PubSubContext) => {
-    const data = JSON.parse(
-      Buffer.from(context.payload.message.data, 'base64').toString()
-    );
-    const payload: BuildCopPayload = data.payload;
+    console.info(JSON.stringify(context.payload, null, 2));
+    const payload: BuildCopPayload = context.payload.payload as BuildCopPayload;
 
     const owner = payload.repoOwner;
     const repo = payload.repoName;

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -63,14 +63,14 @@ interface PubSubContext {
 
 export function buildcop(app: Application) {
   app.on('pubsub.message', async (context: PubSubContext) => {
-    console.info(JSON.stringify(context.payload, null, 2));
     const payload: BuildCopPayload = context.payload.payload as BuildCopPayload;
 
     const owner = payload.repoOwner;
     const repo = payload.repoName;
     const buildID = payload.buildID || '[TODO: set buildID]';
     const buildURL = payload.buildURL || '[TODO: set buildURL]';
-    const xml = JSON.parse(Buffer.from(payload.xunitXML, 'base64').toString());
+
+    const xml = Buffer.from(payload.xunitXML, 'base64').toString();
 
     if (!xml) {
       context.log.info(`[${owner}/${repo}] No XML payload! Skipping.`);

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -57,7 +57,6 @@ interface PubSubContext {
 
 export function buildcop(app: Application) {
   app.on('pubsub.message', async (context: PubSubContext) => {
-    console.log(context.payload);
     const owner = context.payload.organization.login;
     const repo = context.payload.repository.name;
     const buildID = context.payload.buildID || '[TODO: set buildID]';

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -30,15 +30,8 @@ nock.disableNetConnect();
 const fixturesPath = resolve(__dirname, '../../test/fixtures');
 
 function formatPayload(payload: BuildCopPayload) {
-  payload.xunitXML = Buffer.from(JSON.stringify(payload.xunitXML)).toString(
-    'base64'
-  );
-  const data = Buffer.from(JSON.stringify(payload)).toString('base64');
-  return {
-    message: {
-      data,
-    },
-  };
+  payload.xunitXML = Buffer.from(payload.xunitXML).toString('base64');
+  return payload;
 }
 
 describe('buildcop', () => {

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -33,7 +33,7 @@ function formatPayload(payload: BuildCopPayload) {
   payload.xunitXML = Buffer.from(JSON.stringify(payload.xunitXML)).toString(
     'base64'
   );
-  const data = Buffer.from(JSON.stringify({ payload })).toString('base64');
+  const data = Buffer.from(JSON.stringify(payload)).toString('base64');
   return {
     message: {
       data,
@@ -116,8 +116,9 @@ describe('buildcop', () => {
   describe('app', () => {
     it('skips when there is no XML', async () => {
       const payload = formatPayload({
-        repoOwner: 'tbpg',
-        repoName: 'golang-samples',
+        repo: 'tbpg/golang-samples',
+        organization: { login: 'tbpg' },
+        repository: { name: 'golang-samples' },
         buildID: '123',
         buildURL: 'http://example.com',
         xunitXML: '',
@@ -134,8 +135,9 @@ describe('buildcop', () => {
         'utf8'
       );
       const payload = formatPayload({
-        repoOwner: 'tbpg',
-        repoName: 'golang-samples',
+        repo: 'tbpg/golang-samples',
+        organization: { login: 'tbpg' },
+        repository: { name: 'golang-samples' },
         buildID: '123',
         buildURL: 'http://example.com',
         xunitXML: input,
@@ -163,8 +165,9 @@ describe('buildcop', () => {
         'utf8'
       );
       const payload = formatPayload({
-        repoOwner: 'tbpg',
-        repoName: 'golang-samples',
+        repo: 'tbpg/golang-samples',
+        organization: { login: 'tbpg' },
+        repository: { name: 'golang-samples' },
         buildID: '123',
         buildURL: 'http://example.com',
         xunitXML: input,
@@ -203,8 +206,9 @@ describe('buildcop', () => {
         'utf8'
       );
       const payload = formatPayload({
-        repoOwner: 'tbpg',
-        repoName: 'golang-samples',
+        repo: 'tbpg/golang-samples',
+        organization: { login: 'tbpg' },
+        repository: { name: 'golang-samples' },
         buildID: '123',
         buildURL: 'http://example.com',
         xunitXML: input,
@@ -248,8 +252,9 @@ describe('buildcop', () => {
         'utf8'
       );
       const payload = formatPayload({
-        repoOwner: 'tbpg',
-        repoName: 'golang-samples',
+        repo: 'tbpg/golang-samples',
+        organization: { login: 'tbpg' },
+        repository: { name: 'golang-samples' },
         buildID: '123',
         buildURL: 'http://example.com',
         xunitXML: input,
@@ -294,8 +299,9 @@ describe('buildcop', () => {
         'utf8'
       );
       const payload = formatPayload({
-        repoOwner: 'tbpg',
-        repoName: 'golang-samples',
+        repo: 'tbpg/golang-samples',
+        organization: { login: 'tbpg' },
+        repository: { name: 'golang-samples' },
         buildID: '123',
         buildURL: 'http://example.com',
         xunitXML: input,
@@ -334,8 +340,9 @@ describe('buildcop', () => {
         'utf8'
       );
       const payload = formatPayload({
-        repoOwner: 'tbpg',
-        repoName: 'golang-samples',
+        repo: 'tbpg/golang-samples',
+        organization: { login: 'tbpg' },
+        repository: { name: 'golang-samples' },
         buildID: '123',
         buildURL: 'http://example.com',
         xunitXML: input,
@@ -368,8 +375,9 @@ describe('buildcop', () => {
         'utf8'
       );
       const payload = formatPayload({
-        repoOwner: 'tbpg',
-        repoName: 'golang-samples',
+        repo: 'tbpg/golang-samples',
+        organization: { login: 'tbpg' },
+        repository: { name: 'golang-samples' },
         buildID: '123',
         buildURL: 'http://example.com',
         xunitXML: input,

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { buildcop } from '../src/buildcop';
+import { buildcop, BuildCopPayload } from '../src/buildcop';
 const { findFailures, formatFailure } = buildcop;
-import { BuildCopPayload } from '../src/buildcop';
 
 import { resolve } from 'path';
 import { Probot } from 'probot';


### PR DESCRIPTION
I also renamed the app to `buildcop` and adjusted exports so I could use `BuildCopPayload` from tests. Let me know if there is a better way to do that -- wasn't sure the correct way.

Updates #178.