### PR TITLE
feat: listen on edited action

### DIFF
--- a/packages/trusted-contribution/src/trusted-contribution.ts
+++ b/packages/trusted-contribution/src/trusted-contribution.ts
@@ -36,8 +36,15 @@ function isTrustedContribution(author: string): boolean {
 }
 
 export = (app: Application) => {
+  app.on(['pull_request'], async context => {
+    app.log(
+      `PR ${context.payload.pull_request.number} action = ${context.payload.action}`
+    );
+  });
+
   app.on(
     [
+      'pull_request.edited',
       'pull_request.opened',
       'pull_request.reopened',
       'pull_request.synchronized',


### PR DESCRIPTION
I think there's a chance that the `edited` action might fire when a force push happens from renovate; In case this isn't the case, I've also added additional logging so that we can continue to perfect the events we listen on.

see: https://github.com/googleapis/repo-automation-bots/issues/198