### PR TITLE
fix(header-checker-lint): allow for copyright date ranges

### DIFF
--- a/packages/header-checker-lint/src/header-parser.ts
+++ b/packages/header-checker-lint/src/header-parser.ts
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019-2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ export interface LicenseHeader {
   year?: number;
 }
 
-const COPYRIGHT_REGEX = /\s*([*#]|\/\/) \s*Copyright (\d{4}) ([\w\s]+)\.?/;
+const COPYRIGHT_REGEX = /\s*([*#]|\/\/) \s*Copyright (\d{4}(-\d{4})?) ([\w\s]+)\.?/;
 const APACHE2_REGEX = new RegExp(
   'Licensed under the Apache License, Version 2.0'
 );
@@ -36,8 +36,14 @@ export function detectLicenseHeader(contents: string): LicenseHeader {
   contents.split(/\r?\n/).forEach(line => {
     const match = line.match(COPYRIGHT_REGEX);
     if (match) {
-      license.year = Number(match[2]);
-      license.copyright = match[3];
+      // If it's a ranged date, only consider the newest one.
+      if (match[3]) {
+        // The extra '-' should be removed.
+        license.year = Number(match[3].substring(1));
+      } else {
+        license.year = Number(match[2]);
+      }
+      license.copyright = match[4];
     }
 
     if (line.match(APACHE2_REGEX)) {

--- a/packages/header-checker-lint/src/header-parser.ts
+++ b/packages/header-checker-lint/src/header-parser.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/header-checker-lint/test/fixtures/inline-java-style-header-date-range.txt
+++ b/packages/header-checker-lint/test/fixtures/inline-java-style-header-date-range.txt
@@ -1,0 +1,14 @@
+// Copyright 2019-2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+stuff here

--- a/packages/header-checker-lint/test/header-parser.ts
+++ b/packages/header-checker-lint/test/header-parser.ts
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019-2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -62,6 +62,17 @@ describe('detectLicenseHeader', () => {
     const header = detectLicenseHeader(contents);
     assert.strictEqual(header.copyright, 'Google LLC');
     assert.strictEqual(header.year, 2019);
+    assert.strictEqual(header.type, 'Apache-2.0');
+  });
+
+  it('should handle inline java-style comments with date ranges', async () => {
+    const contents = fs.readFileSync(
+      resolve(fixturesPath, './inline-java-style-header-date-range.txt'),
+      'utf-8'
+    );
+    const header = detectLicenseHeader(contents);
+    assert.strictEqual(header.copyright, 'Google LLC');
+    assert.strictEqual(header.year, 2020);
     assert.strictEqual(header.type, 'Apache-2.0');
   });
 });

--- a/packages/header-checker-lint/test/header-parser.ts
+++ b/packages/header-checker-lint/test/header-parser.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes https://github.com/googleapis/repo-automation-bots/issues/207
