### PR TITLE
feature: allow bots to have hyphens in google cloud functions

### DIFF
--- a/scripts/function-1.js
+++ b/scripts/function-1.js
@@ -1,0 +1,4 @@
+exports["hello-World"] = (req, res) => {
+    let message = req.query.message || req.body.message || 'Hello World!';
+    res.status(200).send(message);
+  };

--- a/scripts/function-1.js
+++ b/scripts/function-1.js
@@ -1,4 +1,0 @@
-exports["hello-World"] = (req, res) => {
-    let message = req.query.message || req.body.message || 'Hello World!';
-    res.status(200).send(message);
-  };

--- a/scripts/publish-functions.sh
+++ b/scripts/publish-functions.sh
@@ -43,9 +43,6 @@ for f in *; do
         (
         cd "$f" || exit 1
         echo "$f"
-        # Javascript does not allow function names with '-' so we need to
-        # replace the directory name (which might have '-') with "_"
-        functionname=${f//-/_}
         echo "About to publish function $functionname"
 
         gcloud functions deploy "$functionname" --trigger-http \


### PR DESCRIPTION

Related to Issue #177: after doing some digging with @bcoe, we found out that you can [publish a Google Cloud function](https://screenshot.googleplex.com/jJbAtUqiijw.png) with a hyphen. I'm recommending we make the change in this PR to provide naming consistency in the bots we create and deploy to GCF. In generate-bot, I've changed the logic so that module.exports can export a function with a hyphen, like so:

```
import` { GCFBootstrapper } from 'gcf-utils';
import appFn from './{{programName}}';

const bootstrap = new GCFBootstrapper();
module.exports['{{program-name}}']= bootstrap.gcf(appFn);
```
`

which should work.