### PR TITLE
feat: make buildcop XML optional

### DIFF
--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -1,51 +1,83 @@
-exports['buildcop app opens an issue 1'] = {
+exports['buildcop app testsFailed opens an issue when testsFailed 1'] = {
+  "title": "The build failed",
+  "body": "The build failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop:issue"
+  ]
+}
+
+exports['buildcop app testsFailed opens a new issue when testsFailed and there is a previous one closed 1'] = {
+  "title": "The build failed",
+  "body": "The build failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop:issue"
+  ]
+}
+
+exports['buildcop app testsFailed comments on an existing open issue when testsFailed 1'] = {
+  "body": "The build failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
+}
+
+exports['buildcop app xunitXML opens an issue 1'] = {
   "title": "spanner/spanner_snippets: TestSample failed",
   "body": "spanner/spanner_snippets: TestSample failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
+    "type: bug",
+    "priority: p1",
     "buildcop:issue"
   ]
 }
 
-exports['buildcop app comments on existing issue 1'] = {
+exports['buildcop app xunitXML comments on existing issue 1'] = {
   "body": "spanner/spanner_snippets: TestSample failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
-exports['buildcop app reopens issue for failing test 1'] = {
+exports['buildcop app xunitXML reopens issue for failing test 1'] = {
   "state": "open"
 }
 
-exports['buildcop app reopens issue for failing test 2'] = {
+exports['buildcop app xunitXML reopens issue for failing test 2'] = {
   "body": "spanner/spanner_snippets: TestSample failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
-exports['buildcop app closes an issue for a passing test 1'] = {
+exports['buildcop app xunitXML closes an issue for a passing test 1'] = {
   "body": "Test passed in build 123 (http://example.com)! Closing this issue."
 }
 
-exports['buildcop app closes an issue for a passing test 2'] = {
+exports['buildcop app xunitXML closes an issue for a passing test 2'] = {
   "state": "closed"
 }
 
-exports['buildcop app opens multiple issues for multiple failures 1'] = {
+exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] = {
   "title": "storage/buckets: TestBucketLock failed",
   "body": "storage/buckets: TestBucketLock failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
+    "type: bug",
+    "priority: p1",
     "buildcop:issue"
   ]
 }
 
-exports['buildcop app opens multiple issues for multiple failures 2'] = {
+exports['buildcop app xunitXML opens multiple issues for multiple failures 2'] = {
   "title": "storage/buckets: TestUniformBucketLevelAccess failed",
   "body": "storage/buckets: TestUniformBucketLevelAccess failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
+    "type: bug",
+    "priority: p1",
     "buildcop:issue"
   ]
 }
 
-exports['buildcop app opens multiple issues for multiple failures 3'] = {
+exports['buildcop app xunitXML opens multiple issues for multiple failures 3'] = {
   "title": "storage/buckets: TestDelete failed",
   "body": "storage/buckets: TestDelete failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
+    "type: bug",
+    "priority: p1",
     "buildcop:issue"
   ]
 }


### PR DESCRIPTION
This adds a new boolean field to the Pub/Sub payload: `testsFailed`.

If `xunitXML` is set, `testsFailed` is ignored. Otherwise, `testsFailed` indicates if any test failed (maybe it should be `buildFailed`?)

I also updated the issue labels to automatically add `type: bug` and `priority: p1`. There is some extra logic for searching issues only based on the `buildcop:issue` label.

Fixes #217.