### PR TITLE
fix: ensure header check ignores deleted files

### DIFF
--- a/packages/header-checker-lint/__snapshots__/header-checker-lint.js
+++ b/packages/header-checker-lint/__snapshots__/header-checker-lint.js
@@ -158,3 +158,9 @@ exports['HeaderCheckerLint updated pull request ignores copyright strings in the
   "conclusion": "success",
   "head_sha": "87139750cdcf551e8fe8d90c129527a4f358321c"
 }
+
+exports['HeaderCheckerLint updated pull request ignores a deleted file 1'] = {
+  "name": "header-check",
+  "conclusion": "success",
+  "head_sha": "87139750cdcf551e8fe8d90c129527a4f358321c"
+}

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -151,7 +151,7 @@ export = (app: Application) => {
         continue;
       }
 
-      if (file.status == "removed") {
+      if (file.status === 'removed') {
         app.log.info('ignoring deleted file: ' + file.filename);
         continue;
       }

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -151,6 +151,11 @@ export = (app: Application) => {
         continue;
       }
 
+      if (file.status == "removed") {
+        app.log.info('ignoring deleted file: ' + file.filename);
+        continue;
+      }
+
       if (!configuration.isSourceFile(file.filename)) {
         app.log.info('ignoring non-source file: ' + file.filename);
         continue;

--- a/packages/header-checker-lint/test/fixtures/deleted_file_ignored.json
+++ b/packages/header-checker-lint/test/fixtures/deleted_file_ignored.json
@@ -1,0 +1,14 @@
+[
+  {
+    "sha": "26529b280619729dbc14d1f055df2711f3d5e83a",
+    "filename": "samples/iap.js",
+    "status": "removed",
+    "additions": 0,
+    "deletions": 41,
+    "changes": 41,
+    "blob_url": "https://github.com/chingor13/google-auth-library-java/blob/30f02377cbf2e41c3746f39eebbbe4bb16f31fd2/samples/iap.js",
+    "raw_url": "https://github.com/chingor13/google-auth-library-java/raw/30f02377cbf2e41c3746f39eebbbe4bb16f31fd2/samples/iap.js",
+    "contents_url": "https://api.github.com/repos/chingor13/google-auth-library-java/contents/samples/iap.js?ref=30f02377cbf2e41c3746f39eebbbe4bb16f31fd2",
+    "patch": "@@ -1,41 +0,0 @@\n-// Copyright 2017, Google, Inc.\n-// Licensed under the Apache License, Version 2.0 (the \"License\");\n-// you may not use this file except in compliance with the License.\n-// You may obtain a copy of the License at\n-//\n-//    http://www.apache.org/licenses/LICENSE-2.0\n-//\n-// Unless required by applicable law or agreed to in writing, software\n-// distributed under the License is distributed on an \"AS IS\" BASIS,\n-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n-// See the License for the specific language governing permissions and\n-// limitations under the License.\n-\n-'use strict';\n-\n-const {JWT} = require('google-auth-library');\n-\n-/**\n- * The JWT authorization is ideal for performing server-to-server\n- * communication without asking for user consent.\n- *\n- * Suggested reading for Admin SDK users using service accounts:\n- * https://developers.google.com/admin-sdk/directory/v1/guides/delegation\n- **/\n-\n-const keys = require('./jwt.keys.json');\n-const oauth2Keys = require('./iap.keys.json');\n-\n-async function main() {\n-  const clientId = oauth2Keys.web.client_id;\n-  const client = new JWT({\n-    email: keys.client_email,\n-    key: keys.private_key,\n-    additionalClaims: {target_audience: clientId},\n-  });\n-  const url = `https://iap-demo-dot-el-gato.appspot.com`;\n-  const res = await client.request({url});\n-  console.log(res.data);\n-}\n-\n-main().catch(console.error);"
+  }
+]

--- a/packages/header-checker-lint/test/header-checker-lint.ts
+++ b/packages/header-checker-lint/test/header-checker-lint.ts
@@ -517,5 +517,26 @@ describe('HeaderCheckerLint', () => {
       await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
       requests.done();
     });
+
+    it('ignores a deleted file', async () => {
+      const validFiles = require(resolve(
+        fixturesPath,
+        './deleted_file_ignored'
+      ));
+      const blob = require(resolve(fixturesPath, './valid_license'));
+      const requests = nock('https://api.github.com')
+        .get(
+          '/repos/chingor13/google-auth-library-java/pulls/3/files?per_page=100'
+        )
+        .reply(200, validFiles)
+        .post('/repos/chingor13/google-auth-library-java/check-runs', body => {
+          snapshot(body);
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: 'pull_request', payload, id: '867' });
+      requests.done();
+    });
   });
 });


### PR DESCRIPTION
fixes #222 - Ensures the header lint checker skips deleted files