### PR TITLE
fix: labels can be blank for repo

### DIFF
--- a/packages/label-sync/src/label-sync.ts
+++ b/packages/label-sync/src/label-sync.ts
@@ -133,7 +133,7 @@ handler.getApiLabels = async (
   const repo = (JSON.parse(
     publicRepos[0].toString()
   ) as PublicReposResponse).repos.find(repo => {
-    return repo.repo === repoPath && repo.github_label !== "";
+    return repo.repo === repoPath && repo.github_label !== '';
   });
 
   if (repo) {

--- a/packages/label-sync/src/label-sync.ts
+++ b/packages/label-sync/src/label-sync.ts
@@ -133,7 +133,7 @@ handler.getApiLabels = async (
   const repo = (JSON.parse(
     publicRepos[0].toString()
   ) as PublicReposResponse).repos.find(repo => {
-    return repo.repo === repoPath;
+    return repo.repo === repoPath && repo.github_label !== "";
   });
 
   if (repo) {


### PR DESCRIPTION
repos might be tracked but not have a product label associated with them.