### PR TITLE
fix: labels from first invocation were being applied to future calls

### DIFF
--- a/packages/label-sync/src/label-sync.ts
+++ b/packages/label-sync/src/label-sync.ts
@@ -47,7 +47,7 @@ async function getLabels(github: GitHubAPI, repoPath: string): Promise<Labels> {
     await refreshLabels(github, repoPath);
   }
   const labels = {
-    labels: labelsCache.labels.slice(0)
+    labels: labelsCache.labels.slice(0),
   } as Labels;
   const apiLabelsRes = await handler.getApiLabels(repoPath);
   apiLabelsRes.apis.forEach(api => {
@@ -135,7 +135,7 @@ handler.getApiLabels = async (
   const repo = (JSON.parse(
     publicRepos[0].toString()
   ) as PublicReposResponse).repos.find(repo => {
-    return repo.repo === repoPath && repo.github_label !== "";
+    return repo.repo === repoPath && repo.github_label !== '';
   });
 
   if (repo) {


### PR DESCRIPTION
caching was interfering with our ability to return labels based on the context of the repo firing a webhook, this lead to the label for the first repo invoking the cloud function to be applied to subsequent calls.