### PR TITLE
fix: published cloud functions do not include src/

### DIFF
--- a/packages/auto-label/package.json
+++ b/packages/auto-label/package.json
@@ -15,7 +15,7 @@
     "probot-app"
   ],
   "scripts": {
-    "compile": "tsc -p .",
+    "compile": "tsc -p . && cp ./src/colors.json ./build/src/colors.json",
     "start": "probot run ./build/src/auto-label.js",
     "start:local": "node ./build/src/local.js",
     "prepare": "npm run compile",

--- a/packages/auto-label/src/auto-label.ts
+++ b/packages/auto-label/src/auto-label.ts
@@ -18,9 +18,7 @@ import { GitHubAPI } from 'probot/lib/github';
 import * as path from 'path';
 
 const fs = require('fs');
-const colorsData = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, '../../src/colors.json'), 'utf8')
-);
+const colorsData = require('./colors.json');
 
 interface JSONData {
   github_label: string;


### PR DESCRIPTION
we're currently having deployment failures due to reliance on a file in `src/`, whereas we only upload `build/`.