### PR TITLE
chore: set config to push only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push]
 name: ci
 jobs:
   test:


### PR DESCRIPTION
Let's try using `push` only rather than `pull_request` and `push`.
