### PR TITLE
fix: ignore case when linting commit messages

### DIFF
--- a/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
+++ b/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
@@ -5,7 +5,7 @@ exports['ConventionalCommitLint sets a "failure" context on PR, if commits fail 
   "output": {
     "title": "Commit message did not follow Conventional Commits",
     "summary": "Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nRun `git commit --amend` and edit your message to match Conventional Commit guidelines.",
-    "text": ":x: linting errors for \"*Fix all the bugs*\"\n* subject may not be empty\n* type may not be empty\n\n\n"
+    "text": ":x: linting errors for \"*fix all the bugs*\"\n* subject may not be empty\n* type may not be empty\n\n\n"
   }
 }
 

--- a/packages/conventional-commit-lint/src/conventional-commit-lint.ts
+++ b/packages/conventional-commit-lint/src/conventional-commit-lint.ts
@@ -64,7 +64,7 @@ export = (app: Application) => {
     let text = '';
     let lintError = false;
 
-    const result = await lint(message, rules);
+    const result = await lint(message.toLowerCase(), rules);
     if (result.valid === false) {
       lintError = true;
       text += `:x: linting errors for "*${result.input}*"\n`;

--- a/packages/conventional-commit-lint/test/fixtures/pull_request_synchronize.json
+++ b/packages/conventional-commit-lint/test/fixtures/pull_request_synchronize.json
@@ -12,7 +12,7 @@
     "number": 11,
     "state": "open",
     "locked": false,
-    "title": "blerg!: this is a conventional commit",
+    "title": "blerg!: This is a conventional commit",
     "user": {
       "login": "bcoe",
       "id": 194609,


### PR DESCRIPTION
The Conventional Commit specification indicates:

"Any casing may be used, but it’s best to be consistent."

fixes #59 