### PR TITLE
feat(trusted_contribution): allow customizing list of trusted contributors

### DIFF
--- a/packages/trusted-contribution/README.md
+++ b/packages/trusted-contribution/README.md
@@ -12,7 +12,18 @@ npm install
 npm start
 ```
 
+### Configuration
+
+To configure the bot, you can create a configuration file:
+`.github/trusted-contribution.yml`. The contents of this file allow for the following
+options:
+
+| Name | Description | Type | Default |
+|----- | ----------- | ---- | ------- |
+| `trustedContributors` | List of user login names that are considered trusted  | `string[]` | `['renovate-bot', 'release-please[bot]']` |
+
 ## Deployment and Permissions
+
 ### Repository permissions
 - metadata - read
 - pull requests - read & write

--- a/packages/trusted-contribution/test/fixtures/custom.yml
+++ b/packages/trusted-contribution/test/fixtures/custom.yml
@@ -1,0 +1,2 @@
+trustedContributors:
+  - custom-user

--- a/packages/trusted-contribution/test/fixtures/no-contributors.yml
+++ b/packages/trusted-contribution/test/fixtures/no-contributors.yml
@@ -1,0 +1,1 @@
+trustedContributors: []

--- a/packages/trusted-contribution/test/trusted-contribution.ts
+++ b/packages/trusted-contribution/test/trusted-contribution.ts
@@ -16,10 +16,10 @@ import myProbotApp from '../src/trusted-contribution';
 
 import { resolve } from 'path';
 import { Probot } from 'probot';
-import snapshot from 'snap-shot-it';
 import Webhooks from '@octokit/webhooks';
 
 import nock from 'nock';
+import * as fs from 'fs';
 nock.disableNetConnect();
 
 const fixturesPath = resolve(__dirname, '../../test/fixtures');
@@ -30,6 +30,8 @@ global.console.warn = () => {};
 
 describe('TrustedContributionTestRunner', () => {
   let probot: Probot;
+  let requests: nock.Scope;
+
   beforeEach(() => {
     probot = new Probot({
       // use a bare instance of octokit, the default version
@@ -45,63 +47,264 @@ describe('TrustedContributionTestRunner', () => {
       },
     };
     probot.load(myProbotApp);
+
+    requests = nock('https://api.github.com');
   });
 
-  describe('opened pull request', () => {
-    let payload: Webhooks.WebhookPayloadPullRequest;
-
+  describe('without configuration file', () => {
     beforeEach(() => {
-      payload = require(resolve(fixturesPath, './pull_request_opened'));
-    });
-
-    it('sets a label on PR, if PR author is a trusted contributor', async () => {
-      const requests = nock('https://api.github.com')
-        .post(
-          '/repos/chingor13/google-auth-library-java/issues/3/labels',
-          (body: object) => {
-            return true;
-          }
+      requests = requests
+        .get(
+          '/repos/chingor13/google-auth-library-java/contents/.github/trusted-contribution.yml'
         )
-        .reply(200);
-
-      await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
-      requests.done();
+        .reply(404)
+        .get(
+          // FIXME(#68): why is this necessary?
+          '/repos/chingor13/.github/contents/.github/trusted-contribution.yml'
+        )
+        .reply(404);
     });
 
-    it('does not set a label on PR, if PR author is not a trusted contributor', async () => {
-      payload.pull_request.user.login = 'notauthorized';
-      const requests = nock('https://api.github.com');
-      await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
-      requests.done();
+    describe('opened pull request', () => {
+      let payload: Webhooks.WebhookPayloadPullRequest;
+
+      beforeEach(() => {
+        payload = require(resolve(fixturesPath, './pull_request_opened'));
+      });
+
+      it('sets a label on PR, if PR author is a trusted contributor', async () => {
+        requests = requests
+          .post(
+            '/repos/chingor13/google-auth-library-java/issues/3/labels',
+            (body: object) => {
+              return true;
+            }
+          )
+          .reply(200);
+
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+
+      it('does not set a label on PR, if PR author is not a trusted contributor', async () => {
+        payload.pull_request.user.login = 'notauthorized';
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+    });
+
+    describe('updated pull request', () => {
+      let payload: Webhooks.WebhookPayloadPullRequest;
+
+      before(() => {
+        payload = require(resolve(fixturesPath, './pull_request_synchronized'));
+      });
+
+      it('sets a label on PR, if PR author is a trusted contributor', async () => {
+        requests = requests
+          .post(
+            '/repos/chingor13/google-auth-library-java/issues/3/labels',
+            (body: object) => {
+              return true;
+            }
+          )
+          .reply(200);
+
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+
+      it('does not set a label on PR, if PR author is not a trusted contributor', async () => {
+        payload.pull_request.user.login = 'notauthorized';
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
     });
   });
 
-  describe('updated pull request', () => {
-    let payload: Webhooks.WebhookPayloadPullRequest;
-
-    before(() => {
-      payload = require(resolve(fixturesPath, './pull_request_synchronized'));
-    });
-
-    it('sets a label on PR, if PR author is a trusted contributor', async () => {
-      const requests = nock('https://api.github.com')
-        .post(
-          '/repos/chingor13/google-auth-library-java/issues/3/labels',
-          (body: object) => {
-            return true;
-          }
+  describe('with a custom configuration file', () => {
+    beforeEach(() => {
+      const config = fs.readFileSync(resolve(fixturesPath, 'custom.yml'));
+      requests = requests
+        .get(
+          '/repos/chingor13/google-auth-library-java/contents/.github/trusted-contribution.yml'
         )
-        .reply(200);
-
-      await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
-      requests.done();
+        .reply(200, { content: config.toString('base64') });
     });
 
-    it('does not set a label on PR, if PR author is not a trusted contributor', async () => {
-      payload.pull_request.user.login = 'notauthorized';
-      const requests = nock('https://api.github.com');
-      await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
-      requests.done();
+    describe('opened pull request', () => {
+      let payload: Webhooks.WebhookPayloadPullRequest;
+
+      beforeEach(() => {
+        payload = require(resolve(fixturesPath, './pull_request_opened'));
+      });
+
+      it('sets a label on PR, if PR author is a trusted contributor', async () => {
+        payload.pull_request.user.login = 'custom-user';
+        requests = requests
+          .post(
+            '/repos/chingor13/google-auth-library-java/issues/3/labels',
+            (body: object) => {
+              return true;
+            }
+          )
+          .reply(200);
+
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+
+      it('does not set a label on PR, if PR author is not a trusted contributor', async () => {
+        payload.pull_request.user.login = 'release-please[bot]';
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+    });
+
+    describe('updated pull request', () => {
+      let payload: Webhooks.WebhookPayloadPullRequest;
+
+      before(() => {
+        payload = require(resolve(fixturesPath, './pull_request_synchronized'));
+      });
+
+      it('sets a label on PR, if PR author is a trusted contributor', async () => {
+        payload.pull_request.user.login = 'custom-user';
+        requests = requests
+          .post(
+            '/repos/chingor13/google-auth-library-java/issues/3/labels',
+            (body: object) => {
+              return true;
+            }
+          )
+          .reply(200);
+
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+
+      it('does not set a label on PR, if PR author is not a trusted contributor', async () => {
+        payload.pull_request.user.login = 'release-please[bot]';
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+    });
+  });
+
+  describe('with an empty configuration file', () => {
+    beforeEach(() => {
+      const config = fs.readFileSync(resolve(fixturesPath, 'empty.yml'));
+      requests = requests
+        .get(
+          '/repos/chingor13/google-auth-library-java/contents/.github/trusted-contribution.yml'
+        )
+        .reply(200, { content: config.toString('base64') });
+    });
+
+    describe('opened pull request', () => {
+      let payload: Webhooks.WebhookPayloadPullRequest;
+
+      beforeEach(() => {
+        payload = require(resolve(fixturesPath, './pull_request_opened'));
+      });
+
+      it('sets a label on PR, if PR author is a trusted contributor', async () => {
+        requests = requests
+          .post(
+            '/repos/chingor13/google-auth-library-java/issues/3/labels',
+            (body: object) => {
+              return true;
+            }
+          )
+          .reply(200);
+
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+
+      it('does not set a label on PR, if PR author is not a trusted contributor', async () => {
+        payload.pull_request.user.login = 'unauthorized';
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+    });
+
+    describe('updated pull request', () => {
+      let payload: Webhooks.WebhookPayloadPullRequest;
+
+      before(() => {
+        payload = require(resolve(fixturesPath, './pull_request_synchronized'));
+      });
+
+      it('sets a label on PR, if PR author is a trusted contributor', async () => {
+        requests = requests
+          .post(
+            '/repos/chingor13/google-auth-library-java/issues/3/labels',
+            (body: object) => {
+              return true;
+            }
+          )
+          .reply(200);
+
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+
+      it('does not set a label on PR, if PR author is not a trusted contributor', async () => {
+        payload.pull_request.user.login = 'unauthorized';
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+    });
+  });
+
+  describe('with an empty list of contributors file', () => {
+    beforeEach(() => {
+      const config = fs.readFileSync(
+        resolve(fixturesPath, 'no-contributors.yml')
+      );
+      requests = requests
+        .get(
+          '/repos/chingor13/google-auth-library-java/contents/.github/trusted-contribution.yml'
+        )
+        .reply(200, { content: config.toString('base64') });
+    });
+
+    describe('opened pull request', () => {
+      let payload: Webhooks.WebhookPayloadPullRequest;
+
+      beforeEach(() => {
+        payload = require(resolve(fixturesPath, './pull_request_opened'));
+      });
+
+      it('does not set a label on PR, even if PR author is a default trusted contributor', async () => {
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+
+      it('does not set a label on PR, if PR author is not a trusted contributor', async () => {
+        payload.pull_request.user.login = 'custom-user';
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+    });
+
+    describe('updated pull request', () => {
+      let payload: Webhooks.WebhookPayloadPullRequest;
+
+      before(() => {
+        payload = require(resolve(fixturesPath, './pull_request_synchronized'));
+      });
+
+      it('does not set a label on PR, even if PR author is a default trusted contributor', async () => {
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
+
+      it('does not set a label on PR, if PR author is not a trusted contributor', async () => {
+        await probot.receive({ name: 'pull_request', payload, id: 'abc123' });
+        requests.done();
+      });
     });
   });
 });


### PR DESCRIPTION
This allows repos to opt-out of the functionality by explicitly configuring an empty list of `trustedContributors` via the `.github/trusted-contribution.yml` configuration file. You can also customize the list by specifying your own list of usernames to allow (replaces the default list rather than merging).

We could make the entire bot do nothing in the absence of a configuration (like release-please), but that is not included in this PR.

For context, we would like to not automatically run the tests for `release-please[bot]` PRs in java as it can overwhelm CI.

The current default behavior (i.e. no configuration file) is preserved.