### PR TITLE
fix: new release-please with fix for Python

### DIFF
--- a/packages/failurechecker/package.json
+++ b/packages/failurechecker/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "gcf-utils": "1.6.1",
     "moment": "^2.24.0",
-    "probot": "9.9.4",
     "@octokit/rest": "16.41.2"
   },
   "devDependencies": {

--- a/packages/generate-bot/templates/package.json
+++ b/packages/generate-bot/templates/package.json
@@ -27,7 +27,6 @@
     },
     "dependencies": {
       "gcf-utils": "1.6.1",
-      "probot": "9.9.4",
       "@octokit/rest": "16.41.2"
     },
     "devDependencies": {

--- a/packages/header-checker-lint/package.json
+++ b/packages/header-checker-lint/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "gcf-utils": "1.6.1",
     "minimatch": "^3.0.4",
-    "probot": "9.9.4",
     "@octokit/rest": "16.41.2"
   },
   "devDependencies": {

--- a/packages/label-sync/package.json
+++ b/packages/label-sync/package.json
@@ -27,8 +27,7 @@
     "@google-cloud/storage": "^4.3.0",
     "@octokit/rest": "16.41.2",
     "gaxios": "^2.1.0",
-    "gcf-utils": "1.6.1",
-    "probot": "9.9.4"
+    "gcf-utils": "1.6.1"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.6",

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -29,7 +29,6 @@
     "@google-cloud/secret-manager": "^1.1.0",
     "gcf-utils": "1.6.1",
     "node-fetch": "^2.6.0",
-    "probot": "9.9.4",
     "tar": "^6.0.0",
     "uuid": "^3.3.3",
     "@octokit/rest": "16.41.2"

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -26,10 +26,9 @@
     "lint": "gts check"
   },
   "dependencies": {
+    "@octokit/rest": "16.41.2",
     "gcf-utils": "1.6.1",
-    "probot": "9.9.4",
-    "release-please": "^3.1.1",
-    "@octokit/rest": "16.41.2"
+    "release-please": "^3.2.2"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.6",

--- a/packages/trusted-contribution/package.json
+++ b/packages/trusted-contribution/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@octokit/rest": "^16.28.3",
     "gcf-utils": "1.6.1",
-    "probot": "9.9.4",
     "@octokit/rest": "16.41.2"
   },
   "devDependencies": {


### PR DESCRIPTION
updates release-please, addressing https://github.com/googleapis/repo-automation-bots/issues/277.

also removes `probot` dependency, which we get implicitly through `gcf-utils` (there were annoying TypeScript build issues due to these versions sometimes getting out of whack).