### PR TITLE
fix(Build Cop): fix flaky detection, fix local dev

### DIFF
--- a/packages/buildcop/package.json
+++ b/packages/buildcop/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "compile": "tsc -p .",
-    "start": "probot run ./build/src/buildcop.js",
+    "start": "node ./build/src/main.js",
     "start:local": "node ./build/src/local.js",
     "prepare": "npm run compile",
     "pretest": "npm run compile",

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -84,8 +84,8 @@ interface PubSubContext {
 
 export function buildcop(app: Application) {
   app.on('pubsub.message', async (context: PubSubContext) => {
-    const owner = context.payload.organization.login;
-    const repo = context.payload.repository.name;
+    const owner = context.payload.organization?.login;
+    const repo = context.payload.repository?.name;
     const buildID = context.payload.buildID || '[TODO: set buildID]';
     const buildURL = context.payload.buildURL || '[TODO: set buildURL]';
 
@@ -312,6 +312,9 @@ buildcop.closeIssues = async (
 
     // Don't close flaky issues.
     if (buildcop.isFlaky(issue)) {
+      context.log.info(
+        `[${owner}/${repo}] not closing flaky issue #${issue.number}`
+      );
       continue;
     }
 
@@ -378,7 +381,7 @@ buildcop.isFlaky = (issue: Octokit.IssuesListForRepoResponseItem): boolean => {
     return false;
   }
   for (const label of issue.labels) {
-    if (label.toString() === FLAKY_LABEL) {
+    if (label.name === FLAKY_LABEL) {
       return true;
     }
   }

--- a/packages/buildcop/src/main.ts
+++ b/packages/buildcop/src/main.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC. All Rights Reserved.
+ * Copyright 2020 Google LLC. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/buildcop/src/main.ts
+++ b/packages/buildcop/src/main.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// buildcop.ts doesn't have the Probot app as a default export.
+// Import the app and run it directly rather than using `probot run`.
+
+import { Probot } from 'probot';
+import { buildcop } from './buildcop';
+
+Probot.run(buildcop);

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -397,7 +397,7 @@ describe('buildcop', () => {
               }),
               number: 16,
               body: `Failure!`,
-              labels: ['buildcop: flaky'],
+              labels: [{ name: 'buildcop: flaky' }],
               state: 'open',
             },
           ]);
@@ -459,7 +459,7 @@ describe('buildcop', () => {
               }),
               number: 16,
               body: 'Failure!',
-              labels: ['buildcop: flaky'],
+              labels: [{ name: 'buildcop: flaky' }],
               state: 'closed',
             },
           ])
@@ -708,7 +708,7 @@ describe('buildcop', () => {
               }),
               number: 16,
               body: `Failure!`,
-              labels: ['buildcop: flaky'],
+              labels: [{ name: 'buildcop: flaky' }],
             },
           ]);
 
@@ -798,7 +798,7 @@ describe('buildcop', () => {
               title,
               number: 17,
               body: 'Failure!',
-              labels: ['buildcop: flaky'],
+              labels: [{ name: 'buildcop: flaky' }],
               state: 'open',
             },
           ])
@@ -826,7 +826,7 @@ describe('buildcop', () => {
               title,
               number: 17,
               body: 'Failure!',
-              labels: ['buildcop: flaky'],
+              labels: [{ name: 'buildcop: flaky' }],
               state: 'open',
             },
           ]);


### PR DESCRIPTION
Local development wasn't working because `buildcop.ts` doesn't have the Probot app as the default export. I found the `main.ts` pattern [in the Probot docs](https://probot.github.io/docs/development/#alternate-way-of-running-a-probot-app), adapted it for this, and it works.

That local development was how I figured out the payload for labels was not correct, so issues were never detected as flaky.

Fixes #281 🦕
