### PR TITLE
fix(Build Cop): only close duplicates when the test was run

### DIFF
--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -22,9 +22,9 @@ exports['buildcop app testsFailed comments on an existing open issue when testsF
   "body": "The build failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
-exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] = {
-  "title": "storage/buckets: TestBucketLock failed",
-  "body": "storage/buckets: TestBucketLock failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+exports['buildcop app xunitXML opens an issue [Go] 1'] = {
+  "title": "spanner/spanner_snippets: TestSample failed",
+  "body": "spanner/spanner_snippets: TestSample failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -32,9 +32,17 @@ exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] =
   ]
 }
 
-exports['buildcop app xunitXML opens multiple issues for multiple failures 2'] = {
-  "title": "storage/buckets: TestUniformBucketLevelAccess failed",
-  "body": "storage/buckets: TestUniformBucketLevelAccess failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+exports['buildcop app xunitXML closes a duplicate issue 1'] = {
+  "body": "Closing as a duplicate of #19"
+}
+
+exports['buildcop app xunitXML closes a duplicate issue 2'] = {
+  "state": "closed"
+}
+
+exports['buildcop app xunitXML opens an issue [Python] 1'] = {
+  "title": "appengine.flexible.datastore.main_test: test_index failed",
+  "body": "appengine.flexible.datastore.main_test: test_index failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -76,9 +84,9 @@ exports['buildcop app xunitXML closes an issue for a passing test [Python] 2'] =
   "state": "closed"
 }
 
-exports['buildcop app xunitXML opens an issue [Go] 1'] = {
-  "title": "spanner/spanner_snippets: TestSample failed",
-  "body": "spanner/spanner_snippets: TestSample failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] = {
+  "title": "storage/buckets: TestBucketLock failed",
+  "body": "storage/buckets: TestBucketLock failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -86,20 +94,12 @@ exports['buildcop app xunitXML opens an issue [Go] 1'] = {
   ]
 }
 
-exports['buildcop app xunitXML opens an issue [Python] 1'] = {
-  "title": "appengine.flexible.datastore.main_test: test_index failed",
-  "body": "appengine.flexible.datastore.main_test: test_index failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+exports['buildcop app xunitXML opens multiple issues for multiple failures 2'] = {
+  "title": "storage/buckets: TestUniformBucketLevelAccess failed",
+  "body": "storage/buckets: TestUniformBucketLevelAccess failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
     "buildcop: issue"
   ]
-}
-
-exports['buildcop app xunitXML closes a duplicate issue 1'] = {
-  "body": "Closing as a duplicate of #17"
-}
-
-exports['buildcop app xunitXML closes a duplicate issue 2'] = {
-  "state": "closed"
 }

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -782,6 +782,10 @@ describe('buildcop', () => {
             'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
           testCase: 'TestSample',
         });
+        const title2 = formatTestCase({
+          package: 'appengine/go11x/helloworld',
+          testCase: 'TestIndexHandler',
+        });
 
         const requests = nock('https://api.github.com')
           .get(
@@ -801,13 +805,26 @@ describe('buildcop', () => {
               labels: [{ name: 'buildcop: flaky' }],
               state: 'open',
             },
+            {
+              title: title2,
+              number: 18,
+              body: 'Failure!',
+              state: 'open',
+            },
+            {
+              title: title2,
+              number: 19,
+              body: 'Failure!',
+              labels: [{ name: 'buildcop: flaky' }],
+              state: 'open',
+            },
           ])
-          .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
+          .post('/repos/tbpg/golang-samples/issues/18/comments', body => {
             snapshot(body);
             return true;
           })
           .reply(200)
-          .patch('/repos/tbpg/golang-samples/issues/16', body => {
+          .patch('/repos/tbpg/golang-samples/issues/18', body => {
             snapshot(body);
             return true;
           })
@@ -815,21 +832,7 @@ describe('buildcop', () => {
           .get(
             '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
           )
-          .reply(200, [
-            {
-              title,
-              number: 16,
-              body: 'Failure!',
-              state: 'closed',
-            },
-            {
-              title,
-              number: 17,
-              body: 'Failure!',
-              labels: [{ name: 'buildcop: flaky' }],
-              state: 'open',
-            },
-          ]);
+          .reply(200, []); // Real response would include all issues again.
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 


### PR DESCRIPTION
Otherwise, if there are 50 invocations of the bot at the same time, they
will all try to close the duplicate issues. This isn't perfect, but will
be way better than 50.

Fixes #283 🦕
