### PR TITLE
fix: filter to org in payload

### DIFF
--- a/packages/merge-on-green/src/merge-logic.ts
+++ b/packages/merge-on-green/src/merge-logic.ts
@@ -422,7 +422,9 @@ mergeOnGreen.checkReviews = async function checkReviews(
   if (reviewsCompleted.length !== 0) {
     reviewsCompleted.forEach(review => {
       if (review.state !== 'APPROVED') {
-        console.log('One of your reviewers did not approve the PR');
+        console.log(
+          `One of your reviewers did not approve the PR ${owner}/${repo}/${pr} state = ${review.state}`
+        );
         reviewsPassed = false;
       }
     });

--- a/packages/merge-on-green/src/merge-on-green.ts
+++ b/packages/merge-on-green/src/merge-on-green.ts
@@ -85,9 +85,16 @@ handler.addPR = async function addPR(wp: WatchPR, url: string) {
 function handler(app: Application) {
   app.on(['schedule.repository'], async context => {
     const watchedPRs = await handler.listPRs();
+    console.info(`running for org ${context.payload.org}`);
     for (const wp of watchedPRs) {
       const start = Date.now();
       console.info(`checking PR: ${wp.url}`);
+      if (!wp.owner.startsWith(context.payload.org)) {
+        console.info(
+          `skipping mergeOnGreen for ${wp.url} not part of org ${context.payload.org}`
+        );
+        continue;
+      }
       try {
         const remove = await mergeOnGreen(
           wp.owner,

--- a/packages/merge-on-green/test/merge-on-green.ts
+++ b/packages/merge-on-green/test/merge-on-green.ts
@@ -197,7 +197,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 
@@ -238,7 +238,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 
@@ -276,7 +276,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 
@@ -314,7 +314,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 
@@ -350,7 +350,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 
@@ -388,7 +388,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 
@@ -427,7 +427,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 
@@ -465,7 +465,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 
@@ -510,7 +510,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 
@@ -554,7 +554,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 
@@ -601,7 +601,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 
@@ -649,7 +649,7 @@ describe('merge-on-green', () => {
 
     await probot.receive({
       name: 'schedule.repository',
-      payload: {},
+      payload: { org: 'testOwner' },
       id: 'abc123',
     });
 


### PR DESCRIPTION
The underlying problem with `automerge` on `GoogleCloudPlatform` was that it has a different installation ID than `googleapis`, and we weren't clever enough to support this. We now have a cron setup for both `GoogleCloudPlatform` and for `googleapis`, each with a different installation ID.

This was the quickest fix, we may want to revisit this design in `gcf-utils` in the future, and make it so that a single cron can have multiple `installation` IDs, this would take quite a few finicky changes though.