### PR TITLE
build: ignore synth workflows

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -12,5 +12,6 @@ s.copy(templates, excludes=[
   '.nycrc',
   'README.md',
   '.github/release-please.yml'
-  '.kokoro'
+  '.kokoro/',
+  '.github/workflows/'
 ])

--- a/synth.py
+++ b/synth.py
@@ -11,7 +11,8 @@ s.copy(templates, excludes=[
   '.prettierrc',
   '.nycrc',
   'README.md',
-  '.github/release-please.yml'
+  '.github/release-please.yml',
   '.kokoro/',
-  '.github/workflows/'
+  '.github/workflows/',
+  'codecov.yaml'
 ])


### PR DESCRIPTION
I noticed in #110 synth was still trying to synchronize kokoro, and was trying to sync up github workflows.  Trying to see if this works. 