### PR TITLE
fix(Build Cop): keep existing labels when marking as flaky

### DIFF
--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -56,6 +56,7 @@ exports['buildcop app xunitXML comments on existing issue 1'] = {
 
 exports['buildcop app xunitXML reopens issue for failing test 1'] = {
   "labels": [
+    "api: spanner",
     "type: bug",
     "priority: p1",
     "buildcop: issue",

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -252,11 +252,15 @@ buildcop.openIssues = async (
         context.log.info(
           `[${owner}/${repo}] reopening issue #${existingIssue.number}`
         );
+        const labels = existingIssue.labels
+          .map(l => l.name)
+          .filter(l => !l.startsWith('buildcop'))
+          .concat(LABELS_FOR_FLAKY_ISSUE);
         await context.github.issues.update({
           owner,
           repo,
           issue_number: existingIssue.number,
-          labels: LABELS_FOR_FLAKY_ISSUE,
+          labels,
           state: 'open',
         });
         let body = FLAKY_MESSAGE;

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -487,7 +487,7 @@ describe('buildcop', () => {
               }),
               number: 16,
               body: 'Failure!',
-              labels: [{ name: 'buildcop: flaky' }],
+              labels: [{ name: 'buildcop: flaky' }, { name: 'api: spanner' }],
               state: 'closed',
             },
           ])


### PR DESCRIPTION
Fixes #339 🦕
