### PR TITLE
fix(Build Cop): make fewer comments

### DIFF
--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -56,11 +56,11 @@ exports['buildcop app xunitXML comments on existing issue 1'] = {
 
 exports['buildcop app xunitXML reopens issue for failing test 1'] = {
   "labels": [
-    "api: spanner",
     "type: bug",
     "priority: p1",
     "buildcop: issue",
-    "buildcop: flaky"
+    "buildcop: flaky",
+    "api: spanner"
   ],
   "state": "open"
 }
@@ -121,4 +121,38 @@ exports['buildcop app xunitXML closes an issue for a passing test [Java] 1'] = {
 
 exports['buildcop app xunitXML closes an issue for a passing test [Java] 2'] = {
   "state": "closed"
+}
+
+exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (comment) 1'] = {
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop: issue",
+    "buildcop: flaky",
+    null
+  ],
+  "state": "open"
+}
+
+exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (comment) 2'] = {
+  "body": "Looks like this issue is flaky. :worried:\n\nI'm going to leave this open and stop commenting.\n\nA human should fix and close this."
+}
+
+exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (issue body) 1'] = {
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop: issue",
+    "buildcop: flaky",
+    null
+  ],
+  "state": "open"
+}
+
+exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (issue body) 2'] = {
+  "body": "Looks like this issue is flaky. :worried:\n\nI'm going to leave this open and stop commenting.\n\nA human should fix and close this."
+}
+
+exports['buildcop app xunitXML does not comment about failure on existing flaky issue 1'] = {
+  "body": "storage/buckets: TestUniformBucketLevelAccess failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
 }

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -243,6 +243,8 @@ describe('buildcop', () => {
               state: 'open',
             },
           ])
+          .get('/repos/tbpg/golang-samples/issues/16/comments')
+          .reply(200, [])
           .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
             snapshot(body);
             return true;
@@ -387,6 +389,8 @@ describe('buildcop', () => {
               state: 'open',
             },
           ])
+          .get('/repos/tbpg/golang-samples/issues/16/comments')
+          .reply(200, [])
           .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
             snapshot(body);
             return true;
@@ -400,7 +404,7 @@ describe('buildcop', () => {
 
       it('does not comment about failure on existing flaky issue', async () => {
         const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'one_failed.xml'),
+          resolve(fixturesPath, 'testdata', 'many_failed_same_pkg.xml'),
           'utf8'
         );
         const payload = formatPayload({
@@ -420,15 +424,32 @@ describe('buildcop', () => {
             {
               title: formatTestCase({
                 package:
-                  'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
-                testCase: 'TestSample',
+                  'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
+                testCase: 'TestBucketLock',
               }),
               number: 16,
               body: `Failure!`,
               labels: [{ name: 'buildcop: flaky' }],
               state: 'open',
             },
-          ]);
+            {
+              title: formatTestCase({
+                package:
+                  'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
+                testCase: 'TestUniformBucketLevelAccess',
+              }),
+              number: 17,
+              body: `Failure!`,
+              state: 'open',
+            },
+          ])
+          .get('/repos/tbpg/golang-samples/issues/17/comments')
+          .reply(200, [])
+          .post('/repos/tbpg/golang-samples/issues/17/comments', body => {
+            snapshot(body);
+            return true;
+          })
+          .reply(200);
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
@@ -713,7 +734,17 @@ describe('buildcop', () => {
             {
               body: `status: failed\nbuildID: 123`,
             },
-          ]);
+          ])
+          .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
+            snapshot(body);
+            return true;
+          })
+          .reply(200)
+          .patch('/repos/tbpg/golang-samples/issues/16', body => {
+            snapshot(body);
+            return true;
+          })
+          .reply(200);
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
@@ -742,13 +773,23 @@ describe('buildcop', () => {
             {
               title: formatTestCase({
                 package:
-                  'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
-                testCase: 'TestSample',
+                  'github.com/GoogleCloudPlatform/golang-samples/appengine/go11x/helloworld',
+                testCase: 'TestIndexHandler',
               }),
               number: 16,
               body: `status: failed\nbuildID: 123`,
             },
-          ]);
+          ])
+          .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
+            snapshot(body);
+            return true;
+          })
+          .reply(200)
+          .patch('/repos/tbpg/golang-samples/issues/16', body => {
+            snapshot(body);
+            return true;
+          })
+          .reply(200);
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
@@ -912,29 +953,6 @@ describe('buildcop', () => {
 
         requests.done();
       });
-    });
-  });
-
-  describe('formatBody and containsBuildFailure', () => {
-    it('correctly finds a failure', () => {
-      const buildID = 'my-build-id';
-      const buildURL = 'my.build.url';
-      const failure = {
-        package: 'my-package',
-        testCase: 'my-test',
-      };
-      const body = buildcop.formatBody(failure, buildID, buildURL);
-      expect(buildcop.containsBuildFailure(body, buildID)).to.equal(true);
-    });
-    it('corectly does not find a failure', () => {
-      const failure = {
-        package: 'my-package',
-        testCase: 'my-test',
-      };
-      const body = buildcop.formatBody(failure, 'my-build-id', 'my.build.url');
-      expect(buildcop.containsBuildFailure(body, 'other-build-id')).to.equal(
-        false
-      );
     });
   });
 });


### PR DESCRIPTION
* If a test passes and fails in the same build, mark the issue as flaky. That way, we will stop commenting on it.
* Only comment once per build about a failure. This means we will possibly make more API calls, but I think it's OK. We only get the issues for failing tests that failed again, in which case we were already commenting that it failed again. But, sometimes, we won't comment again (because there is already a failure comment).
  * Some python-docs-samples issues get spammed by 4+ comments for the same build ID.

I also fixed a bug where we would `return` too early after finding a flaky issue. Switched to a `continue` to continue processing the rest of the issues.

Updates #282 🦕

Note: I plan to mark this issue as fixed if this PR sufficiently reduces the amount of noise.