### PR TITLE
fix: GitHub API can return a null value for body, breaking merge logic

### DIFF
--- a/packages/merge-on-green/src/merge-logic.ts
+++ b/packages/merge-on-green/src/merge-logic.ts
@@ -477,7 +477,7 @@ mergeOnGreen.merge = async function merge(
       repo,
       pull_number: pr,
       commit_title: commitInfo.title,
-      commit_message: commitInfo.body,
+      commit_message: commitInfo.body || '',
       merge_method: 'squash',
     })
   ).data as Merge;


### PR DESCRIPTION
I observed this recently trying to automerge [these PRs](https://github.com/googleapis/nodejs-recommender/pull/28), we saw the error:

`failed to merge "'commit_message' cannot be null: " googleapis/nodejs-asset/269`, @chingor13 saw similar behavior yesterday.

I've confirmed this fix, it must be that GitHub is returning `null`.