### PR TITLE
fix(Build Cop): handle comment pagination and elaborate on flaky issues

### DIFF
--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -1,6 +1,6 @@
 exports['buildcop app testsFailed opens an issue when testsFailed 1'] = {
   "title": "The build failed",
-  "body": "The build failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -10,7 +10,7 @@ exports['buildcop app testsFailed opens an issue when testsFailed 1'] = {
 
 exports['buildcop app testsFailed opens a new issue when testsFailed and there is a previous one closed 1'] = {
   "title": "The build failed",
-  "body": "The build failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -19,12 +19,12 @@ exports['buildcop app testsFailed opens a new issue when testsFailed and there i
 }
 
 exports['buildcop app testsFailed comments on an existing open issue when testsFailed 1'] = {
-  "body": "The build failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
 exports['buildcop app xunitXML opens an issue [Go] 1'] = {
   "title": "spanner/spanner_snippets: TestSample failed",
-  "body": "spanner/spanner_snippets: TestSample failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -42,7 +42,7 @@ exports['buildcop app xunitXML closes a duplicate issue 2'] = {
 
 exports['buildcop app xunitXML opens an issue [Python] 1'] = {
   "title": "appengine.flexible.datastore.main_test: test_index failed",
-  "body": "appengine.flexible.datastore.main_test: test_index failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -51,7 +51,7 @@ exports['buildcop app xunitXML opens an issue [Python] 1'] = {
 }
 
 exports['buildcop app xunitXML comments on existing issue 1'] = {
-  "body": "spanner/spanner_snippets: TestSample failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
 exports['buildcop app xunitXML reopens issue for failing test 1'] = {
@@ -66,7 +66,7 @@ exports['buildcop app xunitXML reopens issue for failing test 1'] = {
 }
 
 exports['buildcop app xunitXML reopens issue for failing test 2'] = {
-  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\nspanner/spanner_snippets: TestSample failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
 exports['buildcop app xunitXML closes an issue for a passing test [Go] 1'] = {
@@ -87,7 +87,7 @@ exports['buildcop app xunitXML closes an issue for a passing test [Python] 2'] =
 
 exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] = {
   "title": "storage/buckets: TestBucketLock failed",
-  "body": "storage/buckets: TestBucketLock failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -97,7 +97,7 @@ exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] =
 
 exports['buildcop app xunitXML opens multiple issues for multiple failures 2'] = {
   "title": "storage/buckets: TestUniformBucketLevelAccess failed",
-  "body": "storage/buckets: TestUniformBucketLevelAccess failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -107,7 +107,7 @@ exports['buildcop app xunitXML opens multiple issues for multiple failures 2'] =
 
 exports['buildcop app xunitXML opens an issue [Java] 1'] = {
   "title": "com.google.cloud.vision.it.ITSystemTest: detectSafeSearchGcsTest failed",
-  "body": "com.google.cloud.vision.it.ITSystemTest: detectSafeSearchGcsTest failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -134,11 +134,11 @@ exports['buildcop app reopens the original flaky issue when there is a duplicate
 }
 
 exports['buildcop app reopens the original flaky issue when there is a duplicate 2'] = {
-  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\nspanner/spanner_snippets: TestSample failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
 exports['buildcop app xunitXML does not comment about failure on existing flaky issue 1'] = {
-  "body": "storage/buckets: TestUniformBucketLevelAccess failed\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
 exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (comment) 1'] = {
@@ -153,7 +153,7 @@ exports['buildcop app xunitXML keeps an issue open for a passing test that faile
 }
 
 exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (comment) 2'] = {
-  "body": "Looks like this issue is flaky. :worried:\n\nI'm going to leave this open and stop commenting.\n\nA human should fix and close this."
+  "body": "Looks like this issue is flaky. :worried:\n\nI'm going to leave this open and stop commenting.\n\nA human should fix and close this.\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: passed"
 }
 
 exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (issue body) 1'] = {
@@ -168,5 +168,5 @@ exports['buildcop app xunitXML keeps an issue open for a passing test that faile
 }
 
 exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (issue body) 2'] = {
-  "body": "Looks like this issue is flaky. :worried:\n\nI'm going to leave this open and stop commenting.\n\nA human should fix and close this."
+  "body": "Looks like this issue is flaky. :worried:\n\nI'm going to leave this open and stop commenting.\n\nA human should fix and close this.\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: passed"
 }

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -55,6 +55,7 @@ I reopened the issue, but a human will need to close it again.`;
 interface TestCase {
   package?: string;
   testCase?: string;
+  passed: boolean;
 }
 
 interface TestResults {
@@ -99,7 +100,7 @@ export function buildcop(app: Application) {
         return;
       }
       if (context.payload.testsFailed) {
-        results = { passes: [], failures: [{}] }; // A single failure is used to indicate the whole build failed.
+        results = { passes: [], failures: [{ passed: false }] }; // A single failure is used to indicate the whole build failed.
       } else {
         results = { passes: [], failures: [] }; // Tests passed.
       }
@@ -346,7 +347,8 @@ buildcop.closeIssues = async (
         owner,
         repo,
         buildID,
-        buildURL
+        buildURL,
+        pass
       );
       break;
     }
@@ -404,7 +406,7 @@ buildcop.markIssueFlaky = async (
   repo: string,
   buildID: string,
   buildURL: string,
-  failure?: TestCase
+  testCase: TestCase
 ) => {
   context.log.info(
     `[${owner}/${repo}] marking issue #${existingIssue.number} as flaky`
@@ -425,8 +427,8 @@ buildcop.markIssueFlaky = async (
   if (buildcop.isFlaky(existingIssue)) {
     body = FLAKY_AGAIN_MESSAGE;
   }
-  if (failure) {
-    body = body + '\n\n' + buildcop.formatBody(failure, buildID, buildURL);
+  if (testCase) {
+    body = body + '\n\n' + buildcop.formatBody(testCase, buildID, buildURL);
   }
   await context.github.issues.createComment({
     owner,
@@ -437,12 +439,13 @@ buildcop.markIssueFlaky = async (
 };
 
 buildcop.formatBody = (
-  failure: TestCase,
+  testCase: TestCase,
   buildID: string,
   buildURL: string
 ): string => {
-  const failureText = buildcop.formatTestCase(failure);
-  return `${failureText}\nbuildID: ${buildID}\nbuildURL: ${buildURL}\nstatus: failed`;
+  return `buildID: ${buildID}
+buildURL: ${buildURL}
+status: ${testCase.passed ? 'passed' : 'failed'}`;
 };
 
 buildcop.containsBuildFailure = async (
@@ -524,12 +527,14 @@ buildcop.findTestResults = (xml: string): TestResults => {
         passes.push({
           package: pkg,
           testCase: testcase['_attributes'].name,
+          passed: true,
         });
         continue;
       }
       failures.push({
         package: pkg,
         testCase: testcase['_attributes'].name,
+        passed: false,
       });
     }
   }

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -456,13 +456,12 @@ buildcop.containsBuildFailure = async (
   if (text.includes(`buildID: ${buildID}`) && text.includes('status: failed')) {
     return true;
   }
-  const comments = (
-    await context.github.issues.listComments({
-      owner,
-      repo,
-      issue_number: issue.number,
-    })
-  ).data;
+  const options = context.github.issues.listComments.endpoint.merge({
+    owner,
+    repo,
+    issue_number: issue.number,
+  });
+  const comments = await context.github.paginate(options);
   const comment = comments.find(
     comment =>
       comment.body.includes(`buildID: ${buildID}`) &&

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -66,20 +66,24 @@ describe('buildcop', () => {
             package:
               'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
             testCase: 'TestSample',
+            passed: false,
           },
         ],
         passes: [
           {
             package: 'github.com/GoogleCloudPlatform/golang-samples',
             testCase: 'TestBadFiles',
+            passed: true,
           },
           {
             package: 'github.com/GoogleCloudPlatform/golang-samples',
             testCase: 'TestLicense',
+            passed: true,
           },
           {
             package: 'github.com/GoogleCloudPlatform/golang-samples',
             testCase: 'TestRegionTags',
+            passed: true,
           },
         ],
       });
@@ -97,27 +101,32 @@ describe('buildcop', () => {
             package:
               'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
             testCase: 'TestBucketLock',
+            passed: false,
           },
           {
             package:
               'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
             testCase: 'TestUniformBucketLevelAccess',
+            passed: false,
           },
         ],
         passes: [
           {
             package: 'github.com/GoogleCloudPlatform/golang-samples',
             testCase: 'TestBadFiles',
+            passed: true,
           },
           {
             package:
               'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
             testCase: 'TestCreate',
+            passed: true,
           },
           {
             package:
               'github.com/GoogleCloudPlatform/golang-samples/storage/gcsupload',
             testCase: 'TestUpload',
+            passed: true,
           },
         ],
       });
@@ -135,11 +144,13 @@ describe('buildcop', () => {
           {
             package: 'github.com/GoogleCloudPlatform/golang-samples',
             testCase: 'TestBadFiles',
+            passed: true,
           },
           {
             package:
               'github.com/GoogleCloudPlatform/golang-samples/appengine/go11x/helloworld',
             testCase: 'TestIndexHandler',
+            passed: true,
           },
         ],
       });
@@ -204,7 +215,7 @@ describe('buildcop', () => {
           )
           .reply(200, [
             {
-              title: formatTestCase({}),
+              title: formatTestCase({ passed: false }),
               number: 16,
               body: 'Failure!',
               state: 'closed',
@@ -237,7 +248,7 @@ describe('buildcop', () => {
           )
           .reply(200, [
             {
-              title: formatTestCase({}),
+              title: formatTestCase({ passed: false }),
               number: 16,
               body: 'Failure!',
               state: 'open',
@@ -373,6 +384,7 @@ describe('buildcop', () => {
                 package:
                   'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
                 testCase: 'TestSample',
+                passed: false,
               }),
               number: 15,
               body: 'Failure!',
@@ -383,6 +395,7 @@ describe('buildcop', () => {
                 package:
                   'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
                 testCase: 'TestSample',
+                passed: false,
               }),
               number: 16,
               body: 'Failure!',
@@ -426,6 +439,7 @@ describe('buildcop', () => {
                 package:
                   'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
                 testCase: 'TestBucketLock',
+                passed: false,
               }),
               number: 16,
               body: `Failure!`,
@@ -437,6 +451,7 @@ describe('buildcop', () => {
                 package:
                   'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
                 testCase: 'TestUniformBucketLevelAccess',
+                passed: false,
               }),
               number: 17,
               body: `Failure!`,
@@ -505,6 +520,7 @@ describe('buildcop', () => {
                 package:
                   'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
                 testCase: 'TestSample',
+                passed: false,
               }),
               number: 16,
               body: 'Failure!',
@@ -551,6 +567,7 @@ describe('buildcop', () => {
               title: formatTestCase({
                 package: 'github.com/GoogleCloudPlatform/golang-samples',
                 testCase: 'TestBadFiles',
+                passed: false,
               }),
               number: 16,
               body: 'Failure!',
@@ -597,6 +614,7 @@ describe('buildcop', () => {
               title: formatTestCase({
                 package: 'appengine.standard.app_identity.asserting.main_test',
                 testCase: 'test_app',
+                passed: false,
               }),
               number: 16,
               body: 'Failure!',
@@ -643,6 +661,7 @@ describe('buildcop', () => {
               title: formatTestCase({
                 package: 'com.google.cloud.vision.it.ITSystemTest(sponge_log)',
                 testCase: 'detectLocalizedObjectsTest',
+                passed: false,
               }),
               number: 16,
               body: 'Failure!',
@@ -690,6 +709,7 @@ describe('buildcop', () => {
                 package:
                   'github.com/GoogleCloudPlatform/golang-samples/fake/test',
                 testCase: 'TestFake',
+                passed: false,
               }),
               number: 16,
               body: 'Failure!',
@@ -724,6 +744,7 @@ describe('buildcop', () => {
               title: formatTestCase({
                 package: 'github.com/GoogleCloudPlatform/golang-samples',
                 testCase: 'TestBadFiles',
+                passed: false,
               }),
               number: 16,
               body: 'Failure!',
@@ -775,6 +796,7 @@ describe('buildcop', () => {
                 package:
                   'github.com/GoogleCloudPlatform/golang-samples/appengine/go11x/helloworld',
                 testCase: 'TestIndexHandler',
+                passed: false,
               }),
               number: 16,
               body: `status: failed\nbuildID: 123`,
@@ -820,6 +842,7 @@ describe('buildcop', () => {
                 package:
                   'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
                 testCase: 'TestSample',
+                passed: false,
               }),
               number: 16,
               body: `Failure!`,
@@ -856,6 +879,7 @@ describe('buildcop', () => {
                 package:
                   'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
                 testCase: 'TestSample',
+                passed: false,
               }),
               number: 16,
               body: 'Failure!',
@@ -896,10 +920,12 @@ describe('buildcop', () => {
           package:
             'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
           testCase: 'TestSample',
+          passed: false,
         });
         const title2 = formatTestCase({
           package: 'appengine/go11x/helloworld',
           testCase: 'TestIndexHandler',
+          passed: false,
         });
 
         const requests = nock('https://api.github.com')
@@ -973,6 +999,7 @@ describe('buildcop', () => {
         package:
           'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
         testCase: 'TestSample',
+        passed: false,
       });
 
       const requests = nock('https://api.github.com')


### PR DESCRIPTION
I noticed https://github.com/GoogleCloudPlatform/python-docs-samples/issues/2999#issuecomment-591736913 looks a little weird saying it's flaky without giving the context that it passed in another build. It would be helpful to include that info.

Also, https://github.com/GoogleCloudPlatform/python-docs-samples/issues/2822#issuecomment-591742480 is an example of a duplicate failure comment when there are many comments on the issue. The default page size is 30 and we weren't handling pagination before this, so we didn't find the previous failure message then made a duplicate comment.

Updates #282.