### PR TITLE
chore(deps): only update google.golang.org/genproto once per week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,10 @@
     {
       "extends": "packages:linters",
       "groupName": "linters"
+    },
+    {
+      "packageNames": ["google.golang.org/genproto"],
+      "schedule": "after 9am on monday"
     }
   ],
   "ignoreDeps": ["typescript"]


### PR DESCRIPTION
See https://docs.renovatebot.com/configuration-options/#packagerules.