### PR TITLE
fix(Build Cop): shorten cloud.google.com/go tests

### DIFF
--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -510,6 +510,7 @@ buildcop.formatTestCase = (failure: TestCase): string => {
     /github\.com\/[^\/]+\/[^\/]+\/(.+)/,
     /com\.google\.cloud\.(.+)/,
     /(.+)\(sponge_log\)/,
+    /cloud\.google\.com\/go\/(.+)/,
   ];
   shorteners.forEach(s => {
     const shorten = failure.package?.match(s);

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -160,11 +160,11 @@ describe('buildcop', () => {
   describe('formatTestCase', () => {
     it('shortens cloud.google.com/go', () => {
       const got = formatTestCase({
-        package: "cloud.google.com/go/pubsub",
-        testCase: "TestPublish",
+        package: 'cloud.google.com/go/pubsub',
+        testCase: 'TestPublish',
         passed: true,
       });
-      expect(got).to.equal("pubsub: TestPublish failed")
+      expect(got).to.equal('pubsub: TestPublish failed');
     });
   });
 

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -157,6 +157,17 @@ describe('buildcop', () => {
     });
   });
 
+  describe('formatTestCase', () => {
+    it('shortens cloud.google.com/go', () => {
+      const got = formatTestCase({
+        package: "cloud.google.com/go/pubsub",
+        testCase: "TestPublish",
+        passed: true,
+      });
+      expect(got).to.equal("pubsub: TestPublish failed")
+    });
+  });
+
   describe('app', () => {
     it('skips when there is no XML and no testsFailed', async () => {
       const payload = formatPayload({


### PR DESCRIPTION
Example this will shorten (will deal with renaming/duplicates manually): https://github.com/googleapis/google-cloud-go/issues/1836