### PR TITLE
chore(Build Cop): rename build ID to commit

### DIFF
--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -1,6 +1,6 @@
 exports['buildcop app testsFailed opens an issue when testsFailed 1'] = {
   "title": "The build failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -10,7 +10,7 @@ exports['buildcop app testsFailed opens an issue when testsFailed 1'] = {
 
 exports['buildcop app testsFailed opens a new issue when testsFailed and there is a previous one closed 1'] = {
   "title": "The build failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -19,12 +19,12 @@ exports['buildcop app testsFailed opens a new issue when testsFailed and there i
 }
 
 exports['buildcop app testsFailed comments on an existing open issue when testsFailed 1'] = {
-  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
 exports['buildcop app xunitXML opens an issue [Go] 1'] = {
   "title": "spanner/spanner_snippets: TestSample failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -42,7 +42,7 @@ exports['buildcop app xunitXML closes a duplicate issue 2'] = {
 
 exports['buildcop app xunitXML opens an issue [Python] 1'] = {
   "title": "appengine.flexible.datastore.main_test: test_index failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -51,7 +51,7 @@ exports['buildcop app xunitXML opens an issue [Python] 1'] = {
 }
 
 exports['buildcop app xunitXML comments on existing issue 1'] = {
-  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
 exports['buildcop app xunitXML reopens issue for failing test 1'] = {
@@ -66,11 +66,11 @@ exports['buildcop app xunitXML reopens issue for failing test 1'] = {
 }
 
 exports['buildcop app xunitXML reopens issue for failing test 2'] = {
-  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
 exports['buildcop app xunitXML closes an issue for a passing test [Go] 1'] = {
-  "body": "Test passed in build 123 (http://example.com)! Closing this issue."
+  "body": "Test passed for commit 123 (http://example.com)! Closing this issue."
 }
 
 exports['buildcop app xunitXML closes an issue for a passing test [Go] 2'] = {
@@ -78,7 +78,7 @@ exports['buildcop app xunitXML closes an issue for a passing test [Go] 2'] = {
 }
 
 exports['buildcop app xunitXML closes an issue for a passing test [Python] 1'] = {
-  "body": "Test passed in build 123 (http://example.com)! Closing this issue."
+  "body": "Test passed for commit 123 (http://example.com)! Closing this issue."
 }
 
 exports['buildcop app xunitXML closes an issue for a passing test [Python] 2'] = {
@@ -87,7 +87,7 @@ exports['buildcop app xunitXML closes an issue for a passing test [Python] 2'] =
 
 exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] = {
   "title": "storage/buckets: TestBucketLock failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -97,7 +97,7 @@ exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] =
 
 exports['buildcop app xunitXML opens multiple issues for multiple failures 2'] = {
   "title": "storage/buckets: TestUniformBucketLevelAccess failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -107,7 +107,7 @@ exports['buildcop app xunitXML opens multiple issues for multiple failures 2'] =
 
 exports['buildcop app xunitXML opens an issue [Java] 1'] = {
   "title": "com.google.cloud.vision.it.ITSystemTest: detectSafeSearchGcsTest failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -116,7 +116,7 @@ exports['buildcop app xunitXML opens an issue [Java] 1'] = {
 }
 
 exports['buildcop app xunitXML closes an issue for a passing test [Java] 1'] = {
-  "body": "Test passed in build 123 (http://example.com)! Closing this issue."
+  "body": "Test passed for commit 123 (http://example.com)! Closing this issue."
 }
 
 exports['buildcop app xunitXML closes an issue for a passing test [Java] 2'] = {
@@ -134,11 +134,11 @@ exports['buildcop app reopens the original flaky issue when there is a duplicate
 }
 
 exports['buildcop app reopens the original flaky issue when there is a duplicate 2'] = {
-  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
 exports['buildcop app xunitXML does not comment about failure on existing flaky issue 1'] = {
-  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
 exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (comment) 1'] = {
@@ -153,7 +153,7 @@ exports['buildcop app xunitXML keeps an issue open for a passing test that faile
 }
 
 exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (comment) 2'] = {
-  "body": "Looks like this issue is flaky. :worried:\n\nI'm going to leave this open and stop commenting.\n\nA human should fix and close this.\n\n---\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: passed"
+  "body": "Looks like this issue is flaky. :worried:\n\nI'm going to leave this open and stop commenting.\n\nA human should fix and close this.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: passed"
 }
 
 exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (issue body) 1'] = {
@@ -168,9 +168,9 @@ exports['buildcop app xunitXML keeps an issue open for a passing test that faile
 }
 
 exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (issue body) 2'] = {
-  "body": "Looks like this issue is flaky. :worried:\n\nI'm going to leave this open and stop commenting.\n\nA human should fix and close this.\n\n---\n\nbuildID: 123\nbuildURL: http://example.com\nstatus: passed"
+  "body": "Looks like this issue is flaky. :worried:\n\nI'm going to leave this open and stop commenting.\n\nA human should fix and close this.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: passed"
 }
 
 exports['buildcop app xunitXML does not comment about failure on existing issue labeled quiet 1'] = {
-  "body": "buildID: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed"
 }

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -17,9 +17,7 @@
  *
  * The input payload should include:
  *  - xunitXML: the base64 encoded xUnit XML log.
- *  - buildID: a unique build ID for this build. If there are multiple jobs
- *    for the same build (e.g. for different language versions), they should all
- *    use the same buildID.
+ *  - commit: the commit hash the build was for.
  *  - buildURL: URL to link to for a build.
  *  - repo: the repo being tested (e.g. GoogleCloudPlatform/golang-samples).
  */
@@ -81,7 +79,8 @@ export interface BuildCopPayload {
   repo: string;
   organization: { login: string }; // Filled in by gcf-utils.
   repository: { name: string }; // Filled in by gcf-utils.
-  buildID: string;
+  buildID?: string; // TODO: remove a few hours after commit is added. See https://github.com/googleapis/repo-automation-bots/issues/393.
+  commit?: string; // TODO: this will not be optional after buildID is removed.
   buildURL: string;
 
   xunitXML?: string; // Base64 encoded to avoid JSON escaping issues. Fill in to get separate issues for separate tests.
@@ -99,7 +98,8 @@ export function buildcop(app: Application) {
   app.on('pubsub.message', async (context: PubSubContext) => {
     const owner = context.payload.organization?.login;
     const repo = context.payload.repository?.name;
-    const buildID = context.payload.buildID || '[TODO: set buildID]';
+    const commit =
+      context.payload.commit || context.payload.buildID || '[TODO: set commit]';
     const buildURL = context.payload.buildURL || '[TODO: set buildURL]';
 
     let results: TestResults;
@@ -145,7 +145,7 @@ export function buildcop(app: Application) {
         context,
         owner,
         repo,
-        buildID,
+        commit,
         buildURL
       );
       // Close issues for passing tests (unless they're flaky).
@@ -155,7 +155,7 @@ export function buildcop(app: Application) {
         context,
         owner,
         repo,
-        buildID,
+        commit,
         buildURL
       );
     } catch (err) {
@@ -228,7 +228,7 @@ buildcop.openIssues = async (
   context: PubSubContext,
   owner: string,
   repo: string,
-  buildID: string,
+  commit: string,
   buildURL: string
 ) => {
   for (const failure of failures) {
@@ -263,7 +263,7 @@ buildcop.openIssues = async (
           context,
           owner,
           repo,
-          buildID,
+          commit,
           buildURL,
           failure
         );
@@ -285,7 +285,7 @@ buildcop.openIssues = async (
             context,
             owner,
             repo,
-            buildID
+            commit
           )
         ) {
           continue;
@@ -295,7 +295,7 @@ buildcop.openIssues = async (
           owner,
           repo,
           issue_number: existingIssue.number,
-          body: buildcop.formatBody(failure, buildID, buildURL),
+          body: buildcop.formatBody(failure, commit, buildURL),
         });
       }
     } else {
@@ -307,7 +307,7 @@ buildcop.openIssues = async (
           body:
             NEW_ISSUE_MESSAGE +
             '\n\n' +
-            buildcop.formatBody(failure, buildID, buildURL),
+            buildcop.formatBody(failure, commit, buildURL),
           labels: LABELS_FOR_NEW_ISSUE,
         })
       ).data;
@@ -324,7 +324,7 @@ buildcop.closeIssues = async (
   context: PubSubContext,
   owner: string,
   repo: string,
-  buildID: string,
+  commit: string,
   buildURL: string
 ) => {
   for (const issue of issues) {
@@ -359,14 +359,14 @@ buildcop.closeIssues = async (
     // If the issue has a failure in the same build, don't close it.
     // If it passed in one build and failed in another, it's flaky.
     if (
-      await buildcop.containsBuildFailure(issue, context, owner, repo, buildID)
+      await buildcop.containsBuildFailure(issue, context, owner, repo, commit)
     ) {
       await buildcop.markIssueFlaky(
         issue,
         context,
         owner,
         repo,
-        buildID,
+        commit,
         buildURL,
         pass
       );
@@ -383,7 +383,7 @@ buildcop.closeIssues = async (
       owner,
       repo,
       issue_number: issue.number,
-      body: `Test passed in build ${buildID} (${buildURL})! Closing this issue.`,
+      body: `Test passed for commit ${commit} (${buildURL})! Closing this issue.`,
     });
     await context.github.issues.update({
       owner,
@@ -431,7 +431,7 @@ buildcop.markIssueFlaky = async (
   context: PubSubContext,
   owner: string,
   repo: string,
-  buildID: string,
+  commit: string,
   buildURL: string,
   testCase: TestCase
 ) => {
@@ -455,7 +455,7 @@ buildcop.markIssueFlaky = async (
     body = FLAKY_AGAIN_MESSAGE;
   }
   if (testCase) {
-    body = body + '\n\n' + buildcop.formatBody(testCase, buildID, buildURL);
+    body = body + '\n\n' + buildcop.formatBody(testCase, commit, buildURL);
   }
   await context.github.issues.createComment({
     owner,
@@ -467,10 +467,10 @@ buildcop.markIssueFlaky = async (
 
 buildcop.formatBody = (
   testCase: TestCase,
-  buildID: string,
+  commit: string,
   buildURL: string
 ): string => {
-  return `buildID: ${buildID}
+  return `commit: ${commit}
 buildURL: ${buildURL}
 status: ${testCase.passed ? 'passed' : 'failed'}`;
 };
@@ -480,10 +480,10 @@ buildcop.containsBuildFailure = async (
   context: PubSubContext,
   owner: string,
   repo: string,
-  buildID: string
+  commit: string
 ): Promise<boolean> => {
   const text = issue.body;
-  if (text.includes(`buildID: ${buildID}`) && text.includes('status: failed')) {
+  if (text.includes(`commit: ${commit}`) && text.includes('status: failed')) {
     return true;
   }
   const options = context.github.issues.listComments.endpoint.merge({
@@ -494,7 +494,7 @@ buildcop.containsBuildFailure = async (
   const comments = await context.github.paginate(options);
   const comment = comments.find(
     comment =>
-      comment.body.includes(`buildID: ${buildID}`) &&
+      comment.body.includes(`commit: ${commit}`) &&
       comment.body.includes('status: failed')
   );
   return comment !== undefined;

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -174,7 +174,7 @@ describe('buildcop', () => {
         repo: 'tbpg/golang-samples',
         organization: { login: 'tbpg' },
         repository: { name: 'golang-samples' },
-        buildID: '123',
+        commit: '123',
         buildURL: 'http://example.com',
       });
 
@@ -189,7 +189,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           testsFailed: true,
         });
@@ -215,7 +215,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           testsFailed: true,
         });
@@ -248,7 +248,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           testsFailed: true,
         });
@@ -289,7 +289,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -319,7 +319,7 @@ describe('buildcop', () => {
           repo: 'tbpg/python-docs-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'python-docs-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -349,7 +349,7 @@ describe('buildcop', () => {
           repo: 'tbpg/java-vision',
           organization: { login: 'tbpg' },
           repository: { name: 'java-vision' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -379,7 +379,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -435,7 +435,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -491,7 +491,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -547,7 +547,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -572,7 +572,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -620,7 +620,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -667,7 +667,7 @@ describe('buildcop', () => {
           repo: 'tbpg/python-docs-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'python-docs-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -714,7 +714,7 @@ describe('buildcop', () => {
           repo: 'tbpg/java-vision',
           organization: { login: 'tbpg' },
           repository: { name: 'java-vision' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -761,7 +761,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -797,7 +797,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -820,7 +820,7 @@ describe('buildcop', () => {
           .get('/repos/tbpg/golang-samples/issues/16/comments')
           .reply(200, [
             {
-              body: `status: failed\nbuildID: 123`,
+              body: `status: failed\ncommit: 123`,
             },
           ])
           .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
@@ -848,7 +848,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -866,7 +866,7 @@ describe('buildcop', () => {
                 passed: false,
               }),
               number: 16,
-              body: `status: failed\nbuildID: 123`,
+              body: `status: failed\ncommit: 123`,
             },
           ])
           .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
@@ -894,7 +894,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -931,7 +931,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -978,7 +978,7 @@ describe('buildcop', () => {
           repo: 'tbpg/golang-samples',
           organization: { login: 'tbpg' },
           repository: { name: 'golang-samples' },
-          buildID: '123',
+          commit: '123',
           buildURL: 'http://example.com',
           xunitXML: input,
         });
@@ -1057,7 +1057,7 @@ describe('buildcop', () => {
         repo: 'tbpg/golang-samples',
         organization: { login: 'tbpg' },
         repository: { name: 'golang-samples' },
-        buildID: '123',
+        commit: '123',
         buildURL: 'http://example.com',
         xunitXML: input,
       });


### PR DESCRIPTION
Once this is fully deployed and we're sure no more builds will send the
buildID field, we can delete it.

Updates #393.