### PR TITLE
feat(Build Cop): check for KOKORO_GITHUB_PULL_REQUEST_URL

### DIFF
--- a/packages/buildcop/README.md
+++ b/packages/buildcop/README.md
@@ -57,9 +57,9 @@ Issues or feature requests? Please
      File an issue and/or send a PR to update the `Makefile` if you need a
      different platform.
    * Flags:
-      * **`-repo`**: The repo is automatically detected from the
-        `KOKORO_GITHUB_COMMIT_URL` environment variable. If that variable is
-        not available (e.g. for pull requests), you must set the `-repo` flag.
+      * **`-repo`**: The repo is automatically detected from either
+        `KOKORO_GITHUB_COMMIT_URL` or `KOKORO_GITHUB_PULL_REQUEST_URL`. If those
+        variables are not available, you must set the `-repo` flag.
         If your repo is
         `github.com/GoogleCloudPlatform/golang-samples`, set `-repo` to
         `GoogleCloudPlatform/golang-samples`.

--- a/packages/buildcop/buildcop.go
+++ b/packages/buildcop/buildcop.go
@@ -140,12 +140,22 @@ See https://github.com/apps/build-cop-bot/.`)
 
 // detectRepo tries to detect the repo from the environment.
 func detectRepo() string {
-	if github := os.Getenv("KOKORO_GITHUB_COMMIT_URL"); github != "" {
-		parts := strings.Split(github, "/")
-		repo := fmt.Sprintf("%s/%s", parts[3], parts[4])
-		return repo
+	githubURL := os.Getenv("KOKORO_GITHUB_COMMIT_URL")
+	if githubURL == "" {
+		githubURL = os.Getenv("KOKORO_GITHUB_PULL_REQUEST_URL")
+		if githubURL != "" {
+			log.Printf("Warning! Running on a PR. Double check how you call buildocp before merging.")
+		}
 	}
-	return ""
+	if githubURL == "" {
+		return ""
+	}
+	parts := strings.Split(githubURL, "/")
+	if len(parts) < 5 {
+		return ""
+	}
+	repo := fmt.Sprintf("%s/%s", parts[3], parts[4])
+	return repo
 }
 
 // detectInstallationID tries to detect the GitHub installation ID based on the

--- a/packages/buildcop/buildcop_test.go
+++ b/packages/buildcop/buildcop_test.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"log"
 	"os"
 	"testing"
 
@@ -23,6 +25,8 @@ import (
 )
 
 func TestDetectRepo(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stderr)
 	tests := []struct {
 		envVar   string
 		envValue string
@@ -32,6 +36,16 @@ func TestDetectRepo(t *testing.T) {
 			envVar:   "KOKORO_GITHUB_COMMIT_URL",
 			envValue: "https://github.com/GoogleCloudPlatform/golang-samples/commit/1234",
 			want:     "GoogleCloudPlatform/golang-samples",
+		},
+		{
+			envVar:   "KOKORO_GITHUB_PULL_REQUEST_URL",
+			envValue: "https://github.com/GoogleCloudPlatform/golang-samples/pull/1312",
+			want:     "GoogleCloudPlatform/golang-samples",
+		},
+		{
+			envVar:   "KOKORO_GITHUB_COMMIT_URL",
+			envValue: "https://github.com/GoogleCloudPlatform",
+			want:     "",
 		},
 		{
 			envVar:   "foo",


### PR DESCRIPTION
When you're adding the bot to a repo, you usually want to test that it works on a PR. But, it's easy to forget until you get an error that the repo could not be detected. So, you add the `-repo` flag and try again, and will probably leave it forever, because why risk another build just to remove a flag that definitely works.

This PR adds repo detection for PRs and simplifies the process.

Updates #355.