### PR TITLE
fix: do not require node8 status checks

### DIFF
--- a/packages/sync-repo-settings/src/required-checks.json
+++ b/packages/sync-repo-settings/src/required-checks.json
@@ -95,7 +95,6 @@
       "ci/kokoro: System test",
       "docs",
       "lint",
-      "test (8)",
       "test (10)",
       "test (12)",
       "test (13)",
@@ -103,7 +102,6 @@
       "windows"
     ],
     "ignoredRepos": [
-      "GoogleCloudPlatform/getting-started-nodejs",
       "GoogleCloudPlatform/nodejs-docs-samples",
       "GoogleCloudPlatform/nodejs-getting-started",
       "googleapis/cloud-profiler-nodejs",

--- a/packages/sync-repo-settings/test/test.ts
+++ b/packages/sync-repo-settings/test/test.ts
@@ -55,7 +55,6 @@ function nockUpdateBranchProtection() {
           'ci/kokoro: System test',
           'docs',
           'lint',
-          'test (8)',
           'test (10)',
           'test (12)',
           'test (13)',


### PR DESCRIPTION
I'm not sure how this isn't a problem yet 🤣 