### PR TITLE
fix: do not install chromium in bots

### DIFF
--- a/scripts/serverless-scheduler-proxy-deploy.sh
+++ b/scripts/serverless-scheduler-proxy-deploy.sh
@@ -31,7 +31,7 @@ echo "Deploying proxy to project $PROJECT_ID, with bucket: $BUCKET, key location
 
 gcloud beta run deploy \
             --image "gcr.io/$PROJECT_ID/serverless-scheduler-proxy" \
-            --set-env-vars "PROJECT_ID=$PROJECT_ID,BUCKET_NAME=$BUCKET,KEY_LOCATION=$KEY_LOCATION,KEY_RING=$KEY_RING" \
+            --set-env-vars "PROJECT_ID=$PROJECT_ID,BUCKET_NAME=$BUCKET,KEY_LOCATION=$KEY_LOCATION,KEY_RING=$KEY_RING,PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1" \
             --platform managed \
             --region $REGION \
             --quiet \


### PR DESCRIPTION
this makes `npm i` inside a cloud function run out of memory.