### PR TITLE
Revert "fix(merge-on-green): address bugs related to status check name detection"

### DIFF
--- a/packages/merge-on-green/src/merge-logic.ts
+++ b/packages/merge-on-green/src/merge-logic.ts
@@ -240,19 +240,9 @@ mergeOnGreen.iterateGetStatusi = async function iterateGetStatusi(
 ): Promise<CheckStatus[]> {
   let results: CheckStatus[] = [];
   for (let i = 0; i < 10; i++) {
-    try {
-      const temp = await mergeOnGreen.getStatusi(
-        owner,
-        repo,
-        github,
-        headSha,
-        i
-      );
-      if (temp.length !== 0) {
-        results = results.concat(temp);
-      }
-    } catch (err) {
-      //do nothing with the error, just pagination errors
+    const temp = await mergeOnGreen.getStatusi(owner, repo, github, headSha, i);
+    if (temp.length !== 0) {
+      results = results.concat(temp);
     }
   }
   return results;
@@ -307,19 +297,15 @@ mergeOnGreen.iterateGetCheckRuns = async function iterateGetCheckRuns(
 ): Promise<CheckRun[]> {
   let results: CheckRun[] = [];
   for (let i = 0; i < 10; i++) {
-    try {
-      const temp = await mergeOnGreen.getCheckRuns(
-        owner,
-        repo,
-        github,
-        headSha,
-        i
-      );
-      if (temp !== undefined) {
-        results = results.concat(temp);
-      }
-    } catch (err) {
-      //do nothing with the error, just pagination errors
+    const temp = await mergeOnGreen.getCheckRuns(
+      owner,
+      repo,
+      github,
+      headSha,
+      i
+    );
+    if (temp !== undefined) {
+      results = results.concat(temp);
     }
   }
   return results;
@@ -333,12 +319,10 @@ mergeOnGreen.iterateGetCheckRuns = async function iterateGetCheckRuns(
  */
 mergeOnGreen.checkForRequiredSC = function checkForRequiredSC(
   checkRuns: CheckRun[],
-  regexCheck: RegExp
+  check: string
 ): boolean {
   if (checkRuns.length !== 0) {
-    const checkRunCompleted = checkRuns.find(element =>
-      regexCheck.test(element.name)
-    );
+    const checkRunCompleted = checkRuns.find(element => element.name === check);
     if (
       checkRunCompleted !== undefined &&
       checkRunCompleted.conclusion === 'success'
@@ -386,10 +370,9 @@ mergeOnGreen.statusesForRef = async function statusesForRef(
       console.log(
         `Looking for required checks in status checks for ${owner}/${repo}/${pr}.`
       );
-      const regexCheck = new RegExp(`^${check}`);
       //since find function finds the value of the first element in the array, that will take care of the chronological order of the tests
-      const checkCompleted = checkStatus.find((element: CheckStatus) =>
-        regexCheck.test(element.context)
+      const checkCompleted = checkStatus.find(
+        (element: CheckStatus) => element.context === check
       );
       if (checkCompleted === undefined) {
         console.log(
@@ -404,7 +387,7 @@ mergeOnGreen.statusesForRef = async function statusesForRef(
             headSha
           );
         }
-        mergeable = mergeOnGreen.checkForRequiredSC(checkRuns, regexCheck);
+        mergeable = mergeOnGreen.checkForRequiredSC(checkRuns, check);
         if (!mergeable) {
           console.log(
             'We could not find your required checks in check runs. You have no statuses or checks that match your required checks.'

--- a/packages/merge-on-green/src/merge-on-green.ts
+++ b/packages/merge-on-green/src/merge-on-green.ts
@@ -19,8 +19,8 @@ import { mergeOnGreen } from './merge-logic';
 const TABLE = 'mog-prs';
 const datastore = new Datastore();
 const MAX_TEST_TIME = 1000 * 60 * 60 * 6; // 6 hr.
-const COMMENT_INTERVAL_LOW = 1000 * 60 * 60 * 3; // 3 hours
-const COMMENT_INTERVAL_HIGH = 1000 * 60 * 60 * 3.067; // 3 hours and 4 minutes
+const COMMENT_INTERVAL_LOW = 1000 * 60 * 60 * 2.941; // 2 hours and 57.5 minutes
+const COMMENT_INTERVAL_HIGH = 1000 * 60 * 60 * 3.058; // 3 hours and 3.5 minutes
 const MERGE_ON_GREEN_LABEL = 'automerge';
 const WORKER_SIZE = 4;
 

--- a/packages/merge-on-green/test/merge-on-green.ts
+++ b/packages/merge-on-green/test/merge-on-green.ts
@@ -148,7 +148,7 @@ function getPR(mergeable: boolean, mergeableState: string, state: string) {
     });
 }
 
-describe('merge-on-green', () => {
+describe('merge-on-green-', () => {
   let probot: Probot;
 
   beforeEach(() => {
@@ -459,56 +459,6 @@ describe('merge-on-green', () => {
       scopes.forEach(s => s.done());
     });
 
-    it('rejects status checks that do not match the required check', async () => {
-      const scopes = [
-        getPR(true, 'clean', 'open'),
-        getBranchProtection(["this is what we're looking for"]),
-        getReviewsCompleted([
-          { user: { login: 'octocat' }, state: 'APPROVED' },
-        ]),
-        getLatestCommit([{ sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e' }]),
-        getMogLabel([{ name: 'automerge' }]),
-        getStatusi('6dcb09b5b57875f334f61aebed695e2e4193db5e', [
-          { state: 'success', context: "this is what we're looking fo" },
-        ]),
-      ];
-
-      await probot.receive({
-        name: 'schedule.repository',
-        payload: { org: 'testOwner' },
-        id: 'abc123',
-      });
-
-      scopes.forEach(s => s.done());
-    });
-
-    it('accepts status checks that match the beginning of the required status check', async () => {
-      const scopes = [
-        getPR(true, 'clean', 'open'),
-        getBranchProtection(["this is what we're looking for"]),
-        getReviewsCompleted([
-          { user: { login: 'octocat' }, state: 'APPROVED' },
-        ]),
-        getLatestCommit([{ sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e' }]),
-        getMogLabel([{ name: 'automerge' }]),
-        getStatusi('6dcb09b5b57875f334f61aebed695e2e4193db5e', [
-          {
-            state: 'success',
-            context: "this is what we're looking for/subtest",
-          },
-        ]),
-        merge(),
-      ];
-
-      await probot.receive({
-        name: 'schedule.repository',
-        payload: { org: 'testOwner' },
-        id: 'abc123',
-      });
-
-      scopes.forEach(s => s.done());
-    });
-
     it('posts a comment on the PR if the flag is set to stop and the merge has failed', async () => {
       handler.getDatastore = async () => {
         const pr = [
@@ -554,7 +504,7 @@ describe('merge-on-green', () => {
               repo: 'testRepo',
               number: 1,
               owner: 'testOwner',
-              created: Date.now() - 10920000,
+              created: Date.now() - 10800000,
             },
           ],
         ];


### PR DESCRIPTION
This seems to be breaking merge on green, with:

```
Error in getting statuses: TypeError: Cannot read property 'context' of undefined
```

Reverts googleapis/repo-automation-bots#440