### PR TITLE
chore(Build Cop): refactor tests to reduce duplication

### DIFF
--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -44,8 +44,7 @@ function buildPayload(inputFixture: string, repo: string) {
 
 // Ignore any warning to make it easier to test. No need to include all of the
 // fields from real issues.
-// tslint:disable-next-line: no-any
-function nockIssues(repo: string, issues: any[] = []) {
+function nockIssues(repo: string, issues: {}[] = []) {
   return nock('https://api.github.com')
     .get(
       `/repos/GoogleCloudPlatform/${repo}/issues?per_page=100&labels=buildcop%3A%20issue&state=all`

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -42,8 +42,6 @@ function buildPayload(inputFixture: string, repo: string) {
   };
 }
 
-// Ignore any warning to make it easier to test. No need to include all of the
-// fields from real issues.
 function nockIssues(repo: string, issues: Array<{}> = []) {
   return nock('https://api.github.com')
     .get(

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -40,8 +40,8 @@ function buildPayload(inputFixture: string, repo: string) {
     'utf8'
   );
   const payload = formatPayload({
-    repo: `tbpg/${repo}`,
-    organization: { login: 'tbpg' },
+    repo: `GoogleCloudPlatform/${repo}`,
+    organization: { login: 'GoogleCloudPlatform' },
     repository: { name: repo },
     commit: '123',
     buildURL: 'http://example.com',
@@ -57,14 +57,14 @@ function buildPayload(inputFixture: string, repo: string) {
 function nockIssues(repo: string, issues: any[] = []) {
   return nock('https://api.github.com')
     .get(
-      `/repos/tbpg/${repo}/issues?per_page=100&labels=buildcop%3A%20issue&state=all`
+      `/repos/GoogleCloudPlatform/${repo}/issues?per_page=100&labels=buildcop%3A%20issue&state=all`
     )
     .reply(200, issues);
 }
 
 function nockNewIssue(repo: string) {
   return nock('https://api.github.com')
-    .post(`/repos/tbpg/${repo}/issues`, body => {
+    .post(`/repos/GoogleCloudPlatform/${repo}/issues`, body => {
       snapshot(body);
       return true;
     })
@@ -73,22 +73,25 @@ function nockNewIssue(repo: string) {
 
 function nockGetIssueComments(repo: string, issueNumber: number) {
   return nock('https://api.github.com')
-    .get(`/repos/tbpg/${repo}/issues/${issueNumber}/comments`)
+    .get(`/repos/GoogleCloudPlatform/${repo}/issues/${issueNumber}/comments`)
     .reply(200, []);
 }
 
 function nockIssueComment(repo: string, issueNumber: number) {
   return nock('https://api.github.com')
-    .post(`/repos/tbpg/${repo}/issues/${issueNumber}/comments`, body => {
-      snapshot(body);
-      return true;
-    })
+    .post(
+      `/repos/GoogleCloudPlatform/${repo}/issues/${issueNumber}/comments`,
+      body => {
+        snapshot(body);
+        return true;
+      }
+    )
     .reply(200);
 }
 
 function nockIssuePatch(repo: string, issueNumber: number) {
   return nock('https://api.github.com')
-    .patch(`/repos/tbpg/${repo}/issues/${issueNumber}`, body => {
+    .patch(`/repos/GoogleCloudPlatform/${repo}/issues/${issueNumber}`, body => {
       snapshot(body);
       return true;
     })
@@ -254,8 +257,8 @@ describe('buildcop', () => {
   describe('app', () => {
     it('skips when there is no XML and no testsFailed', async () => {
       const payload = formatPayload({
-        repo: 'tbpg/golang-samples',
-        organization: { login: 'tbpg' },
+        repo: 'GoogleCloudPlatform/golang-samples',
+        organization: { login: 'GoogleCloudPlatform' },
         repository: { name: 'golang-samples' },
         commit: '123',
         buildURL: 'http://example.com',
@@ -269,8 +272,8 @@ describe('buildcop', () => {
     describe('testsFailed', () => {
       it('opens an issue when testsFailed', async () => {
         const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
+          repo: 'GoogleCloudPlatform/golang-samples',
+          organization: { login: 'GoogleCloudPlatform' },
           repository: { name: 'golang-samples' },
           commit: '123',
           buildURL: 'http://example.com',
@@ -289,8 +292,8 @@ describe('buildcop', () => {
 
       it('opens a new issue when testsFailed and there is a previous one closed', async () => {
         const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
+          repo: 'GoogleCloudPlatform/golang-samples',
+          organization: { login: 'GoogleCloudPlatform' },
           repository: { name: 'golang-samples' },
           commit: '123',
           buildURL: 'http://example.com',
@@ -316,8 +319,8 @@ describe('buildcop', () => {
 
       it('comments on an existing open issue when testsFailed', async () => {
         const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
+          repo: 'GoogleCloudPlatform/golang-samples',
+          organization: { login: 'GoogleCloudPlatform' },
           repository: { name: 'golang-samples' },
           commit: '123',
           buildURL: 'http://example.com',
@@ -657,7 +660,7 @@ describe('buildcop', () => {
             },
           ]),
           nock('https://api.github.com')
-            .get('/repos/tbpg/golang-samples/issues/16/comments')
+            .get('/repos/GoogleCloudPlatform/golang-samples/issues/16/comments')
             .reply(200, [
               {
                 body: `status: failed\ncommit: 123`,

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -44,7 +44,7 @@ function buildPayload(inputFixture: string, repo: string) {
 
 // Ignore any warning to make it easier to test. No need to include all of the
 // fields from real issues.
-function nockIssues(repo: string, issues: {}[] = []) {
+function nockIssues(repo: string, issues: Array<{}> = []) {
   return nock('https://api.github.com')
     .get(
       `/repos/GoogleCloudPlatform/${repo}/issues?per_page=100&labels=buildcop%3A%20issue&state=all`

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -21,6 +21,7 @@ import snapshot from 'snap-shot-it';
 import nock from 'nock';
 import * as fs from 'fs';
 import { expect } from 'chai';
+import Octokit from '@octokit/rest';
 
 nock.disableNetConnect();
 
@@ -31,6 +32,67 @@ function formatPayload(payload: BuildCopPayload) {
     payload.xunitXML = Buffer.from(payload.xunitXML).toString('base64');
   }
   return payload;
+}
+
+function buildPayload(inputFixture: string, repo: string) {
+  const input = fs.readFileSync(
+    resolve(fixturesPath, 'testdata', inputFixture),
+    'utf8'
+  );
+  const payload = formatPayload({
+    repo: `tbpg/${repo}`,
+    organization: { login: 'tbpg' },
+    repository: { name: repo },
+    commit: '123',
+    buildURL: 'http://example.com',
+    xunitXML: input,
+  });
+
+  return payload;
+}
+
+// Ignore any warning to make it easier to test. No need to include all of the
+// fields from real issues.
+// tslint:disable-next-line: no-any
+function nockIssues(repo: string, issues: any[] = []) {
+  return nock('https://api.github.com')
+    .get(
+      `/repos/tbpg/${repo}/issues?per_page=100&labels=buildcop%3A%20issue&state=all`
+    )
+    .reply(200, issues);
+}
+
+function nockNewIssue(repo: string) {
+  return nock('https://api.github.com')
+    .post(`/repos/tbpg/${repo}/issues`, body => {
+      snapshot(body);
+      return true;
+    })
+    .reply(200);
+}
+
+function nockGetIssueComments(repo: string, issueNumber: number) {
+  return nock('https://api.github.com')
+    .get(`/repos/tbpg/${repo}/issues/${issueNumber}/comments`)
+    .reply(200, []);
+}
+
+function nockIssueComment(repo: string, issueNumber: number) {
+  return nock('https://api.github.com')
+    .post(`/repos/tbpg/${repo}/issues/${issueNumber}/comments`, body => {
+      snapshot(body);
+      return true;
+    })
+    .reply(200);
+}
+
+function nockIssuePatch(repo: string, issueNumber: number) {
+  return nock('https://api.github.com')
+    .patch(`/repos/tbpg/${repo}/issues/${issueNumber}`, body => {
+      snapshot(body);
+      return true;
+    })
+    .reply(200);
 }
 
 describe('buildcop', () => {
@@ -215,20 +277,14 @@ describe('buildcop', () => {
           testsFailed: true,
         });
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [])
-          .post('/repos/tbpg/golang-samples/issues', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+        const scopes = [
+          nockIssues('golang-samples'),
+          nockNewIssue('golang-samples'),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('opens a new issue when testsFailed and there is a previous one closed', async () => {
@@ -241,27 +297,21 @@ describe('buildcop', () => {
           testsFailed: true,
         });
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title: formatTestCase({ passed: false }),
               number: 16,
               body: 'Failure!',
               state: 'closed',
             },
-          ])
-          .post('/repos/tbpg/golang-samples/issues', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockNewIssue('golang-samples'),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('comments on an existing open issue when testsFailed', async () => {
@@ -274,142 +324,70 @@ describe('buildcop', () => {
           testsFailed: true,
         });
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title: formatTestCase({ passed: false }),
               number: 16,
               body: 'Failure!',
               state: 'open',
             },
-          ])
-          .get('/repos/tbpg/golang-samples/issues/16/comments')
-          .reply(200, [])
-          .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockGetIssueComments('golang-samples', 16),
+          nockIssueComment('golang-samples', 16),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
     });
 
     describe('xunitXML', () => {
       it('opens an issue [Go]', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'one_failed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('one_failed.xml', 'golang-samples');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [])
-          .post('/repos/tbpg/golang-samples/issues', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+        const scopes = [
+          nockIssues('golang-samples'),
+          nockNewIssue('golang-samples'),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('opens an issue [Python]', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'python_one_failed.xml'),
-          'utf8'
+        const payload = buildPayload(
+          'python_one_failed.xml',
+          'python-docs-samples'
         );
-        const payload = formatPayload({
-          repo: 'tbpg/python-docs-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'python-docs-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/python-docs-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [])
-          .post('/repos/tbpg/python-docs-samples/issues', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+        const scopes = [
+          nockIssues('python-docs-samples'),
+          nockNewIssue('python-docs-samples'),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('opens an issue [Java]', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'java_one_failed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/java-vision',
-          organization: { login: 'tbpg' },
-          repository: { name: 'java-vision' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('java_one_failed.xml', 'java-vision');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/java-vision/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [])
-          .post('/repos/tbpg/java-vision/issues', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+        const scopes = [nockIssues('java-vision'), nockNewIssue('java-vision')];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('comments on existing issue', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'one_failed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('one_failed.xml', 'golang-samples');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             // Duplicate issue that's closed. The open one should be updated.
             {
               title: formatTestCase({
@@ -433,39 +411,24 @@ describe('buildcop', () => {
               body: 'Failure!',
               state: 'open',
             },
-          ])
-          .get('/repos/tbpg/golang-samples/issues/16/comments')
-          .reply(200, [])
-          .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockGetIssueComments('golang-samples', 16),
+          nockIssueComment('golang-samples', 16),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('does not comment about failure on existing flaky issue', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'many_failed_same_pkg.xml'),
-          'utf8'
+        const payload = buildPayload(
+          'many_failed_same_pkg.xml',
+          'golang-samples'
         );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title: formatTestCase({
                 package:
@@ -489,39 +452,24 @@ describe('buildcop', () => {
               body: `Failure!`,
               state: 'open',
             },
-          ])
-          .get('/repos/tbpg/golang-samples/issues/17/comments')
-          .reply(200, [])
-          .post('/repos/tbpg/golang-samples/issues/17/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockGetIssueComments('golang-samples', 17),
+          nockIssueComment('golang-samples', 17),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('does not comment about failure on existing issue labeled quiet', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'many_failed_same_pkg.xml'),
-          'utf8'
+        const payload = buildPayload(
+          'many_failed_same_pkg.xml',
+          'golang-samples'
         );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title: formatTestCase({
                 package:
@@ -545,64 +493,31 @@ describe('buildcop', () => {
               body: `Failure!`,
               state: 'open',
             },
-          ])
-          .get('/repos/tbpg/golang-samples/issues/17/comments')
-          .reply(200, [])
-          .post('/repos/tbpg/golang-samples/issues/17/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockGetIssueComments('golang-samples', 17),
+          nockIssueComment('golang-samples', 17),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('handles a testsuite with no test cases', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'no_tests.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('no_tests.xml', 'golang-samples');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, []);
+        const scopes = [nockIssues('golang-samples')];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('reopens issue for failing test', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'one_failed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('one_failed.xml', 'golang-samples');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title: formatTestCase({
                 package:
@@ -615,42 +530,21 @@ describe('buildcop', () => {
               labels: [{ name: 'buildcop: flaky' }, { name: 'api: spanner' }],
               state: 'closed',
             },
-          ])
-          .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200)
-          .patch('/repos/tbpg/golang-samples/issues/16', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockIssueComment('golang-samples', 16),
+          nockIssuePatch('golang-samples', 16),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('closes an issue for a passing test [Go]', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'passed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('passed.xml', 'golang-samples');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title: formatTestCase({
                 package: 'github.com/GoogleCloudPlatform/golang-samples',
@@ -660,44 +554,25 @@ describe('buildcop', () => {
               number: 16,
               body: 'Failure!',
             },
-          ])
-          .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200)
-          .get('/repos/tbpg/golang-samples/issues/16/comments')
-          .reply(200, [])
-          .patch('/repos/tbpg/golang-samples/issues/16', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockIssueComment('golang-samples', 16),
+          nockGetIssueComments('golang-samples', 16),
+          nockIssuePatch('golang-samples', 16),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('closes an issue for a passing test [Python]', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'python_one_passed.xml'),
-          'utf8'
+        const payload = buildPayload(
+          'python_one_passed.xml',
+          'python-docs-samples'
         );
-        const payload = formatPayload({
-          repo: 'tbpg/python-docs-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'python-docs-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/python-docs-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('python-docs-samples', [
             {
               title: formatTestCase({
                 package: 'appengine.standard.app_identity.asserting.main_test',
@@ -707,44 +582,22 @@ describe('buildcop', () => {
               number: 16,
               body: 'Failure!',
             },
-          ])
-          .post('/repos/tbpg/python-docs-samples/issues/16/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200)
-          .get('/repos/tbpg/python-docs-samples/issues/16/comments')
-          .reply(200, [])
-          .patch('/repos/tbpg/python-docs-samples/issues/16', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockIssueComment('python-docs-samples', 16),
+          nockGetIssueComments('python-docs-samples', 16),
+          nockIssuePatch('python-docs-samples', 16),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('closes an issue for a passing test [Java]', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'java_one_passed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/java-vision',
-          organization: { login: 'tbpg' },
-          repository: { name: 'java-vision' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('java_one_passed.xml', 'java-vision');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/java-vision/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('java-vision', [
             {
               title: formatTestCase({
                 package: 'com.google.cloud.vision.it.ITSystemTest(sponge_log)',
@@ -754,44 +607,22 @@ describe('buildcop', () => {
               number: 16,
               body: 'Failure!',
             },
-          ])
-          .post('/repos/tbpg/java-vision/issues/16/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200)
-          .get('/repos/tbpg/java-vision/issues/16/comments')
-          .reply(200, [])
-          .patch('/repos/tbpg/java-vision/issues/16', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockIssueComment('java-vision', 16),
+          nockGetIssueComments('java-vision', 16),
+          nockIssuePatch('java-vision', 16),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('does not close an issue that did not explicitly pass', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'passed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('passed.xml', 'golang-samples');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title: formatTestCase({
                 package:
@@ -802,32 +633,19 @@ describe('buildcop', () => {
               number: 16,
               body: 'Failure!',
             },
-          ]);
+          ]),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('keeps an issue open for a passing test that failed in the same build (comment)', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'passed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('passed.xml', 'golang-samples');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title: formatTestCase({
                 package: 'github.com/GoogleCloudPlatform/golang-samples',
@@ -837,48 +655,28 @@ describe('buildcop', () => {
               number: 16,
               body: 'Failure!',
             },
-          ])
-          .get('/repos/tbpg/golang-samples/issues/16/comments')
-          .reply(200, [
-            {
-              body: `status: failed\ncommit: 123`,
-            },
-          ])
-          .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200)
-          .patch('/repos/tbpg/golang-samples/issues/16', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nock('https://api.github.com')
+            .get('/repos/tbpg/golang-samples/issues/16/comments')
+            .reply(200, [
+              {
+                body: `status: failed\ncommit: 123`,
+              },
+            ]),
+          nockIssueComment('golang-samples', 16),
+          nockIssuePatch('golang-samples', 16),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('keeps an issue open for a passing test that failed in the same build (issue body)', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'passed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('passed.xml', 'golang-samples');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title: formatTestCase({
                 package:
@@ -889,42 +687,21 @@ describe('buildcop', () => {
               number: 16,
               body: `status: failed\ncommit: 123`,
             },
-          ])
-          .post('/repos/tbpg/golang-samples/issues/16/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200)
-          .patch('/repos/tbpg/golang-samples/issues/16', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockIssueComment('golang-samples', 16),
+          nockIssuePatch('golang-samples', 16),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('keeps an issue open for a passing flaky test', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'passed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('passed.xml', 'golang-samples');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title: formatTestCase({
                 package:
@@ -936,32 +713,22 @@ describe('buildcop', () => {
               body: `Failure!`,
               labels: [{ name: 'buildcop: flaky' }],
             },
-          ]);
+          ]),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('opens multiple issues for multiple failures', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'many_failed_same_pkg.xml'),
-          'utf8'
+        const payload = buildPayload(
+          'many_failed_same_pkg.xml',
+          'golang-samples'
         );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title: formatTestCase({
                 package:
@@ -973,36 +740,18 @@ describe('buildcop', () => {
               body: 'Failure!',
               state: 'closed',
             },
-          ])
-          .post('/repos/tbpg/golang-samples/issues', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200)
-          .post('/repos/tbpg/golang-samples/issues', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockNewIssue('golang-samples'),
+          nockNewIssue('golang-samples'),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('closes a duplicate issue', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'passed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('passed.xml', 'golang-samples');
 
         const title = formatTestCase({
           package:
@@ -1016,11 +765,8 @@ describe('buildcop', () => {
           passed: false,
         });
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title,
               number: 16,
@@ -1047,40 +793,19 @@ describe('buildcop', () => {
               labels: [{ name: 'buildcop: flaky' }],
               state: 'open',
             },
-          ])
-          .post('/repos/tbpg/golang-samples/issues/18/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200)
-          .patch('/repos/tbpg/golang-samples/issues/18', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200)
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, []); // Real response would include all issues again.
+          ]),
+          nockIssueComment('golang-samples', 18),
+          nockIssuePatch('golang-samples', 18),
+          nockIssues('golang-samples'), // Real response would include all issues again.
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('reopens the original flaky issue when there is a duplicate', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'one_failed.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('one_failed.xml', 'golang-samples');
 
         const title = formatTestCase({
           package:
@@ -1089,11 +814,8 @@ describe('buildcop', () => {
           passed: false,
         });
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [
+        const scopes = [
+          nockIssues('golang-samples', [
             {
               title,
               number: 18,
@@ -1107,51 +829,27 @@ describe('buildcop', () => {
               labels: [{ name: 'buildcop: flaky' }],
               state: 'closed',
             },
-          ])
-          .post('/repos/tbpg/golang-samples/issues/19/comments', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200)
-          .patch('/repos/tbpg/golang-samples/issues/19', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+          ]),
+          nockIssueComment('golang-samples', 19),
+          nockIssuePatch('golang-samples', 19),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
 
       it('only opens one issue for a group of failures [Go]', async () => {
-        const input = fs.readFileSync(
-          resolve(fixturesPath, 'testdata', 'go_failure_group.xml'),
-          'utf8'
-        );
-        const payload = formatPayload({
-          repo: 'tbpg/golang-samples',
-          organization: { login: 'tbpg' },
-          repository: { name: 'golang-samples' },
-          commit: '123',
-          buildURL: 'http://example.com',
-          xunitXML: input,
-        });
+        const payload = buildPayload('go_failure_group.xml', 'golang-samples');
 
-        const requests = nock('https://api.github.com')
-          .get(
-            '/repos/tbpg/golang-samples/issues?per_page=100&labels=buildcop%3A%20issue&state=all'
-          )
-          .reply(200, [])
-          .post('/repos/tbpg/golang-samples/issues', body => {
-            snapshot(body);
-            return true;
-          })
-          .reply(200);
+        const scopes = [
+          nockIssues('golang-samples'),
+          nockNewIssue('golang-samples'),
+        ];
 
         await probot.receive({ name: 'pubsub.message', payload, id: 'abc123' });
 
-        requests.done();
+        scopes.forEach(s => s.done());
       });
     });
   });

--- a/packages/buildcop/test/fixtures/testdata/no_tests.xml
+++ b/packages/buildcop/test/fixtures/testdata/no_tests.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="0" failures="0" time="266.555" name="github.com/tbpg/golang-samples/dataproc">
+	<testsuite tests="0" failures="0" time="266.555" name="github.com/GoogleCloudPlatform/golang-samples/dataproc">
 		<properties>
 			<property name="go.version" value="go1.11.13"></property>
 		</properties>


### PR DESCRIPTION
I also replaced `tbpg` with `GoogleCloudPlatform`. `java-vision` is not in `GoogleCloudPlatform`, but that's OK.

Fixes #448.
