### PR TITLE
feat(Build Cop): don't mark locked and old issues as flaky

### DIFF
--- a/packages/buildcop/README.md
+++ b/packages/buildcop/README.md
@@ -4,10 +4,16 @@ The Build Cop Bot manages issues for failing tests.
 
 * If a test fails, the bot will open an issue for it.
 * If a test passes, the bot will close the corresponding issue.
-* If the test fails _again_, the bot will reopen the issue, mark it as flaky, then
-  stop commenting and leave it up to a human to close.
-* If someone closes the issue and the test fails _again_, the bot will reopen the
-  issue and leave it up to a human to close again.
+* If the test fails _again_:
+  * If the original issue is locked, the bot will open a new issue.
+  * If the original was closed more than 10 days before, the bot will open a new
+    issue.
+  * Otherwise, the bot will reopen the original issue, mark it as flaky, then
+    stop commenting and leave it up to a human to close.
+* If someone closes a flaky issue and the test fails _again_, the bot will
+  reopen the issue or open a new one, depending on the issue state/age.
+* If the bot opens duplicate issues (sorry!), it will close the duplicates
+  during the next run.
 
 Issues or feature requests? Please
 [file them on this repo](https://github.com/googleapis/repo-automation-bots/issues/new).

--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -184,3 +184,23 @@ exports['buildcop app xunitXML reopens the original flaky issue when there is a 
 exports['buildcop app xunitXML reopens the original flaky issue when there is a duplicate 2'] = {
   "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed"
 }
+
+exports['buildcop app xunitXML opens a new issue when the original is locked [Go] 1'] = {
+  "title": "spanner/spanner_snippets: TestSample failed",
+  "body": "Note: #16 was also for this test, but it is locked\n\n----\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop: issue"
+  ]
+}
+
+exports['buildcop app xunitXML opens a new issue when the original was closed a long time ago [Go] 1'] = {
+  "title": "spanner/spanner_snippets: TestSample failed",
+  "body": "Note: #16 was also for this test, but it was closed more than 10 days ago. So, I didn't mark it flaky.\n\n----\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop: issue"
+  ]
+}


### PR DESCRIPTION
Locked issues shouldn't be reopened.

Issues that have been closed for more than 10 days (chosen arbitrarily) will also stay closed after this change.

I included a link to the old issue when opening a new one. It might be relevant to see the history of a given test when working on a new fix.

Fixes #444.

Unrelated change: I added an extra test case to verify the bot doesn't comment on issues about failures for the same build.