### PR TITLE
fix: queue name rules

### DIFF
--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcf-utils",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "An extension for running Probot in Google Cloud Functions",
   "scripts": {
     "compile": "tsc -p .",

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -237,10 +237,14 @@ export class GCFBootstrapper {
     // Make a task here and return 200 as this is coming from GitHub
     const projectId = process.env.PROJECT_ID || '';
     const location = process.env.GCF_LOCATION || '';
-    const queueName = process.env.GCF_SHORT_FUNCTION_NAME || '';
+    // queue name can contain only letters ([A-Za-z]), numbers ([0-9]), or hyphens (-):
+    const queueName = (process.env.GCF_SHORT_FUNCTION_NAME || '').replace(
+      '_',
+      '-'
+    );
     const queuePath = client.queuePath(projectId, location, queueName);
     // https://us-central1-repo-automation-bots.cloudfunctions.net/merge_on_green:
-    const url = `https://${location}-${projectId}.cloudfunctions.net/${queueName}`;
+    const url = `https://${location}-${projectId}.cloudfunctions.net/${process.env.GCF_SHORT_FUNCTION_NAME}`;
     if (params.body) {
       await client.createTask({
         parent: queuePath,

--- a/scripts/publish-functions.sh
+++ b/scripts/publish-functions.sh
@@ -59,7 +59,7 @@ for f in *; do
         echo "$f"
         # Javascript does not allow function names with '-' so we need to
         # replace the directory name (which might have '-') with "_"
-        functionname=${f//-/_}
+        functionname=${f//_/-}
         echo "About to publish function $functionname"
 
         gcloud functions deploy "$functionname" --trigger-http \


### PR DESCRIPTION
queues have stricter rules about naming than functions:

```
ERROR: (gcloud.tasks.queues.create) INVALID_ARGUMENT: Queue ID "auto_label" can contain only letters ([A-Za-z]), numbers ([0-9]), or hyphens (-). Queue ID must be between 1 and 100 characters.
```