### PR TITLE
fix: queue naming logic and function naming logic are opposite

### DIFF
--- a/scripts/publish-functions.sh
+++ b/scripts/publish-functions.sh
@@ -59,7 +59,8 @@ for f in *; do
         echo "$f"
         # Javascript does not allow function names with '-' so we need to
         # replace the directory name (which might have '-') with "_"
-        functionname=${f//_/-}
+        functionname=${f//-/_}
+        queuename=${f//_/-}
         echo "About to publish function $functionname"
 
         gcloud functions deploy "$functionname" --trigger-http \
@@ -67,7 +68,7 @@ for f in *; do
             --region "$FUNCTION_REGION" \
             --set-env-vars DRIFT_PRO_BUCKET="$BUCKET",KEY_LOCATION="$KEY_LOCATION",KEY_RING="$KEY_RING",GCF_SHORT_FUNCTION_NAME="$functionname",PROJECT_ID="$PROJECT_ID",GCF_LOCATION="$FUNCTION_REGION"
 
-        deploy_queue $functionname
+        deploy_queue $queuename
         )
     fi
 done


### PR DESCRIPTION
functions are expected to always have `_`, whereas queues don't support an `_`.