### PR TITLE
fix: switch to new default publish token

### DIFF
--- a/packages/publish/src/publish.ts
+++ b/packages/publish/src/publish.ts
@@ -316,7 +316,7 @@ handler.getPublicationSecrets = async (
   app: Application,
   config: Configuration
 ): Promise<Secret> => {
-  const secretId = config.secretId || 'publish';
+  const secretId = config.secretId || 'publish-token';
   const project = config.project || process.env.PROJECT_ID;
   app.log.info(`looking up secret for ${project}`);
   const [secret] = await sms.accessSecretVersion({


### PR DESCRIPTION
having a token already named publish caused issues for @orthros's migration to Secret Manager for secrets in general.