### PR TITLE
feat(Build Cop): include test logs in comments

### DIFF
--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -24,7 +24,7 @@ exports['buildcop app testsFailed comments on an existing open issue when testsF
 
 exports['buildcop app xunitXML opens an issue [Go] 1'] = {
   "title": "spanner/spanner_snippets: TestSample failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nsnippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"\n</pre></details>",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -42,7 +42,7 @@ exports['buildcop app xunitXML closes a duplicate issue 2'] = {
 
 exports['buildcop app xunitXML opens an issue [Python] 1'] = {
   "title": "appengine.flexible.datastore.main_test: test_index failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nTraceback (most recent call last):\n  File \"/tmpfs/src/github/python-docs-samples/appengine/flexible/datastore/main_test.py\", line 22, in test_index\n    ...\n    </pre></details>",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -51,7 +51,7 @@ exports['buildcop app xunitXML opens an issue [Python] 1'] = {
 }
 
 exports['buildcop app xunitXML comments on existing issue 1'] = {
-  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nsnippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"\n</pre></details>"
 }
 
 exports['buildcop app xunitXML closes an issue for a passing test [Go] 1'] = {
@@ -72,7 +72,7 @@ exports['buildcop app xunitXML closes an issue for a passing test [Python] 2'] =
 
 exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] = {
   "title": "storage/buckets: TestBucketLock failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:234: failed to create bucket (\"golang-samples-tests-8-storage-buckets-tests\"): Post https://storage.googleapis.com/storage/v1/b?alt=json&prettyPrint=false&project=golang-samples-tests-8: read tcp 10.142.0.112:33618->108.177.12.128:443: read: connection reset by peer</pre></details>",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -82,7 +82,7 @@ exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] =
 
 exports['buildcop app xunitXML opens multiple issues for multiple failures 2'] = {
   "title": "storage/buckets: TestUniformBucketLevelAccess failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:242: failed to enable uniform bucket-level access (\"golang-samples-tests-8-storage-buckets-tests\"): googleapi: Error 404: Not Found, notFound</pre></details>",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -92,7 +92,7 @@ exports['buildcop app xunitXML opens multiple issues for multiple failures 2'] =
 
 exports['buildcop app xunitXML opens an issue [Java] 1'] = {
   "title": "vision.it.ITSystemTest: detectSafeSearchGcsTest failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>java.lang.AssertionError: expected:<UNLIKELY> but was:<VERY_UNLIKELY>\n\tat org.junit.Assert.fail(Assert.java:89)\n\tat org.junit.Assert.failNotEquals(Assert.java:835)\n\tat org.junit.Assert.assertEquals(Assert.java:120)\n\tat org.junit.Assert.assertEquals(Assert.java:146)\n\tat com.google.cloud.vision.it.ITSystemTest.detectSafeSearchGcsTest(ITSystemTest.java:404)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)\n\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)\n\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n\tat org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)\n\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)\n\tat org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)\n\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)\n\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)\n\tat org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)\n\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)\n\tat org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)\n\tat org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)\n\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n\tat org.junit.runners.ParentRunner.run(ParentRunner.java:413)\n\tat org.junit.runners.Suite.runChild(Suite.java:128)\n\tat org.junit.runners.Suite.runChild(Suite.java:27)\n\tat org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)\n\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)\n\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)\n\tat org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)\n\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)\n\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n\tat org.junit.runners.ParentRunner.run(ParentRunner.java:413)\n\tat org.apache.maven.surefire.junitcore.JUnitCore.run(JUnitCore.java:55)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.createRequestAndRun(JUnitCoreWrapper.java:137)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.executeEager(JUnitCoreWrapper.java:107)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:83)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:75)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:158)\n\tat org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:377)\n\tat org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:138)\n\tat org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:465)\n\tat org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:451)\n</pre></details>",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -109,7 +109,7 @@ exports['buildcop app xunitXML closes an issue for a passing test [Java] 2'] = {
 }
 
 exports['buildcop app xunitXML does not comment about failure on existing flaky issue 1'] = {
-  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:242: failed to enable uniform bucket-level access (\"golang-samples-tests-8-storage-buckets-tests\"): googleapi: Error 404: Not Found, notFound</pre></details>"
 }
 
 exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (comment) 1'] = {
@@ -143,7 +143,7 @@ exports['buildcop app xunitXML keeps an issue open for a passing test that faile
 }
 
 exports['buildcop app xunitXML does not comment about failure on existing issue labeled quiet 1'] = {
-  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:242: failed to enable uniform bucket-level access (\"golang-samples-tests-8-storage-buckets-tests\"): googleapi: Error 404: Not Found, notFound</pre></details>"
 }
 
 exports['buildcop app xunitXML only opens one issue for a group of failures [Go] 1'] = {
@@ -167,12 +167,12 @@ exports['buildcop app xunitXML reopens the original flaky issue when there is a 
 }
 
 exports['buildcop app xunitXML reopens the original flaky issue when there is a duplicate 2'] = {
-  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nsnippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"\n</pre></details>"
 }
 
 exports['buildcop app xunitXML opens a new issue when the original is locked [Go] 1'] = {
   "title": "spanner/spanner_snippets: TestSample failed",
-  "body": "Note: #16 was also for this test, but it is locked\n\n----\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "Note: #16 was also for this test, but it is locked\n\n----\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nsnippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"\n</pre></details>",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -182,7 +182,7 @@ exports['buildcop app xunitXML opens a new issue when the original is locked [Go
 
 exports['buildcop app xunitXML opens a new issue when the original was closed a long time ago [Go] 1'] = {
   "title": "spanner/spanner_snippets: TestSample failed",
-  "body": "Note: #16 was also for this test, but it was closed more than 10 days ago. So, I didn't mark it flaky.\n\n----\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
+  "body": "Note: #16 was also for this test, but it was closed more than 10 days ago. So, I didn't mark it flaky.\n\n----\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nsnippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"\n</pre></details>",
   "labels": [
     "type: bug",
     "priority: p1",
@@ -202,5 +202,5 @@ exports['buildcop app xunitXML reopens issue with correct labels for failing tes
 }
 
 exports['buildcop app xunitXML reopens issue with correct labels for failing test 2'] = {
-  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "Oops! Looks like this issue is still flaky. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nsnippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"\n</pre></details>"
 }

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -72,6 +72,7 @@ interface TestCase {
   package?: string;
   testCase?: string;
   passed: boolean;
+  log?: string;
 }
 
 interface TestResults {
@@ -548,9 +549,13 @@ buildcop.formatBody = (
   commit: string,
   buildURL: string
 ): string => {
-  return `commit: ${commit}
+  let body = `commit: ${commit}
 buildURL: ${buildURL}
 status: ${testCase.passed ? 'passed' : 'failed'}`;
+  if (testCase.log) {
+    body += `\n<details><summary>Test output</summary><br><pre>${testCase.log}</pre></details>`;
+  }
+  return body;
 };
 
 buildcop.containsBuildFailure = async (
@@ -656,10 +661,16 @@ buildcop.findTestResults = (xml: string): TestResults => {
         });
         continue;
       }
+      let log = failure['_text'];
+      // Java puts its test logs in a CDATA element.
+      if (log === undefined) {
+        log = failure['_cdata'];
+      }
       failures.push({
         package: pkg,
         testCase: testcase['_attributes'].name,
         passed: false,
+        log,
       });
     }
   }

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -123,6 +123,8 @@ describe('buildcop', () => {
               'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
             testCase: 'TestSample',
             passed: false,
+            log:
+              '\nsnippet_test.go:242: got output ""; want it to contain "4 Venue 4" snippet_test.go:243: got output ""; want it to contain "19 Venue 19" snippet_test.go:244: got output ""; want it to contain "42 Venue 42"\n',
           },
         ],
         passes: [
@@ -158,12 +160,16 @@ describe('buildcop', () => {
               'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
             testCase: 'TestBucketLock',
             passed: false,
+            log:
+              'main_test.go:234: failed to create bucket ("golang-samples-tests-8-storage-buckets-tests"): Post https://storage.googleapis.com/storage/v1/b?alt=json&prettyPrint=false&project=golang-samples-tests-8: read tcp 10.142.0.112:33618->108.177.12.128:443: read: connection reset by peer',
           },
           {
             package:
               'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
             testCase: 'TestUniformBucketLevelAccess',
             passed: false,
+            log:
+              'main_test.go:242: failed to enable uniform bucket-level access ("golang-samples-tests-8-storage-buckets-tests"): googleapi: Error 404: Not Found, notFound',
           },
         ],
         passes: [


### PR DESCRIPTION
Fixes #513.

cc @ace-n (GitHub won't let me add you as a reviewer)

Here is an example of what one of the comments would look like:

----

This test failed!

To configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).

If I'm commenting on this issue too often, add the `buildcop: quiet` label and
I will stop commenting.

---

commit: 123
buildURL: http://example.com
status: failed
<details><summary>Test output</summary><br><pre>
snippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"
</pre></details>
