### PR TITLE
chore(Build Cop): update gcf-utils, drop try/catch

### DIFF
--- a/packages/buildcop/package.json
+++ b/packages/buildcop/package.json
@@ -28,7 +28,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "1.6.1",
+    "gcf-utils": "3.0.6",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {


### PR DESCRIPTION
This will hopefully lead to catching more errors and fewer missing reports. The upgraded gcf-utils will retry invocations using Cloud Tasks.

Updates #532.