### PR TITLE
fix(Build Cop): downgrade gcf-utils to stop using Tasks

### DIFF
--- a/packages/buildcop/package.json
+++ b/packages/buildcop/package.json
@@ -28,7 +28,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "3.0.6",
+    "gcf-utils": "^1.6.1",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/packages/buildcop/package.json
+++ b/packages/buildcop/package.json
@@ -28,7 +28,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "^1.6.1",
+    "gcf-utils": "1.6.2",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -30,7 +30,7 @@ import {LoggerWithTarget} from 'probot/lib/wrap-logger';
 import {GitHubAPI} from 'probot/lib/github';
 import xmljs from 'xml-js';
 // eslint-disable-next-line node/no-extraneous-import
-import {Octokit} from '@octokit/rest';
+import Octokit from '@octokit/rest';
 
 const ISSUE_LABEL = 'buildcop: issue';
 const FLAKY_LABEL = 'buildcop: flaky';

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -30,7 +30,7 @@ import {LoggerWithTarget} from 'probot/lib/wrap-logger';
 import {GitHubAPI} from 'probot/lib/github';
 import xmljs from 'xml-js';
 // eslint-disable-next-line node/no-extraneous-import
-import Octokit from '@octokit/rest';
+import {Octokit} from '@octokit/rest';
 
 const ISSUE_LABEL = 'buildcop: issue';
 const FLAKY_LABEL = 'buildcop: flaky';


### PR DESCRIPTION
Some build logs are too large to fit in a Task, so they would get
silently dropped.

Fixes #532.