### PR TITLE
fix(Blunderbuss): make assign_issues_by work without assign_issues

### DIFF
--- a/packages/blunderbuss/src/blunderbuss.ts
+++ b/packages/blunderbuss/src/blunderbuss.ts
@@ -69,15 +69,17 @@ export = (app: Application) => {
         : context.payload.pull_request) as Issue;
 
       if (
-        (context.payload.issue && !config.assign_issues) ||
+        (context.payload.issue &&
+          !config.assign_issues &&
+          !config.assign_issues_by) ||
         (context.payload.pull_request && !config.assign_prs)
       ) {
         const paramName = context.payload.issue
-          ? 'assign_issues'
-          : 'assign_prs';
+          ? '"assign_issues" and "assign_issues_by"'
+          : '"assign_prs"';
         context.log.info(
           util.format(
-            '[%s/%s] #%s ignored: "%s" not in config',
+            '[%s/%s] #%s ignored: %s not in config',
             issue.owner,
             issue.repo,
             issue.number,

--- a/packages/blunderbuss/test/fixtures/config/on_label.yml
+++ b/packages/blunderbuss/test/fixtures/config/on_label.yml
@@ -1,5 +1,3 @@
-assign_issues:
-- issues1
 assign_issues_by:
   - labels:
     - 'api: foo'


### PR DESCRIPTION
Before this, if the config didn't have an `assign_issues` value, the issue was skipped.