### PR TITLE
feat(Build Cop): grab the right package for Node.js tests

### DIFF
--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -204,3 +204,13 @@ exports['buildcop app xunitXML reopens issue with correct labels for failing tes
 exports['buildcop app xunitXML reopens issue with correct labels for failing test 2'] = {
   "body": "Oops! Looks like this issue is still flaky. It failed again. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nsnippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"\n</pre></details>"
 }
+
+exports['buildcop app xunitXML opens an issue [Node.js] 1'] = {
+  "title": "Spanner: should delete and then insert rows in the example tables failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>expected 'Deleted individual rows in Albums.\\n5 records deleted from Singers.\\n2 records deleted from Singers.\\n0 records deleted from Singers.\\n' to include '3 records deleted from Singers.'\n    AssertionError: expected 'Deleted individual rows in Albums.\\n5 records deleted from Singers.\\n2 records deleted from Singers.\\n0 records deleted from Singers.\\n' to include '3 records deleted from Singers.'\n        at Context.it (system-test/spanner.test.js:198:12)</pre></details>",
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop: issue"
+  ]
+}

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -667,7 +667,7 @@ buildcop.findTestResults = (xml: string): TestResults => {
     }
     for (const testcase of testcases) {
       let pkg = testsuiteName;
-      if (testsuiteName === 'pytest') {
+      if (testsuiteName === 'pytest' || testsuiteName === 'Mocha Tests') {
         pkg = testcase['_attributes'].classname;
       }
       // Ignore skipped tests. They didn't pass and they didn't fail.

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -414,6 +414,19 @@ describe('buildcop', () => {
         scopes.forEach(s => s.done());
       });
 
+      it('opens an issue [Node.js]', async () => {
+        const payload = buildPayload('node_one_failed.xml', 'nodejs-spanner');
+
+        const scopes = [
+          nockIssues('nodejs-spanner'),
+          nockNewIssue('nodejs-spanner'),
+        ];
+
+        await probot.receive({name: 'pubsub.message', payload, id: 'abc123'});
+
+        scopes.forEach(s => s.done());
+      });
+
       it('comments on existing issue', async () => {
         const payload = buildPayload('one_failed.xml', 'golang-samples');
 

--- a/packages/buildcop/test/fixtures/testdata/node_one_failed.xml
+++ b/packages/buildcop/test/fixtures/testdata/node_one_failed.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<testsuite name="Mocha Tests" tests="64" failures="0" errors="24" skipped="0" timestamp="Thu, 11 Jun 2020 22:41:07 GMT" time="885.891">
+    <testcase classname="Spanner" name="should create an example database" time="5.998"/>
+    <testcase classname="Spanner" name="should delete and then insert rows in the example tables" time="3.578"><failure>expected &#x27;Deleted individual rows in Albums.\n5 records deleted from Singers.\n2 records deleted from Singers.\n0 records deleted from Singers.\n&#x27; to include &#x27;3 records deleted from Singers.&#x27;
+    AssertionError: expected &#x27;Deleted individual rows in Albums.\n5 records deleted from Singers.\n2 records deleted from Singers.\n0 records deleted from Singers.\n&#x27; to include &#x27;3 records deleted from Singers.&#x27;
+        at Context.it (system-test/spanner.test.js:198:12)</failure></testcase>
+</testsuite>


### PR DESCRIPTION
This will not rename or close old "Mocha Tests: ..." issues; the bot will file duplicates.