### PR TITLE
feat(Build Cop): group tests into a single issue when 10+ fail

### DIFF
--- a/packages/buildcop/README.md
+++ b/packages/buildcop/README.md
@@ -14,6 +14,12 @@ The Build Cop Bot manages issues for failing tests.
   reopen the issue or open a new one, depending on the issue state/age.
 * If the bot opens duplicate issues (sorry!), it will close the duplicates
   during the next run.
+* If 10 or more tests fail in the same package, they will all be grouped into a
+  single issue. If there are already open issues for tests in the package, they
+  will be left open until the corresponding test passes.
+
+  Note: the "package" is the part of the issue title before the `:`. If the
+  package is wrong, please file an issue.
 
 Issues or feature requests? Please
 [file them on this repo](https://github.com/googleapis/repo-automation-bots/issues/new).

--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -32,14 +32,6 @@ exports['buildcop app xunitXML opens an issue [Go] 1'] = {
   ]
 }
 
-exports['buildcop app xunitXML closes a duplicate issue 1'] = {
-  "body": "Closing as a duplicate of #19"
-}
-
-exports['buildcop app xunitXML closes a duplicate issue 2'] = {
-  "state": "closed"
-}
-
 exports['buildcop app xunitXML opens an issue [Python] 1'] = {
   "title": "appengine.flexible.datastore.main_test: test_index failed",
   "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nTraceback (most recent call last):\n  File \"/tmpfs/src/github/python-docs-samples/appengine/flexible/datastore/main_test.py\", line 22, in test_index\n    ...\n    </pre></details>",
@@ -50,8 +42,51 @@ exports['buildcop app xunitXML opens an issue [Python] 1'] = {
   ]
 }
 
+exports['buildcop app xunitXML opens an issue [Java] 1'] = {
+  "title": "vision.it.ITSystemTest: detectSafeSearchGcsTest failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>java.lang.AssertionError: expected:<UNLIKELY> but was:<VERY_UNLIKELY>\n\tat org.junit.Assert.fail(Assert.java:89)\n\tat org.junit.Assert.failNotEquals(Assert.java:835)\n\tat org.junit.Assert.assertEquals(Assert.java:120)\n\tat org.junit.Assert.assertEquals(Assert.java:146)\n\tat com.google.cloud.vision.it.ITSystemTest.detectSafeSearchGcsTest(ITSystemTest.java:404)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)\n\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)\n\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n\tat org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)\n\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)\n\tat org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)\n\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)\n\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)\n\tat org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)\n\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)\n\tat org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)\n\tat org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)\n\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n\tat org.junit.runners.ParentRunner.run(ParentRunner.java:413)\n\tat org.junit.runners.Suite.runChild(Suite.java:128)\n\tat org.junit.runners.Suite.runChild(Suite.java:27)\n\tat org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)\n\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)\n\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)\n\tat org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)\n\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)\n\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n\tat org.junit.runners.ParentRunner.run(ParentRunner.java:413)\n\tat org.apache.maven.surefire.junitcore.JUnitCore.run(JUnitCore.java:55)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.createRequestAndRun(JUnitCoreWrapper.java:137)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.executeEager(JUnitCoreWrapper.java:107)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:83)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:75)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:158)\n\tat org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:377)\n\tat org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:138)\n\tat org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:465)\n\tat org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:451)\n</pre></details>",
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop: issue"
+  ]
+}
+
+exports['buildcop app xunitXML opens an issue [Node.js] 1'] = {
+  "title": "Spanner: should delete and then insert rows in the example tables failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>expected 'Deleted individual rows in Albums.\\n5 records deleted from Singers.\\n2 records deleted from Singers.\\n0 records deleted from Singers.\\n' to include '3 records deleted from Singers.'\n    AssertionError: expected 'Deleted individual rows in Albums.\\n5 records deleted from Singers.\\n2 records deleted from Singers.\\n0 records deleted from Singers.\\n' to include '3 records deleted from Singers.'\n        at Context.it (system-test/spanner.test.js:198:12)</pre></details>",
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop: issue"
+  ]
+}
+
 exports['buildcop app xunitXML comments on existing issue 1'] = {
   "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nsnippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"\n</pre></details>"
+}
+
+exports['buildcop app xunitXML does not comment about failure on existing flaky issue 1'] = {
+  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:242: failed to enable uniform bucket-level access (\"golang-samples-tests-8-storage-buckets-tests\"): googleapi: Error 404: Not Found, notFound</pre></details>"
+}
+
+exports['buildcop app xunitXML does not comment about failure on existing issue labeled quiet 1'] = {
+  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:242: failed to enable uniform bucket-level access (\"golang-samples-tests-8-storage-buckets-tests\"): googleapi: Error 404: Not Found, notFound</pre></details>"
+}
+
+exports['buildcop app xunitXML reopens issue with correct labels for failing test 1'] = {
+  "labels": [
+    "buildcop: issue",
+    "buildcop: flaky",
+    "api: spanner",
+    "priority: p2",
+    "type: cleanup"
+  ],
+  "state": "open"
+}
+
+exports['buildcop app xunitXML reopens issue with correct labels for failing test 2'] = {
+  "body": "Oops! Looks like this issue is still flaky. It failed again. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nsnippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"\n</pre></details>"
 }
 
 exports['buildcop app xunitXML closes an issue for a passing test [Go] 1'] = {
@@ -70,46 +105,12 @@ exports['buildcop app xunitXML closes an issue for a passing test [Python] 2'] =
   "state": "closed"
 }
 
-exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] = {
-  "title": "storage/buckets: TestBucketLock failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:234: failed to create bucket (\"golang-samples-tests-8-storage-buckets-tests\"): Post https://storage.googleapis.com/storage/v1/b?alt=json&prettyPrint=false&project=golang-samples-tests-8: read tcp 10.142.0.112:33618->108.177.12.128:443: read: connection reset by peer</pre></details>",
-  "labels": [
-    "type: bug",
-    "priority: p1",
-    "buildcop: issue"
-  ]
-}
-
-exports['buildcop app xunitXML opens multiple issues for multiple failures 2'] = {
-  "title": "storage/buckets: TestUniformBucketLevelAccess failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:242: failed to enable uniform bucket-level access (\"golang-samples-tests-8-storage-buckets-tests\"): googleapi: Error 404: Not Found, notFound</pre></details>",
-  "labels": [
-    "type: bug",
-    "priority: p1",
-    "buildcop: issue"
-  ]
-}
-
-exports['buildcop app xunitXML opens an issue [Java] 1'] = {
-  "title": "vision.it.ITSystemTest: detectSafeSearchGcsTest failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>java.lang.AssertionError: expected:<UNLIKELY> but was:<VERY_UNLIKELY>\n\tat org.junit.Assert.fail(Assert.java:89)\n\tat org.junit.Assert.failNotEquals(Assert.java:835)\n\tat org.junit.Assert.assertEquals(Assert.java:120)\n\tat org.junit.Assert.assertEquals(Assert.java:146)\n\tat com.google.cloud.vision.it.ITSystemTest.detectSafeSearchGcsTest(ITSystemTest.java:404)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)\n\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)\n\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n\tat org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)\n\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)\n\tat org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)\n\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)\n\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)\n\tat org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)\n\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)\n\tat org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)\n\tat org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)\n\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n\tat org.junit.runners.ParentRunner.run(ParentRunner.java:413)\n\tat org.junit.runners.Suite.runChild(Suite.java:128)\n\tat org.junit.runners.Suite.runChild(Suite.java:27)\n\tat org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)\n\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)\n\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)\n\tat org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)\n\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)\n\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n\tat org.junit.runners.ParentRunner.run(ParentRunner.java:413)\n\tat org.apache.maven.surefire.junitcore.JUnitCore.run(JUnitCore.java:55)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.createRequestAndRun(JUnitCoreWrapper.java:137)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.executeEager(JUnitCoreWrapper.java:107)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:83)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:75)\n\tat org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:158)\n\tat org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:377)\n\tat org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:138)\n\tat org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:465)\n\tat org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:451)\n</pre></details>",
-  "labels": [
-    "type: bug",
-    "priority: p1",
-    "buildcop: issue"
-  ]
-}
-
 exports['buildcop app xunitXML closes an issue for a passing test [Java] 1'] = {
   "body": "Test passed for commit 123 (http://example.com)! Closing this issue."
 }
 
 exports['buildcop app xunitXML closes an issue for a passing test [Java] 2'] = {
   "state": "closed"
-}
-
-exports['buildcop app xunitXML does not comment about failure on existing flaky issue 1'] = {
-  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:242: failed to enable uniform bucket-level access (\"golang-samples-tests-8-storage-buckets-tests\"): googleapi: Error 404: Not Found, notFound</pre></details>"
 }
 
 exports['buildcop app xunitXML keeps an issue open for a passing test that failed in the same build (comment) 1'] = {
@@ -142,18 +143,32 @@ exports['buildcop app xunitXML keeps an issue open for a passing test that faile
   "body": "Looks like this issue is flaky. :worried:\n\nI'm going to leave this open and stop commenting.\n\nA human should fix and close this.\n\n---\n\nWhen run at the same commit (123), this test passed in one build (http://example.com) and failed in another build ([Build Status](example.com/failure))."
 }
 
-exports['buildcop app xunitXML does not comment about failure on existing issue labeled quiet 1'] = {
-  "body": "commit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:242: failed to enable uniform bucket-level access (\"golang-samples-tests-8-storage-buckets-tests\"): googleapi: Error 404: Not Found, notFound</pre></details>"
-}
-
-exports['buildcop app xunitXML only opens one issue for a group of failures [Go] 1'] = {
-  "title": "bigquery/snippets/querying: TestQueries failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
+exports['buildcop app xunitXML opens multiple issues for multiple failures 1'] = {
+  "title": "storage/buckets: TestBucketLock failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:234: failed to create bucket (\"golang-samples-tests-8-storage-buckets-tests\"): Post https://storage.googleapis.com/storage/v1/b?alt=json&prettyPrint=false&project=golang-samples-tests-8: read tcp 10.142.0.112:33618->108.177.12.128:443: read: connection reset by peer</pre></details>",
   "labels": [
     "type: bug",
     "priority: p1",
     "buildcop: issue"
   ]
+}
+
+exports['buildcop app xunitXML opens multiple issues for multiple failures 2'] = {
+  "title": "storage/buckets: TestUniformBucketLevelAccess failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>main_test.go:242: failed to enable uniform bucket-level access (\"golang-samples-tests-8-storage-buckets-tests\"): googleapi: Error 404: Not Found, notFound</pre></details>",
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop: issue"
+  ]
+}
+
+exports['buildcop app xunitXML closes a duplicate issue 1'] = {
+  "body": "Closing as a duplicate of #19"
+}
+
+exports['buildcop app xunitXML closes a duplicate issue 2'] = {
+  "state": "closed"
 }
 
 exports['buildcop app xunitXML reopens the original flaky issue when there is a duplicate 1'] = {
@@ -168,6 +183,16 @@ exports['buildcop app xunitXML reopens the original flaky issue when there is a 
 
 exports['buildcop app xunitXML reopens the original flaky issue when there is a duplicate 2'] = {
   "body": "Oops! Looks like this issue is still flaky. It failed again. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nsnippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"\n</pre></details>"
+}
+
+exports['buildcop app xunitXML only opens one issue for a group of failures [Go] 1'] = {
+  "title": "bigquery/snippets/querying: TestQueries failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop: issue"
+  ]
 }
 
 exports['buildcop app xunitXML opens a new issue when the original is locked [Go] 1'] = {
@@ -190,27 +215,40 @@ exports['buildcop app xunitXML opens a new issue when the original was closed a 
   ]
 }
 
-exports['buildcop app xunitXML reopens issue with correct labels for failing test 1'] = {
-  "labels": [
-    "buildcop: issue",
-    "buildcop: flaky",
-    "api: spanner",
-    "priority: p2",
-    "type: cleanup"
-  ],
-  "state": "open"
-}
-
-exports['buildcop app xunitXML reopens issue with correct labels for failing test 2'] = {
-  "body": "Oops! Looks like this issue is still flaky. It failed again. :grimacing:\n\nI reopened the issue, but a human will need to close it again.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>\nsnippet_test.go:242: got output \"\"; want it to contain \"4 Venue 4\" snippet_test.go:243: got output \"\"; want it to contain \"19 Venue 19\" snippet_test.go:244: got output \"\"; want it to contain \"42 Venue 42\"\n</pre></details>"
-}
-
-exports['buildcop app xunitXML opens an issue [Node.js] 1'] = {
-  "title": "Spanner: should delete and then insert rows in the example tables failed",
-  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>expected 'Deleted individual rows in Albums.\\n5 records deleted from Singers.\\n2 records deleted from Singers.\\n0 records deleted from Singers.\\n' to include '3 records deleted from Singers.'\n    AssertionError: expected 'Deleted individual rows in Albums.\\n5 records deleted from Singers.\\n2 records deleted from Singers.\\n0 records deleted from Singers.\\n' to include '3 records deleted from Singers.'\n        at Context.it (system-test/spanner.test.js:198:12)</pre></details>",
+exports['buildcop app xunitXML Grouped issues opens a single issue for many tests in the same package 1'] = {
+  "title": "Spanner: many tests failed",
+  "body": "Many tests failed at the same time in this package.\n\n* I will close this issue when there are no more failures in this package _and_\n  there is at least one pass.\n* No new issues will be filed for this package until this issue is closed.\n* If there are already issues for individual test cases, I will close them when\n  the corresponding test passes. You can close them earlier, if you prefer, and\n  I won't reopen them while this issue is still open.\n\nHere are the tests that failed:\n* should delete and then insert rows in the example tables (#8)\n* should query an example table and return matching rows\n* should read an example table\n* should update existing rows in an example table\n* should read stale data from an example table\n* should query an example table with an additional column and return matching rows\n* should query an example table with an index and return matching rows\n* should respect query boundaries when querying an example table with an index\n* should read an example table with an index\n* should read an example table with a storing index\n* should use query options from a database reference\n* should use query options on request\n* should read an example table using transactions\n* should read from and write to an example table using transactions\n* should update existing rows in an example table with commit timestamp column\n* should query an example table with an additional timestamp column and return matching rows\n* should insert rows into an example table with timestamp column\n* should query an example table with a non-null timestamp column and return matching rows\n* should update a row in an example table using a DML statement\n* should delete a row from an example table using a DML statement\n* should update the timestamp of multiple records in an example table using a DML statement\n* should transfer value from one record to another using DML statements within a transaction\n* should update multiple records using a partitioned DML statement\n* should insert and update records using Batch DML\n\n\n-----\ncommit: 123\nbuildURL: http://example.com\nstatus: failed",
   "labels": [
     "type: bug",
     "priority: p1",
     "buildcop: issue"
   ]
+}
+
+exports['buildcop app xunitXML Grouped issues closes group issues when all tests pass 1'] = {
+  "body": "Test passed for commit 123 (http://example.com)! Closing this issue."
+}
+
+exports['buildcop app xunitXML Grouped issues closes group issues when all tests pass 2'] = {
+  "state": "closed"
+}
+
+exports['buildcop app xunitXML Grouped issues closes group issues when all tests pass 3'] = {
+  "body": "Test passed for commit 123 (http://example.com)! Closing this issue."
+}
+
+exports['buildcop app xunitXML Grouped issues closes group issues when all tests pass 4'] = {
+  "state": "closed"
+}
+
+exports['buildcop app xunitXML Grouped issues closes an individual issue and keeps grouped issue open 1'] = {
+  "body": "24 tests failed in this package for commit 123 (http://example.com).\n-----\ncommit: 123\nbuildURL: http://example.com\nstatus: failed"
+}
+
+exports['buildcop app xunitXML Grouped issues closes an individual issue and keeps grouped issue open 2'] = {
+  "body": "Test passed for commit 123 (http://example.com)! Closing this issue."
+}
+
+exports['buildcop app xunitXML Grouped issues closes an individual issue and keeps grouped issue open 3'] = {
+  "state": "closed"
 }

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -61,10 +61,14 @@ function nockNewIssue(repo: string) {
     .reply(200);
 }
 
-function nockGetIssueComments(repo: string, issueNumber: number) {
+function nockGetIssueComments(
+  repo: string,
+  issueNumber: number,
+  comments: Array<{}> = []
+) {
   return nock('https://api.github.com')
     .get(`/repos/GoogleCloudPlatform/${repo}/issues/${issueNumber}/comments`)
-    .reply(200, []);
+    .reply(200, comments);
 }
 
 function nockIssueComment(repo: string, issueNumber: number) {
@@ -992,6 +996,128 @@ describe('buildcop', () => {
         await probot.receive({name: 'pubsub.message', payload, id: 'abc123'});
 
         scopes.forEach(s => s.done());
+      });
+
+      describe('Grouped issues', () => {
+        it('opens a single issue for many tests in the same package', async () => {
+          const payload = buildPayload('node_group.xml', 'nodejs-spanner');
+
+          const scopes = [
+            nockIssues('nodejs-spanner', [
+              {
+                // Should be referenced as #8 in snapshot.
+                title: buildcop.formatTestCase({
+                  passed: false,
+                  package: 'Spanner',
+                  testCase:
+                    'should delete and then insert rows in the example tables',
+                }),
+                number: 8,
+                body: 'Failed',
+                state: 'open,',
+              },
+            ]),
+            nockNewIssue('nodejs-spanner'),
+          ];
+
+          await probot.receive({name: 'pubsub.message', payload, id: 'abc123'});
+
+          scopes.forEach(s => s.done());
+        });
+
+        it('closes an individual issue and keeps grouped issue open', async () => {
+          const payload = buildPayload('node_group.xml', 'nodejs-spanner');
+
+          const scopes = [
+            nockIssues('nodejs-spanner', [
+              {
+                title: buildcop.formatTestCase({
+                  passed: false,
+                  package: 'Spanner',
+                  testCase: 'should create an example database',
+                }),
+                number: 9,
+                body: 'Failed',
+                state: 'open,',
+              },
+              {
+                title: buildcop.formatGroupedTitle('Spanner'),
+                number: 10,
+                body: 'Group failure!',
+                state: 'open',
+              },
+            ]),
+            nockGetIssueComments('nodejs-spanner', 10),
+            nockIssueComment('nodejs-spanner', 10),
+            nockGetIssueComments('nodejs-spanner', 9),
+            nockIssueComment('nodejs-spanner', 9),
+            nockIssuePatch('nodejs-spanner', 9),
+          ];
+
+          await probot.receive({name: 'pubsub.message', payload, id: 'abc123'});
+
+          scopes.forEach(s => s.done());
+        });
+
+        it('does not duplicate comment on grouped issue', async () => {
+          const payload = buildPayload('node_group.xml', 'nodejs-spanner');
+
+          const testCase = buildcop.groupedTestCase('Spanner');
+          const scopes = [
+            nockIssues('nodejs-spanner', [
+              {
+                title: buildcop.formatGroupedTitle('Spanner'),
+                number: 10,
+                body: 'Group failure!',
+                state: 'open',
+              },
+            ]),
+            nockGetIssueComments('nodejs-spanner', 10, [
+              {
+                body: buildcop.formatBody(testCase, '123', 'build.url'),
+              },
+            ]),
+          ];
+
+          await probot.receive({name: 'pubsub.message', payload, id: 'abc123'});
+
+          scopes.forEach(s => s.done());
+        });
+
+        it('closes group issues when all tests pass', async () => {
+          const payload = buildPayload('node_group_pass.xml', 'nodejs-spanner');
+
+          const scopes = [
+            nockIssues('nodejs-spanner', [
+              {
+                title: buildcop.formatTestCase({
+                  passed: true,
+                  package: 'Spanner',
+                  testCase: 'should create an example database',
+                }),
+                number: 9,
+                body: 'Failed',
+                state: 'open,',
+              },
+              {
+                title: buildcop.formatGroupedTitle('Spanner'),
+                number: 10,
+                body: 'Group failure!',
+                state: 'open',
+              },
+            ]),
+            nockIssueComment('nodejs-spanner', 9),
+            nockGetIssueComments('nodejs-spanner', 9),
+            nockIssuePatch('nodejs-spanner', 9),
+            nockIssueComment('nodejs-spanner', 10),
+            nockGetIssueComments('nodejs-spanner', 10),
+            nockIssuePatch('nodejs-spanner', 10),
+          ];
+
+          await probot.receive({name: 'pubsub.message', payload, id: 'abc123'});
+
+          scopes.forEach(s => s.done());
+        });
       });
     });
   });

--- a/packages/buildcop/test/fixtures/testdata/node_group.xml
+++ b/packages/buildcop/test/fixtures/testdata/node_group.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Mocha Tests" tests="64" failures="0" errors="24" skipped="0" timestamp="Thu, 11 Jun 2020 22:41:07 GMT" time="885.891">
+    <testcase classname="Spanner" name="should create an example database" time="5.998"/>
+    <testcase classname="Spanner" name="should insert rows into an example table" time="3.121"/>
+    <testcase classname="Spanner" name="should delete and then insert rows in the example tables" time="3.578"><failure>expected &#x27;Deleted individual rows in Albums.\n5 records deleted from Singers.\n2 records deleted from Singers.\n0 records deleted from Singers.\n&#x27; to include &#x27;3 records deleted from Singers.&#x27;
+    AssertionError: expected &#x27;Deleted individual rows in Albums.\n5 records deleted from Singers.\n2 records deleted from Singers.\n0 records deleted from Singers.\n&#x27; to include &#x27;3 records deleted from Singers.&#x27;
+        at Context.it (system-test/spanner.test.js:198:12)</failure></testcase>
+    <testcase classname="Spanner" name="should query an example table and return matching rows" time="3.225"><failure>expected &#x27;&#x27; to match /SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk/
+    AssertionError: expected &#x27;&#x27; to match /SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk/
+        at Context.it (system-test/spanner.test.js:210:12)</failure></testcase>
+    <testcase classname="Spanner" name="should read an example table" time="3.237"><failure>expected &#x27;&#x27; to match /SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk/
+    AssertionError: expected &#x27;&#x27; to match /SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk/
+        at Context.it (system-test/spanner.test.js:218:12)</failure></testcase>
+    <testcase classname="Spanner" name="should add a column to a table" time="4.985"/>
+    <testcase classname="Spanner" name="should update existing rows in an example table" time="3.385"><failure>expected &#x27;&#x27; to match /Updated data\./
+    AssertionError: expected &#x27;&#x27; to match /Updated data\./
+        at Context.it (system-test/spanner.test.js:235:12)</failure></testcase>
+    <testcase classname="Spanner" name="should read stale data from an example table" time="19.328"><failure>expected &#x27;&#x27; to match /SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk, MarketingBudget: 100000/
+    AssertionError: expected &#x27;&#x27; to match /SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk, MarketingBudget: 100000/
+        at Context.it (system-test/spanner.test.js:246:12)</failure></testcase>
+    <testcase classname="Spanner" name="should query an example table with an additional column and return matching rows" time="3.44"><failure>expected &#x27;&#x27; to match /SingerId: 1, AlbumId: 1, MarketingBudget: 100000/
+    AssertionError: expected &#x27;&#x27; to match /SingerId: 1, AlbumId: 1, MarketingBudget: 100000/
+        at Context.it (system-test/spanner.test.js:261:12)</failure></testcase>
+    <testcase classname="Spanner" name="should create an index in an example table" time="18.709"/>
+    <testcase classname="Spanner" name="should create a storing index in an example table" time="18.87"/>
+    <testcase classname="Spanner" name="should query an example table with an index and return matching rows" time="3.286"><failure>expected &#x27;&#x27; to match /AlbumId: 2, AlbumTitle: Go, Go, Go, MarketingBudget:/
+    AssertionError: expected &#x27;&#x27; to match /AlbumId: 2, AlbumTitle: Go, Go, Go, MarketingBudget:/
+        at Context.it (system-test/spanner.test.js:288:12)</failure></testcase>
+    <testcase classname="Spanner" name="should respect query boundaries when querying an example table with an index" time="3.385"><failure>expected &#x27;&#x27; to match /AlbumId: 1, AlbumTitle: Total Junk, MarketingBudget:/
+    AssertionError: expected &#x27;&#x27; to match /AlbumId: 1, AlbumTitle: Total Junk, MarketingBudget:/
+        at Context.it (system-test/spanner.test.js:302:12)</failure></testcase>
+    <testcase classname="Spanner" name="should read an example table with an index" time="3.434"><failure>expected &#x27;&#x27; to match /AlbumId: 1, AlbumTitle: Total Junk/
+    AssertionError: expected &#x27;&#x27; to match /AlbumId: 1, AlbumTitle: Total Junk/
+        at Context.it (system-test/spanner.test.js:317:12)</failure></testcase>
+    <testcase classname="Spanner" name="should read an example table with a storing index" time="3.447"><failure>expected &#x27;&#x27; to match /AlbumId: 1, AlbumTitle: Total Junk/
+    AssertionError: expected &#x27;&#x27; to match /AlbumId: 1, AlbumTitle: Total Junk/
+        at Context.it (system-test/spanner.test.js:325:12)</failure></testcase>
+    <testcase classname="Spanner" name="should use query options from a database reference" time="3.229"><failure>expected &#x27;&#x27; to match /AlbumId: 2, AlbumTitle: Forever Hold your Peace, MarketingBudget:/
+    AssertionError: expected &#x27;&#x27; to match /AlbumId: 2, AlbumTitle: Forever Hold your Peace, MarketingBudget:/
+        at Context.it (system-test/spanner.test.js:333:12)</failure></testcase>
+    <testcase classname="Spanner" name="should use query options on request" time="3.336"><failure>expected &#x27;&#x27; to match /AlbumId: 2, AlbumTitle: Forever Hold your Peace, MarketingBudget:/
+    AssertionError: expected &#x27;&#x27; to match /AlbumId: 2, AlbumTitle: Forever Hold your Peace, MarketingBudget:/
+        at Context.it (system-test/spanner.test.js:344:12)</failure></testcase>
+    <testcase classname="Spanner" name="should read an example table using transactions" time="3.098"><failure>expected &#x27;Successfully executed read-only transaction.\n&#x27; to match /SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk/
+    AssertionError: expected &#x27;Successfully executed read-only transaction.\n&#x27; to match /SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk/
+        at Context.it (system-test/spanner.test.js:355:12)</failure></testcase>
+    <testcase classname="Spanner" name="should read from and write to an example table using transactions" time="3.141"><failure>expected &#x27;&#x27; to match /The first album&#x27;s marketing budget: 100000/
+    AssertionError: expected &#x27;&#x27; to match /The first album&#x27;s marketing budget: 100000/
+        at Context.it (system-test/spanner.test.js:364:12)</failure></testcase>
+    <testcase classname="Spanner" name="should create query partitions" time="4.283"/>
+    <testcase classname="Spanner" name="should execute a partition" time="3.801"/>
+    <testcase classname="Spanner" name="should add a timestamp column to a table" time="5.024"/>
+    <testcase classname="Spanner" name="should update existing rows in an example table with commit timestamp column" time="3.12"><failure>expected &#x27;&#x27; to match /Updated data\./
+    AssertionError: expected &#x27;&#x27; to match /Updated data\./
+        at Context.it (system-test/spanner.test.js:426:12)</failure></testcase>
+    <testcase classname="Spanner" name="should query an example table with an additional timestamp column and return matching rows" time="3.35"><failure>expected &#x27;&#x27; to match /SingerId: 1, AlbumId: 1, MarketingBudget: 1000000, LastUpdateTime:/
+    AssertionError: expected &#x27;&#x27; to match /SingerId: 1, AlbumId: 1, MarketingBudget: 1000000, LastUpdateTime:/
+        at Context.it (system-test/spanner.test.js:434:12)</failure></testcase>
+    <testcase classname="Spanner" name="should create an example table with a timestamp column" time="5.485"/>
+    <testcase classname="Spanner" name="should insert rows into an example table with timestamp column" time="3.398"><failure>expected &#x27;&#x27; to match /Inserted data\./
+    AssertionError: expected &#x27;&#x27; to match /Inserted data\./
+        at Context.it (system-test/spanner.test.js:465:12)</failure></testcase>
+    <testcase classname="Spanner" name="should query an example table with a non-null timestamp column and return matching rows" time="3.599"><failure>expected &#x27;&#x27; to match /SingerId: 1, VenueId: 4, EventDate:/
+    AssertionError: expected &#x27;&#x27; to match /SingerId: 1, VenueId: 4, EventDate:/
+        at Context.it (system-test/spanner.test.js:473:12)</failure></testcase>
+    <testcase classname="Spanner" name="should insert rows into an example table for use with struct query examples" time="3.552"/>
+    <testcase classname="Spanner" name="should query an example table with a STRUCT param" time="3.534"/>
+    <testcase classname="Spanner" name="should query an example table with an array of STRUCT param" time="3.046"/>
+    <testcase classname="Spanner" name="should query an example table with a STRUCT field param" time="3.443"/>
+    <testcase classname="Spanner" name="should query an example table with a nested STRUCT param" time="3.251"/>
+    <testcase classname="Spanner" name="should insert rows into an example table using a DML statement" time="3.192"/>
+    <testcase classname="Spanner" name="should update a row in an example table using a DML statement" time="3.531"><failure>expected &#x27;Successfully updated 0 record.\n&#x27; to match /Successfully updated 1 record/
+    AssertionError: expected &#x27;Successfully updated 0 record.\n&#x27; to match /Successfully updated 1 record/
+        at Context.it (system-test/spanner.test.js:536:12)</failure></testcase>
+    <testcase classname="Spanner" name="should delete a row from an example table using a DML statement" time="3.372"><failure>expected &#x27;Successfully deleted 0 record.\n&#x27; to match /Successfully deleted 1 record\./
+    AssertionError: expected &#x27;Successfully deleted 0 record.\n&#x27; to match /Successfully deleted 1 record\./
+        at Context.it (system-test/spanner.test.js:544:12)</failure></testcase>
+    <testcase classname="Spanner" name="should update the timestamp of multiple records in an example table using a DML statement" time="3.325"><failure>expected &#x27;Successfully updated 0 records.\n&#x27; to match /Successfully updated 2 records/
+    AssertionError: expected &#x27;Successfully updated 0 records.\n&#x27; to match /Successfully updated 2 records/
+        at Context.it (system-test/spanner.test.js:552:12)</failure></testcase>
+    <testcase classname="Spanner" name="should insert a record in an example table using a DML statement and then query the record" time="3.367"/>
+    <testcase classname="Spanner" name="should update a record in an example table using a DML statement along with a struct value" time="3.261"/>
+    <testcase classname="Spanner" name="should insert multiple records into an example table using a DML statement" time="3.11"/>
+    <testcase classname="Spanner" name="should use a parameter query to query record that was inserted using a DML statement" time="3.162"/>
+    <testcase classname="Spanner" name="should transfer value from one record to another using DML statements within a transaction" time="3.547"><failure>expected &#x27;&#x27; to match /Successfully executed read-write transaction using DML to transfer 200000 from Album 2 to Album 1/
+    AssertionError: expected &#x27;&#x27; to match /Successfully executed read-write transaction using DML to transfer 200000 from Album 2 to Album 1/
+        at Context.it (system-test/spanner.test.js:592:12)</failure></testcase>
+    <testcase classname="Spanner" name="should update multiple records using a partitioned DML statement" time="3.097"><failure>expected &#x27;Successfully updated 0 records.\n&#x27; to match /Successfully updated 3 records/
+    AssertionError: expected &#x27;Successfully updated 0 records.\n&#x27; to match /Successfully updated 3 records/
+        at Context.it (system-test/spanner.test.js:603:12)</failure></testcase>
+    <testcase classname="Spanner" name="should delete multiple records using a partitioned DML statement" time="3.345"/>
+    <testcase classname="Spanner" name="should insert and update records using Batch DML" time="1.749"><failure>Command failed: node dml.js updateUsingBatchDml test-instance-1591914381325 test-database-1591914381325 long-door-651
+    ERROR: { Error: Parent row for row [1,3] in table Albums is missing. Row cannot be written.
+        at Immediate.request (/tmpfs/src/github/nodejs-spanner/build/src/transaction.js:1082:31)
+        at runCallback (timers.js:706:11)
+        at tryOnImmediate (timers.js:676:5)
+        at processImmediate (timers.js:658:5)
+      code: 5,
+      metadata: Metadata { internalRepr: Map {}, options: {} },
+      rowCounts: [] }
+    dml.js updateUsingBatchDml &#x3C;instanceName&#x3E; &#x3C;databaseName&#x3E; &#x3C;projectId&#x3E;
+    
+    Insert and Update records using Batch DML.
+    
+    Options:
+      --version  Show version number                                                                               [boolean]
+      --help     Show help                                                                                         [boolean]
+    
+    { Error: Parent row for row [1,3] in table Albums is missing. Row cannot be written.
+        at Immediate.request (/tmpfs/src/github/nodejs-spanner/build/src/transaction.js:1082:31)
+        at runCallback (timers.js:706:11)
+        at tryOnImmediate (timers.js:676:5)
+        at processImmediate (timers.js:658:5)
+      code: 5,
+      metadata: Metadata { internalRepr: Map {}, options: {} },
+      rowCounts: [] }
+    
+    Error: Command failed: node dml.js updateUsingBatchDml test-instance-1591914381325 test-database-1591914381325 long-door-651
+    ERROR: { Error: Parent row for row [1,3] in table Albums is missing. Row cannot be written.
+        at Immediate.request (/tmpfs/src/github/nodejs-spanner/build/src/transaction.js:1082:31)
+      code: 5,
+      metadata: Metadata { internalRepr: Map {}, options: {} },
+      rowCounts: [] }
+    dml.js updateUsingBatchDml &#x3C;instanceName&#x3E; &#x3C;databaseName&#x3E; &#x3C;projectId&#x3E;
+    
+    Insert and Update records using Batch DML.
+    
+    Options:
+      --version  Show version number                                                                               [boolean]
+      --help     Show help                                                                                         [boolean]
+    
+    { Error: Parent row for row [1,3] in table Albums is missing. Row cannot be written.
+        at Immediate.request (/tmpfs/src/github/nodejs-spanner/build/src/transaction.js:1082:31)
+      code: 5,
+      metadata: Metadata { internalRepr: Map {}, options: {} },
+      rowCounts: [] }
+    
+        at checkExecSyncError (child_process.js:629:11)
+        at Object.execSync (child_process.js:666:13)
+        at execSync (system-test/spanner.test.js:23:28)
+        at Context.it (system-test/spanner.test.js:616:20)</failure></testcase>
+    <testcase classname="Spanner" name="should create Venues example table with supported datatype columns" time="5.168"/>
+    <testcase classname="Spanner" name="should insert multiple records into Venues example table" time="3.113"/>
+    <testcase classname="Spanner" name="should use an ARRAY query parameter to query record from the Venues example table" time="2.918"/>
+    <testcase classname="Spanner" name="should use a BOOL query parameter to query record from the Venues example table" time="3.216"/>
+    <testcase classname="Spanner" name="should use a BYTES query parameter to query record from the Venues example table" time="3.43"/>
+    <testcase classname="Spanner" name="should use a DATE query parameter to query record from the Venues example table" time="3.225"/>
+    <testcase classname="Spanner" name="should use a FLOAT64 query parameter to query record from the Venues example table" time="3.07"/>
+    <testcase classname="Spanner" name="should use a INT64 query parameter to query record from the Venues example table" time="3.259"/>
+    <testcase classname="Spanner" name="should use a STRING query parameter to query record from the Venues example table" time="3.224"/>
+    <testcase classname="Spanner" name="should use a TIMESTAMP query parameter to query record from the Venues example table" time="3.309"/>
+    <testcase classname="Spanner" name="should create a backup of the database" time="184.743"/>
+    <testcase classname="Spanner" name="should cancel a backup of the database" time="9.671"/>
+    <testcase classname="Spanner" name="should list backups in the instance" time="3.039"/>
+    <testcase classname="Spanner" name="should list backup operations in the instance" time="3.297"/>
+    <testcase classname="Spanner" name="should update the expire time of a backup" time="3.151"/>
+    <testcase classname="Spanner" name="should restore database from a backup" time="420.033"/>
+    <testcase classname="Spanner" name="should list database operations in the instance" time="3.573"/>
+    <testcase classname="Spanner" name="should delete a backup" time="3.497"/>
+    <testcase classname="Spanner instance" name="should create an example instance" time="3.621"/>
+    <testcase classname="Spanner quickstart" name="should query a table" time="3.269"/>
+    </testsuite>

--- a/packages/buildcop/test/fixtures/testdata/node_group_pass.xml
+++ b/packages/buildcop/test/fixtures/testdata/node_group_pass.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<testsuite name="Mocha Tests" tests="64" failures="0" errors="24" skipped="0" timestamp="Thu, 11 Jun 2020 22:41:07 GMT" time="885.891">
+    <testcase classname="Spanner" name="should create an example database" time="5.998"/>
+</testsuite>


### PR DESCRIPTION
If the common setup code for 100 tests fails, in some cases all 100 tests with "fail." Before this change, the bot would file a separate issue for each of those tests, which was very annoying.

This change groups tests into a single issue when 10 or more fail in a single build.

I made the choice to leave existing individual issues open when opening a "grouped" issue. People may be actively discussing a broken test in one of the issues; it would be rude if the bot decided to close the existing issue and end the discussion.

Note: I refactored some of the existing logic into a `findExistingIssue` function. The diff does not make that very clear.

Areas to watch out for in review:
* The choice to leave existing issues open.
* README docs, the grouped issue body, and grouped issue comments. Are they helpful and clear?
* Test coverage -- missing any edge cases that should be tested?
* I'm always open to JS/TS/Node.js style advice.
* And, you know, bugs. :smile: 

Fixes #550
