### PR TITLE
feat(sync-repo-settings): allow configuring extra team permissions by language

### DIFF
--- a/packages/sync-repo-settings/src/required-checks.json
+++ b/packages/sync-repo-settings/src/required-checks.json
@@ -20,6 +20,12 @@
       "GoogleCloudPlatform/java-docs-samples",
       "GoogleCloudPlatform/getting-started-java"
     ],
+    "additionalTeams": [
+      {
+          "slug": "java-samples-reviewers",
+          "permission": "push"
+      }
+    ],
     "repoOverrides": [
       {
         "repo": "googleapis/java-cloud-bom",

--- a/packages/sync-repo-settings/test/fixtures/repos.json
+++ b/packages/sync-repo-settings/test/fixtures/repos.json
@@ -3,6 +3,7 @@
     { "language": "kotlin", "repo": "Codertocat/Hello-World"},
     { "language": "nodejs", "repo": "googleapis/nodejs-dialogflow"},
     { "language": "java", "repo": "googleapis/api-common-java"},
-    { "language": "java", "repo": "googleapis/google-api-java-client"}
+    { "language": "java", "repo": "googleapis/google-api-java-client"},
+    { "language": "java", "repo": "googleapis/java-asset"}
   ]
 }

--- a/packages/sync-repo-settings/test/test.ts
+++ b/packages/sync-repo-settings/test/test.ts
@@ -263,4 +263,47 @@ describe('Sync repo settings', () => {
     });
     scopes.forEach(s => s.done());
   });
+
+  it('should add extra teams specified in teams.json', async () => {
+    const scopes = [
+      nockUpdateRepoSettings('java-asset', false, true),
+      nockUpdateBranchProtection(
+        'java-asset',
+        [
+          'dependencies',
+          'linkage-monitor',
+          'lint',
+          'clirr',
+          'units (7)',
+          'units (8)',
+          'units (11)',
+          'Kokoro - Test: Integration',
+          'cla/google',
+        ],
+        false
+      ),
+      nockUpdateTeamMembership('yoshi-admins', 'googleapis', 'java-asset'),
+      nockUpdateTeamMembership('yoshi-java-admins', 'googleapis', 'java-asset'),
+      nockUpdateTeamMembership('yoshi-java', 'googleapis', 'java-asset'),
+      nockUpdateTeamMembership(
+        'java-samples-reviewers',
+        'googleapis',
+        'java-asset'
+      ),
+    ];
+    await probot.receive({
+      name: 'schedule.repository',
+      payload: {
+        repository: {
+          name: 'java-asset',
+        },
+        organization: {
+          login: 'googleapis',
+        },
+        cron_org: 'googleapis',
+      },
+      id: 'abc123',
+    });
+    scopes.forEach(s => s.done());
+  });
 });


### PR DESCRIPTION
Alternative to #601 

Instead, puts the configuration into required-checks.json which is a misnomer now.
