### PR TITLE
refactor(failurechecker): clean up dependencies and exports

### DIFF
--- a/packages/failurechecker/.gitignore
+++ b/packages/failurechecker/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+coverage/
+build/

--- a/packages/failurechecker/package.json
+++ b/packages/failurechecker/package.json
@@ -28,12 +28,10 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "1.6.1",
-    "moment": "2.27.0"
+    "gcf-utils": "1.6.1"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.6",
-    "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.0",
     "@types/ioredis": "^4.0.13",
     "@types/lru-cache": "^5.1.0",
@@ -43,7 +41,6 @@
     "@types/sinon": "^9.0.4",
     "c8": "^7.1.0",
     "cross-env": "^7.0.0",
-    "dotenv": "^8.0.0",
     "gts": "^2.0.0",
     "mocha": "^8.0.0",
     "nock": "^13.0.0",

--- a/packages/failurechecker/package.json
+++ b/packages/failurechecker/package.json
@@ -32,9 +32,7 @@
     "moment": "2.27.0"
   },
   "devDependencies": {
-    "@types/body-parser": "^1.17.0",
     "@types/bunyan": "^1.8.6",
-    "@types/chai": "^4.1.7",
     "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.0",
     "@types/ioredis": "^4.0.13",
@@ -42,14 +40,14 @@
     "@types/mocha": "^7.0.0",
     "@types/nock": "^10.0.3",
     "@types/node": "^12.6.1",
-    "body-parser": "^1.19.0",
+    "@types/sinon": "^9.0.4",
     "c8": "^7.1.0",
-    "chai": "^4.2.0",
     "cross-env": "^7.0.0",
     "dotenv": "^8.0.0",
     "gts": "^2.0.0",
     "mocha": "^8.0.0",
     "nock": "^13.0.0",
+    "sinon": "^9.0.2",
     "smee-client": "^1.1.0",
     "snap-shot-it": "^7.8.0",
     "typescript": "^3.5.3"

--- a/packages/failurechecker/package.json
+++ b/packages/failurechecker/package.json
@@ -28,7 +28,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "1.6.1"
+    "gcf-utils": "5.0.1"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.6",

--- a/packages/failurechecker/src/app.ts
+++ b/packages/failurechecker/src/app.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {GCFBootstrapper} from 'gcf-utils';
-import appFn from './failurechecker';
+import {failureChecker} from './failurechecker';
 
 const bootstrap = new GCFBootstrapper();
-module.exports.failurechecker = bootstrap.gcf(appFn);
+module.exports.failurechecker = bootstrap.gcf(failureChecker);

--- a/packages/failurechecker/src/failurechecker.ts
+++ b/packages/failurechecker/src/failurechecker.ts
@@ -18,7 +18,6 @@
 
 // eslint-disable-next-line node/no-extraneous-import
 import {Application} from 'probot';
-import * as moment from 'moment';
 // eslint-disable-next-line node/no-extraneous-import
 import {GitHubAPI} from 'probot/lib/github';
 // labels indicative of the fact that a release has not completed yet.
@@ -35,9 +34,9 @@ const WARNING_THRESHOLD = 60 * 60 * 3 * 1000;
 const END_HOUR_UTC = 3;
 const START_HOUR_UTC = 17;
 
-const failureChecker = (app: Application) => {
+export function failureChecker(app: Application) {
   app.on(['schedule.repository'], async context => {
-    const utcHour: number = failureChecker.utcHour();
+    const utcHour = new Date().getUTCHours();
     const owner = context.payload.organization.login;
     const repo = context.payload.repository.name;
 
@@ -121,10 +120,4 @@ const failureChecker = (app: Application) => {
       labels: LABELS.split(','),
     });
   }
-};
-
-failureChecker.utcHour = () => {
-  return moment.utc().hour();
-};
-
-export = failureChecker;
+}

--- a/packages/failurechecker/test/failurechecker.ts
+++ b/packages/failurechecker/test/failurechecker.ts
@@ -31,7 +31,7 @@ describe('failurechecker', () => {
       // use a bare instance of octokit, the default version
       // enables retries which makes testing difficult.
       // eslint-disable-next-line node/no-extraneous-require
-      Octokit: require('@octokit/rest'),
+      Octokit: require('@octokit/rest').Octokit,
     });
     probot.app = {
       getSignedJsonWebToken() {


### PR DESCRIPTION
This is me poking at a few things which may not need to be poked.  For some reason I'm bothered by the way we need to pin all of the exportable methods to a single function.  It makes the code harder to read in other bots.  I kind of wanted to test this out here, and see if I could make things work without doing it.  Someone please check me to make sure I'm not breaking something :)

Second - cleaning up some dependencies.  