### PR TITLE
fix(gcf-utils): prepackage required type modules and interfaces

### DIFF
--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -22,6 +22,11 @@
     "@google-cloud/secret-manager": "^3.0.0",
     "@google-cloud/storage": "^5.0.0",
     "@google-cloud/tasks": "^2.0.0",
+    "@types/bunyan": "^1.8.6",
+    "@types/dotenv": "^6.1.1",
+    "@types/express": "^4.17.0",
+    "@types/ioredis": "^4.14.8",
+    "@types/lru-cache": "^5.1.0",
     "@octokit/plugin-enterprise-compatibility": "1.2.5",
     "express": "^4.17.1",
     "gaxios": "^3.0.0",
@@ -30,11 +35,6 @@
     "yargs": "^15.0.0"
   },
   "devDependencies": {
-    "@types/bunyan": "^1.8.6",
-    "@types/dotenv": "^6.1.1",
-    "@types/express": "^4.17.0",
-    "@types/ioredis": "^4.14.8",
-    "@types/lru-cache": "^5.1.0",
     "@types/mocha": "^7.0.0",
     "@types/node": "^12.6.1",
     "@types/sinon": "^9.0.0",

--- a/packages/gcf-utils/src/promise-events.ts
+++ b/packages/gcf-utils/src/promise-events.ts
@@ -15,6 +15,7 @@
 // define types for a few modules used by probot that do not have their
 // own definitions published. Before taking this step, folks should first
 // check whether type bindings are already published.
+
 declare module 'promise-events' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   class EventEmitter {}


### PR DESCRIPTION
Takes a collection of `@types` modules, and moves them from `devDependencies`
into `dependencies`.  Every bot we were building needed to randomly `npm install`
these dependencies, and it was leading to a general confusion about what was
actually required.

I also moved the promise events type information from a `d.ts` into a `.ts` file.
This ensures the interface gets packaged in a `d.ts` in the `build/src` dir,
and means we can delete this file from every other package.  After this version of
`gcf-utils` ships, we can run around and delete all of the `index.d.ts` files,
and remove a bunch of dependencies from `package.json` across the board.