### PR TITLE
fix(gcf-utils): populate repository.owner

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -242,8 +242,8 @@ export class GCFBootstrapper {
         name: repoName,
         full_name: repoFullName,
         owner: {
-          login: orgName
-        }
+          login: orgName,
+        },
       },
       organization: {
         login: orgName,

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -241,6 +241,9 @@ export class GCFBootstrapper {
       repository: {
         name: repoName,
         full_name: repoFullName,
+        owner: {
+          login: orgName
+        }
       },
       organization: {
         login: orgName,


### PR DESCRIPTION
This field is used when fetching config.