### PR TITLE
fix: paginate result set when listing installations

### DIFF
--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcf-utils",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "An extension for running Probot in Google Cloud Functions",
   "scripts": {
     "compile": "tsc -p .",

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -203,19 +203,22 @@ export class GCFBootstrapper {
         auth: await this.getInstallationToken(body.installation.id),
       });
       // Installations API documented here: https://developer.github.com/v3/apps/installations/
-      const {data} = await octokit.request('/installation/repositories', {
+      for await (const response of octokit.paginate.iterator({
+        url: '/installation/repositories',
+        method: 'GET',
         headers: {
           Accept: 'application/vnd.github.machine-man-preview+json',
         },
-      });
-      for (const repo of data.repositories) {
-        await this.scheduledToTask(
-          repo.full_name,
-          id,
-          body,
-          eventName,
-          signature
-        );
+      })) {
+        for (const repo of response.data) {
+          await this.scheduledToTask(
+            repo.full_name,
+            id,
+            body,
+            eventName,
+            signature
+          );
+        }
       }
     }
   }

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -203,13 +203,14 @@ export class GCFBootstrapper {
         auth: await this.getInstallationToken(body.installation.id),
       });
       // Installations API documented here: https://developer.github.com/v3/apps/installations/
-      for await (const response of octokit.paginate.iterator({
+      const installationsPaginated = octokit.paginate.iterator({
         url: '/installation/repositories',
         method: 'GET',
         headers: {
           Accept: 'application/vnd.github.machine-man-preview+json',
         },
-      })) {
+      });
+      for await (const response of installationsPaginated) {
         for (const repo of response.data) {
           await this.scheduledToTask(
             repo.full_name,


### PR DESCRIPTION
we were not paginating over all repos, so we would have only had a partial result set.
