### PR TITLE
feat(buildcop): use tested config type

### DIFF
--- a/packages/buildcop/buildcop.go
+++ b/packages/buildcop/buildcop.go
@@ -97,7 +97,6 @@ type config struct {
 	commit         string
 	logsDir        string
 	serviceAccount string
-	buildURL       string
 }
 
 func (cfg *config) setDefaults() (ok bool) {

--- a/packages/buildcop/buildcop.go
+++ b/packages/buildcop/buildcop.go
@@ -51,11 +51,26 @@ func main() {
 
 	flag.Parse()
 
-	log.Println("Sending logs to Build Cop Bot...")
-	log.Println("See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.")
-	if ok := publish(*projectID, *topicID, *repo, *installationID, *commit, *logsDir, *serviceAccount); !ok {
+	cfg := &config{
+		projectID:      *projectID,
+		topicID:        *topicID,
+		repo:           *repo,
+		installationID: *installationID,
+		commit:         *commit,
+		logsDir:        *logsDir,
+		serviceAccount: *serviceAccount,
+	}
+	if ok := cfg.setDefaults(); !ok {
 		os.Exit(1)
 	}
+
+	log.Println("Sending logs to Build Cop Bot...")
+	log.Println("See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.")
+
+	if ok := publish(cfg); !ok {
+		os.Exit(1)
+	}
+
 	log.Println("Done!")
 }
 
@@ -74,65 +89,87 @@ type message struct {
 	XUnitXML     string             `json:"xunitXML"`
 }
 
-// publish searches for sponge_log.xml files and publishes them to Pub/Sub.
-// publish logs a message and returns false if there was an error.
-func publish(projectID, topicID, repo, installationID, commit, logsDir, serviceAccount string) (ok bool) {
-	ctx := context.Background()
+type config struct {
+	projectID      string
+	topicID        string
+	repo           string
+	installationID string
+	commit         string
+	logsDir        string
+	serviceAccount string
+	buildURL       string
+}
 
-	opts := []option.ClientOption{}
-
-	if serviceAccount == "" {
+func (cfg *config) setDefaults() (ok bool) {
+	if cfg.serviceAccount == "" {
 		if gfileDir := os.Getenv("KOKORO_GFILE_DIR"); gfileDir != "" {
-			serviceAccount = filepath.Join(gfileDir, "kokoro-trampoline.service-account.json")
-			if _, err := os.Stat(serviceAccount); err == nil {
-				opts = append(opts, option.WithCredentialsFile(serviceAccount))
+			path := filepath.Join(gfileDir, "kokoro-trampoline.service-account.json")
+			// Assume any given service account exists, but check the Trampoline
+			// account exists before trying to use it (instead of default
+			// credentials).
+			if _, err := os.Stat(path); err == nil {
+				cfg.serviceAccount = path
 			}
 		}
 	}
 
-	client, err := pubsub.NewClient(ctx, projectID, opts...)
-	if err != nil {
-		log.Printf("Unable to connect to Pub/Sub: %v", err)
-		return false
+	if cfg.repo == "" {
+		cfg.repo = detectRepo()
 	}
-	topic := client.Topic(topicID)
-
-	if repo == "" {
-		repo = detectRepo()
-		if repo == "" {
-			log.Print(`Unable to detect repo. Please set the --repo flag.
+	if cfg.repo == "" {
+		log.Printf(`Unable to detect repo. Please set the --repo flag.
 If your repo is github.com/GoogleCloudPlatform/golang-samples, --repo should be GoogleCloudPlatform/golang-samples.
 
 If your repo is not in GoogleCloudPlatform or googleapis, you must also set
 --installation_id. See https://github.com/apps/build-cop-bot/.`)
-			return false
-		}
+		return false
 	}
 
-	if installationID == "" {
-		installationID = detectInstallationID(repo)
-		if installationID == "" {
-			log.Printf(`Unable to detect installation ID from repo=%q. Please set the --installation_id flag.
+	if cfg.installationID == "" {
+		cfg.installationID = detectInstallationID(cfg.repo)
+	}
+	if cfg.installationID == "" {
+		log.Printf(`Unable to detect installation ID from repo=%q. Please set the --installation_id flag.
 If your repo is part of GoogleCloudPlatform or googleapis and you see this error,
 file an issue at https://github.com/googleapis/repo-automation-bots/issues.
 Otherwise, set --installation_id with the numeric installation ID.
-See https://github.com/apps/build-cop-bot/.`, repo)
-			return false
-		}
+See https://github.com/apps/build-cop-bot/.`, cfg.repo)
+		return false
 	}
 
-	if commit == "" {
-		commit = os.Getenv("KOKORO_GIT_COMMIT")
-		if commit == "" {
-			log.Printf(`Unable to detect commit hash (expected the KOKORO_GIT_COMMIT env var).
+	if cfg.commit == "" {
+		cfg.commit = os.Getenv("KOKORO_GIT_COMMIT")
+	}
+	if cfg.commit == "" {
+		log.Printf(`Unable to detect commit hash (expected the KOKORO_GIT_COMMIT env var).
 Please set --commit_hash to the latest git commit hash.
 See https://github.com/apps/build-cop-bot/.`)
-			return false
-		}
+		return false
 	}
 
+	return true
+}
+
+// publish searches for sponge_log.xml files and publishes them to Pub/Sub.
+// publish logs a message and returns false if there was an error.
+func publish(cfg *config) (ok bool) {
+	ctx := context.Background()
+
+	opts := []option.ClientOption{}
+
+	if cfg.serviceAccount != "" {
+		opts = append(opts, option.WithCredentialsFile(cfg.serviceAccount))
+	}
+
+	client, err := pubsub.NewClient(ctx, cfg.projectID, opts...)
+	if err != nil {
+		log.Printf("Unable to connect to Pub/Sub: %v", err)
+		return false
+	}
+	topic := client.Topic(cfg.topicID)
+
 	// Handle logs in the current directory.
-	if err := filepath.Walk(logsDir, processLog(ctx, repo, installationID, commit, topic)); err != nil {
+	if err := filepath.Walk(cfg.logsDir, processLog(ctx, cfg, topic)); err != nil {
 		log.Printf("Error publishing logs: %v", err)
 		return false
 	}
@@ -173,7 +210,7 @@ func detectInstallationID(repo string) string {
 }
 
 // processLog is used to process log files and publish them to Pub/Sub.
-func processLog(ctx context.Context, repo, installationID, commit string, topic *pubsub.Topic) filepath.WalkFunc {
+func processLog(ctx context.Context, cfg *config, topic *pubsub.Topic) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -191,9 +228,9 @@ func processLog(ctx context.Context, repo, installationID, commit string, topic 
 			Name:         "buildcop",
 			Type:         "function",
 			Location:     "us-central1",
-			Installation: githubInstallation{ID: installationID},
-			Repo:         repo,
-			Commit:       commit,
+			Installation: githubInstallation{ID: cfg.installationID},
+			Repo:         cfg.repo,
+			Commit:       cfg.commit,
 			BuildURL:     buildURL,
 			XUnitXML:     enc,
 		}

--- a/packages/buildcop/buildcop_test.go
+++ b/packages/buildcop/buildcop_test.go
@@ -24,6 +24,83 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestSetDefaults(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stderr)
+
+	tests := []struct {
+		name   string
+		env    map[string]string
+		in     *config
+		want   *config
+		wantOK bool
+	}{
+		{
+			name: "detect repo and installationID",
+			env: map[string]string{
+				"KOKORO_GITHUB_COMMIT_URL": "https://github.com/GoogleCloudPlatform/golang-samples/commit/1234",
+			},
+			in: &config{
+				commit: "abc123",
+			},
+			want: &config{
+				repo:           "GoogleCloudPlatform/golang-samples",
+				installationID: "5943459",
+				commit:         "abc123",
+			},
+			wantOK: true,
+		},
+		{
+			name: "detect commit",
+			env: map[string]string{
+				"KOKORO_GIT_COMMIT": "abc123",
+			},
+			in: &config{
+				repo:           "GoogleCloudPlatform/golang-samples",
+				installationID: "5943459",
+			},
+			want: &config{
+				repo:           "GoogleCloudPlatform/golang-samples",
+				installationID: "5943459",
+				commit:         "abc123",
+			},
+			wantOK: true,
+		},
+		{
+			name:   "empty config and env",
+			in:     &config{},
+			wantOK: false,
+		},
+		{
+			name: "missing commit",
+			in: &config{
+				repo:           "repo",
+				installationID: "123",
+			},
+			wantOK: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for k, v := range test.env {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
+			cfg := test.in
+			if ok := cfg.setDefaults(); ok != test.wantOK {
+				t.Fatalf("setDefaults got ok=%v, want ok=%v", ok, test.wantOK)
+			}
+			if !test.wantOK {
+				return
+			}
+			if diff := cmp.Diff(cfg, test.want, cmp.AllowUnexported(config{})); diff != "" {
+				t.Errorf("newConfig got %+v, want %+v. Diff (+want, -got):\n%s", cfg, test.want, diff)
+			}
+		})
+	}
+}
+
 func TestDetectRepo(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stderr)


### PR DESCRIPTION
I'm not 100% sure of this design. So, I'm open to other ideas. Perhaps we should put the long error message in a custom error type?

I thought about having `func newConfig`, but that had the same issue of having too many arguments and being confusing.

We could also use something like Viper, but it doesn't seem necessary.