### PR TITLE
fix(buildcop): add extra newline to prevent title formatting

### DIFF
--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -242,7 +242,7 @@ exports['buildcop app xunitXML Grouped issues closes group issues when all tests
 }
 
 exports['buildcop app xunitXML Grouped issues closes an individual issue and keeps grouped issue open 1'] = {
-  "body": "24 tests failed in this package for commit 123 (http://example.com).\n-----\ncommit: 123\nbuildURL: http://example.com\nstatus: failed"
+  "body": "24 tests failed in this package for commit 123 (http://example.com).\n\n-----\ncommit: 123\nbuildURL: http://example.com\nstatus: failed"
 }
 
 exports['buildcop app xunitXML Grouped issues closes an individual issue and keeps grouped issue open 2'] = {

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -298,7 +298,7 @@ buildcop.openIssues = async (
       const testString = pkgFailures.length === 1 ? 'test' : 'tests';
       const body = `${
         pkgFailures.length
-      } ${testString} failed in this package for commit ${commit} (${buildURL}).\n-----\n${buildcop.formatBody(
+      } ${testString} failed in this package for commit ${commit} (${buildURL}).\n\n-----\n${buildcop.formatBody(
         testCase,
         commit,
         buildURL


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-go/issues/2571#issuecomment-656331671 for an example of the accidental title formatting.