### PR TITLE
fix(release-please): default to java language for snapshots

### DIFF
--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -198,7 +198,7 @@ export = (app: Application) => {
 
     const releaseType = configuration.releaseType
       ? configuration.releaseType
-      : 'java';
+      : 'java-yoshi';
 
     // TODO: this should be refactored into an interface.
     await createReleasePR(

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -198,7 +198,7 @@ export = (app: Application) => {
 
     const releaseType = configuration.releaseType
       ? configuration.releaseType
-      : releaseTypeFromRepoLanguage(context.payload.repository.language);
+      : 'java';
 
     // TODO: this should be refactored into an interface.
     await createReleasePR(

--- a/packages/release-please/test/release-please.ts
+++ b/packages/release-please/test/release-please.ts
@@ -296,7 +296,6 @@ describe('ReleasePleaseBot', () => {
           owner: {
             login: 'Codertocat',
           },
-          language: 'Ruby',
         },
         organization: {
           login: 'Codertocat',
@@ -304,7 +303,7 @@ describe('ReleasePleaseBot', () => {
         cron_org: 'Codertocat',
       };
       Runner.runner = async (pr: ReleasePR) => {
-        assert(pr instanceof Ruby);
+        assert(pr instanceof JavaYoshi);
         executed = true;
       };
       const config = fs.readFileSync(


### PR DESCRIPTION
The cron task does not (_currently, see [tracking issue](https://github.com/googleapis/repo-automation-bots/issues/676)_) populate all repo meta data, like repo language.

For now, we can assume that snapshots are being created for Java.