### PR TITLE
fix(gcf-utils): add missing dev dependency @types/sonic-boom

### DIFF
--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -42,6 +42,7 @@
     "@types/tmp": "^0.2.0",
     "@types/yargs": "^15.0.0",
     "@types/pino": "^6.3.0",
+    "@types/sonic-boom": "^0.7.0",
     "c8": "^7.1.0",
     "cross-env": "^7.0.0",
     "dotenv": "^8.0.0",


### PR DESCRIPTION
`@types/sonic-boom` is required to compile gcf-utils and is therefore required as a devDependency.

Fixes https://github.com/googleapis/repo-automation-bots/issues/697