### PR TITLE
feat(gcf-utils): some bots have large payloads not appropriate for cloud task payload 

### DIFF
--- a/packages/buildcop/package.json
+++ b/packages/buildcop/package.json
@@ -28,7 +28,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "5.0.1",
+    "gcf-utils": "^5.2.2",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/packages/buildcop/src/app.ts
+++ b/packages/buildcop/src/app.ts
@@ -16,4 +16,6 @@ import {GCFBootstrapper} from 'gcf-utils';
 import {buildcop} from './buildcop';
 
 const bootstrap = new GCFBootstrapper();
-module.exports.buildcop = bootstrap.gcf(buildcop);
+module.exports.buildcop = bootstrap.gcf(buildcop, {
+  background: false
+});

--- a/packages/buildcop/src/app.ts
+++ b/packages/buildcop/src/app.ts
@@ -17,5 +17,5 @@ import {buildcop} from './buildcop';
 
 const bootstrap = new GCFBootstrapper();
 module.exports.buildcop = bootstrap.gcf(buildcop, {
-  background: false
+  background: false,
 });

--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcf-utils",
-  "version": "5.1.0",
+  "version": "5.2.2",
   "description": "An extension for running Probot in Google Cloud Functions",
   "scripts": {
     "compile": "tsc -p .",
@@ -27,6 +27,7 @@
     "@types/express": "^4.17.0",
     "@types/ioredis": "^4.14.8",
     "@types/lru-cache": "^5.1.0",
+    "@types/sonic-boom": "^0.7.0",
     "@octokit/plugin-enterprise-compatibility": "1.2.5",
     "express": "^4.17.1",
     "gaxios": "^3.0.0",
@@ -38,11 +39,10 @@
   "devDependencies": {
     "@types/mocha": "^8.0.0",
     "@types/node": "^12.6.1",
+    "@types/pino": "^6.3.0",
     "@types/sinon": "^9.0.0",
     "@types/tmp": "^0.2.0",
     "@types/yargs": "^15.0.0",
-    "@types/pino": "^6.3.0",
-    "@types/sonic-boom": "^0.7.0",
     "c8": "^7.1.0",
     "cross-env": "^7.0.0",
     "dotenv": "^8.0.0",
@@ -50,8 +50,8 @@
     "mocha": "^8.0.0",
     "nock": "^13.0.0",
     "sinon": "^9.0.0",
-    "stream-mock": "^2.0.5",
     "sonic-boom": "^1.0.1",
+    "stream-mock": "^2.0.5",
     "typescript": "^3.8.3"
   },
   "engines": {

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -67,7 +67,7 @@ export interface GCFLogger {
   flushSync: {(): void};
 }
 
-interface WrapOptions {
+export interface WrapOptions {
   background: boolean;
 }
 

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -67,6 +67,10 @@ export interface GCFLogger {
   flushSync: {(): void};
 }
 
+interface WrapOptions {
+  background: boolean;
+}
+
 export const logger: GCFLogger = initLogger();
 
 export function initLogger(
@@ -283,8 +287,13 @@ export class GCFBootstrapper {
   }
 
   gcf(
-    appFn: ApplicationFunction
+    appFn: ApplicationFunction,
+    wrapOptions?: WrapOptions
   ): (request: express.Request, response: express.Response) => Promise<void> {
+    let background = true;
+    if (wrapOptions) {
+      background = wrapOptions.background;
+    }
     return async (request: express.Request, response: express.Response) => {
       // Otherwise let's listen handle the payload
       this.probot = this.probot || (await this.loadProbot(appFn));
@@ -319,12 +328,27 @@ export class GCFBootstrapper {
         });
       } else if (triggerType === TriggerType.GITHUB) {
         try {
-          await this.enqueueTask({
-            id,
-            name,
-            signature,
-            body: JSON.stringify(request.body),
-          });
+          if (background) {
+            // by default, jobs are run through a background task, this has
+            // the benefit of supporting retries, and giving us more insight
+            // into failing payloads:
+            console.info('scheduling cloud task');
+            await this.enqueueTask({
+              id,
+              name,
+              signature,
+              body: JSON.stringify(request.body),
+            });
+          } else {
+            // a bot can opt out of running through tasks, some bots do this
+            // due to large payload sizes:
+            console.info('skipping cloud tasks');
+            await this.probot.receive({
+              name,
+              id,
+              payload: request.body,
+            });
+          }
         } catch (err) {
           response.status(500).send({
             body: JSON.stringify({message: err}),

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -290,10 +290,7 @@ export class GCFBootstrapper {
     appFn: ApplicationFunction,
     wrapOptions?: WrapOptions
   ): (request: express.Request, response: express.Response) => Promise<void> {
-    let background = true;
-    if (wrapOptions) {
-      background = wrapOptions.background;
-    }
+    wrapOptions = wrapOptions ?? {background: true};
     return async (request: express.Request, response: express.Response) => {
       // Otherwise let's listen handle the payload
       this.probot = this.probot || (await this.loadProbot(appFn));
@@ -328,7 +325,7 @@ export class GCFBootstrapper {
         });
       } else if (triggerType === TriggerType.GITHUB) {
         try {
-          if (background) {
+          if (wrapOptions?.background) {
             // by default, jobs are run through a background task, this has
             // the benefit of supporting retries, and giving us more insight
             // into failing payloads:


### PR DESCRIPTION
We should add a test for this, but I thought it would be good to get a hot fix in for build cop quickly.

This also unblocks @azizsonawalla's work  as well, which requires that bots have `@types/sonic-boom` available.

Refs: https://github.com/googleapis/repo-automation-bots/issues/699 (tracking issue for test).