### PR TITLE
build: upgrade some bots to gcf-utils 5.2.2

### DIFF
--- a/packages/auto-label/package.json
+++ b/packages/auto-label/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^5.0.0",
-    "gcf-utils": "^5.0.1"
+    "gcf-utils": "^5.2.2"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",

--- a/packages/blunderbuss/package.json
+++ b/packages/blunderbuss/package.json
@@ -28,7 +28,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "^5.0.1"
+    "gcf-utils": "^5.2.2"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",

--- a/packages/conventional-commit-lint/package.json
+++ b/packages/conventional-commit-lint/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@commitlint/config-conventional": "^9.0.1",
     "@commitlint/lint": "^9.0.1",
-    "gcf-utils": "5.0.1"
+    "gcf-utils": "5.2.2"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",

--- a/packages/conventional-commit-lint/package.json
+++ b/packages/conventional-commit-lint/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@commitlint/config-conventional": "^9.0.1",
     "@commitlint/lint": "^9.0.1",
-    "gcf-utils": "5.2.2"
+    "gcf-utils": "^5.2.2"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",


### PR DESCRIPTION
Upgrade auto_label, blunderbuss and conventional_commit_lint to gcf-utils 5.2.2