### PR TITLE
chore: add repo override for proto-plus-python

### DIFF
--- a/packages/sync-repo-settings/src/required-checks.json
+++ b/packages/sync-repo-settings/src/required-checks.json
@@ -198,7 +198,7 @@
       "cla/google"
     ],
     "repoOverrides": [
-    {
+      {
         "repo": "googleapis/proto-plus-python",
         "requiredStatusChecks": [
           "ci/circleci: docs",
@@ -212,7 +212,7 @@
           "cla/google"
         ]
       },
-    ]
+    ],
     "ignoredRepos": [
       "GoogleCloudPlatform/python-docs-samples",
       "GoogleCloudPlatform/getting-started-python",

--- a/packages/sync-repo-settings/src/required-checks.json
+++ b/packages/sync-repo-settings/src/required-checks.json
@@ -197,6 +197,22 @@
       "Kokoro",
       "cla/google"
     ],
+    "repoOverrides": [
+    {
+        "repo": "googleapis/proto-plus-python",
+        "requiredStatusChecks": [
+          "ci/circleci: docs",
+          "ci/circleci: style-check",
+          "ci/circleci: unit-3.5",
+          "ci/circleci: unit-3.6",
+          "ci/circleci: unit-3.7",
+          "ci/circleci: unit-cpp-3.5",
+          "ci/circleci: unit-cpp-3.6",
+          "ci/circleci: unit-cpp-3.7",
+          "cla/google"
+        ]
+      },
+    ]
     "ignoredRepos": [
       "GoogleCloudPlatform/python-docs-samples",
       "GoogleCloudPlatform/getting-started-python",

--- a/packages/sync-repo-settings/src/required-checks.json
+++ b/packages/sync-repo-settings/src/required-checks.json
@@ -211,7 +211,7 @@
           "ci/circleci: unit-cpp-3.7",
           "cla/google"
         ]
-      },
+      }
     ],
     "ignoredRepos": [
       "GoogleCloudPlatform/python-docs-samples",


### PR DESCRIPTION
@software-dov Could you check the list of required checks? They were accidentally erased (and replaced with "kokoro") when I added proto-plus to Sloth's list of repos.