### PR TITLE
fix(sync-repo-settings): always add team memberships

### DIFF
--- a/packages/sync-repo-settings/src/app.ts
+++ b/packages/sync-repo-settings/src/app.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {GCFBootstrapper} from 'gcf-utils';
-import appFn from './sync-repo-settings';
+import {handler} from './sync-repo-settings';
 
 const bootstrap = new GCFBootstrapper();
-module.exports['sync_repo_settings'] = bootstrap.gcf(appFn);
+module.exports['sync_repo_settings'] = bootstrap.gcf(handler);


### PR DESCRIPTION
When syncing settings, we previously were looking for an `ignored` flag, and then not running any of the repo setup code if ignored.  For master branch protection and repo settings, this makes sense.  For adding teams that have access though, it's creating problems where access is manually managed.  Since it's rare that someone would want to prevent adding the team membership, we're ignoring ignore now for that scenario.