### PR TITLE
fix(mog): do not double schedule work

### DIFF
--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcf-utils",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "An extension for running Probot in Google Cloud Functions",
   "scripts": {
     "compile": "tsc -p .",

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -315,12 +315,12 @@ export class GCFBootstrapper {
         // installation ID:
         try {
           if (wrapOptions?.background) {
-            console.info('scheduling cloud task');
+            console.info(`${id}: scheduling cloud task`);
             await this.handleScheduled(id, request, name, signature);
           } else {
             // a bot can opt out of running through tasks, some bots do this
             // due to large payload sizes:
-            console.info('skipping cloud tasks');
+            console.info(`${id}: skipping cloud tasks`);
             await this.probot.receive({
               name,
               id,

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -314,7 +314,19 @@ export class GCFBootstrapper {
         // clever and instead pull up a list of repos we're installed on by
         // installation ID:
         try {
-          await this.handleScheduled(id, request, name, signature);
+          if (wrapOptions?.background) {
+            console.info('scheduling cloud task');
+            await this.handleScheduled(id, request, name, signature);
+          } else {
+            // a bot can opt out of running through tasks, some bots do this
+            // due to large payload sizes:
+            console.info('skipping cloud tasks');
+            await this.probot.receive({
+              name,
+              id,
+              payload: request.body,
+            });
+          }
         } catch (err) {
           response.status(500).send({
             body: JSON.stringify({message: err}),

--- a/packages/merge-on-green/package.json
+++ b/packages/merge-on-green/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@google-cloud/datastore": "^6.0.0",
-    "gcf-utils": "^5.2.2"
+    "gcf-utils": "^5.2.3"
   },
   "devDependencies": {
     "@types/sinon": "^9.0.0",

--- a/packages/merge-on-green/package.json
+++ b/packages/merge-on-green/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@google-cloud/datastore": "^6.0.0",
-    "gcf-utils": "5.0.1"
+    "gcf-utils": "^5.2.2"
   },
   "devDependencies": {
     "@types/sinon": "^9.0.0",

--- a/packages/merge-on-green/src/app.ts
+++ b/packages/merge-on-green/src/app.ts
@@ -17,5 +17,5 @@ import appFn from './merge-on-green';
 
 const bootstrap = new GCFBootstrapper();
 module.exports['merge_on_green'] = bootstrap.gcf(appFn, {
-  background: false
+  background: false,
 });

--- a/packages/merge-on-green/src/app.ts
+++ b/packages/merge-on-green/src/app.ts
@@ -17,5 +17,7 @@ import appFn from './merge-on-green';
 
 const bootstrap = new GCFBootstrapper();
 module.exports['merge_on_green'] = bootstrap.gcf(appFn, {
+  // By default jobs are managed in background cloud tasks queue, we
+  // shouldn't do this for merge on green, as it already retries on a cron:
   background: false,
 });

--- a/packages/merge-on-green/src/app.ts
+++ b/packages/merge-on-green/src/app.ts
@@ -16,4 +16,6 @@ import {GCFBootstrapper} from 'gcf-utils';
 import appFn from './merge-on-green';
 
 const bootstrap = new GCFBootstrapper();
-module.exports['merge_on_green'] = bootstrap.gcf(appFn);
+module.exports['merge_on_green'] = bootstrap.gcf(appFn, {
+  background: false
+});


### PR DESCRIPTION
Merge on green already has retry logic, I believe using background tasks for it was leading to a thundering herd of retries.
