### PR TITLE
Revert "fix(sync-repo-settings): always add team memberships"

### DIFF
--- a/packages/sync-repo-settings/src/app.ts
+++ b/packages/sync-repo-settings/src/app.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {GCFBootstrapper} from 'gcf-utils';
-import {handler} from './sync-repo-settings';
+import appFn from './sync-repo-settings';
 
 const bootstrap = new GCFBootstrapper();
-module.exports['sync_repo_settings'] = bootstrap.gcf(handler);
+module.exports['sync_repo_settings'] = bootstrap.gcf(appFn);

--- a/packages/sync-repo-settings/test/test.ts
+++ b/packages/sync-repo-settings/test/test.ts
@@ -16,7 +16,7 @@ import {describe, it, beforeEach} from 'mocha';
 import nock from 'nock';
 // eslint-disable-next-line node/no-extraneous-import
 import {Probot} from 'probot';
-import {handler} from '../src/sync-repo-settings';
+import handler from '../src/sync-repo-settings';
 
 nock.disableNetConnect();
 
@@ -87,29 +87,21 @@ describe('Sync repo settings', () => {
   });
 
   it('should ignore repos in ignored repos in required-checks.json', async () => {
-    const org = 'googleapis';
-    const repo = 'api-common-java';
-    const scopes = [
-      nockLanguagesList(org, repo, {java: 1}),
-      nockUpdateTeamMembership('yoshi-admins', org, repo),
-      nockUpdateTeamMembership('yoshi-java-admins', org, repo),
-      nockUpdateTeamMembership('yoshi-java', org, repo),
-      nockUpdateTeamMembership('java-samples-reviewers', org, repo),
-    ];
+    const scope = nockLanguagesList('googleapis', 'api-common-java', {java: 1});
     await probot.receive({
       name: 'schedule.repository',
       payload: {
         repository: {
-          name: repo,
+          name: 'api-common-java',
         },
         organization: {
-          login: org,
+          login: 'googleapis',
         },
-        cron_org: org,
+        cron_org: 'googleapis',
       },
       id: 'abc123',
     });
-    scopes.forEach(x => x.done());
+    scope.done();
   });
 
   it('should skip for the wrong context', async () => {
@@ -158,13 +150,11 @@ describe('Sync repo settings', () => {
   });
 
   it('should override master branch protection if the repo is overridden', async () => {
-    const org = 'googleapis';
-    const repo = 'google-api-java-client';
     const scopes = [
-      nockLanguagesList(org, repo, {java: 1}),
-      nockUpdateRepoSettings(repo, false, true),
+      nockLanguagesList('googleapis', 'google-api-java-client', {java: 1}),
+      nockUpdateRepoSettings('google-api-java-client', false, true),
       nockUpdateBranchProtection(
-        repo,
+        'google-api-java-client',
         [
           'Kokoro - Test: Binary Compatibility',
           'Kokoro - Test: Java 11',
@@ -175,10 +165,21 @@ describe('Sync repo settings', () => {
         ],
         false
       ),
-      nockUpdateTeamMembership('yoshi-admins', org, repo),
-      nockUpdateTeamMembership('yoshi-java-admins', org, repo),
-      nockUpdateTeamMembership('yoshi-java', org, repo),
-      nockUpdateTeamMembership('java-samples-reviewers', org, repo),
+      nockUpdateTeamMembership(
+        'yoshi-admins',
+        'googleapis',
+        'google-api-java-client'
+      ),
+      nockUpdateTeamMembership(
+        'yoshi-java-admins',
+        'googleapis',
+        'google-api-java-client'
+      ),
+      nockUpdateTeamMembership(
+        'yoshi-java',
+        'googleapis',
+        'google-api-java-client'
+      ),
     ];
     await probot.receive({
       name: 'schedule.repository',


### PR DESCRIPTION
Reverts googleapis/repo-automation-bots#713

![Screen Shot 2020-07-21 at 12 39 22 PM](https://user-images.githubusercontent.com/55454395/88098888-5066f100-cb4f-11ea-9726-66df6d7c11cb.png)

Not catching the error is causing there to be a backup in the Cloud Tasks. I think what's happening is that these tasks stay in the queue because they're unsuccessful, and bottlenecking future tasks.

Maybe there's a better solution than reverting this PR? 