### PR TITLE
feat: logger must be turned on with config option

### DIFF
--- a/packages/buildcop/package.json
+++ b/packages/buildcop/package.json
@@ -28,7 +28,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "^5.2.2",
+    "gcf-utils": "^5.2.5",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/packages/buildcop/package.json
+++ b/packages/buildcop/package.json
@@ -28,7 +28,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "^5.2.5",
+    "gcf-utils": "^5.2.6",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/packages/buildcop/src/app.ts
+++ b/packages/buildcop/src/app.ts
@@ -18,4 +18,5 @@ import {buildcop} from './buildcop';
 const bootstrap = new GCFBootstrapper();
 module.exports.buildcop = bootstrap.gcf(buildcop, {
   background: false,
+  logging: true
 });

--- a/packages/buildcop/src/app.ts
+++ b/packages/buildcop/src/app.ts
@@ -18,5 +18,5 @@ import {buildcop} from './buildcop';
 const bootstrap = new GCFBootstrapper();
 module.exports.buildcop = bootstrap.gcf(buildcop, {
   background: false,
-  logging: true
+  logging: true,
 });

--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcf-utils",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "description": "An extension for running Probot in Google Cloud Functions",
   "scripts": {
     "compile": "tsc -p .",
@@ -43,7 +43,6 @@
     "@types/sinon": "^9.0.0",
     "@types/tmp": "^0.2.0",
     "@types/yargs": "^15.0.0",
-    "@octokit/rest": "^16.43.1",
     "c8": "^7.1.0",
     "cross-env": "^7.0.0",
     "dotenv": "^8.0.0",

--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcf-utils",
-  "version": "5.2.3",
+  "version": "5.2.5",
   "description": "An extension for running Probot in Google Cloud Functions",
   "scripts": {
     "compile": "tsc -p .",

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -17,6 +17,7 @@ import {CloudTasksClient} from '@google-cloud/tasks';
 import {v1} from '@google-cloud/secret-manager';
 import * as express from 'express';
 import pino from 'pino';
+// eslint-disable-next-line node/no-extraneous-import
 import {Octokit} from '@octokit/rest';
 import SonicBoom from 'sonic-boom';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -200,7 +201,7 @@ export class GCFBootstrapper {
       return {...config, Octokit: LoggingOctokit} as Options;
     } else {
       console.info('custom logging instance not enabled');
-      return config;
+      return config as Options;
     }
   }
 

--- a/packages/gcf-utils/src/logging-octokit-plugin.ts
+++ b/packages/gcf-utils/src/logging-octokit-plugin.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+// eslint-disable-next-line node/no-extraneous-import
 import {Octokit} from '@octokit/rest';
 import {logger} from './gcf-utils';
 

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -58,7 +58,7 @@ describe('GCFBootstrapper', () => {
     let req: express.Request;
 
     const spy: sinon.SinonStub = sinon.stub();
-    let configStub: sinon.SinonStub<[], Promise<Options>>;
+    let configStub: sinon.SinonStub<[boolean?], Promise<Options>>;
 
     let bootstrapper: GCFBootstrapper;
 
@@ -115,6 +115,7 @@ describe('GCFBootstrapper', () => {
     it('does not schedule task if background option is "false"', async () => {
       await mockBootstrapper({
         background: false,
+        logging: true,
       });
       req.body = {
         installation: {id: 1},
@@ -214,7 +215,7 @@ describe('GCFBootstrapper', () => {
 
   describe('loadProbot', () => {
     let bootstrapper: GCFBootstrapper;
-    let configStub: sinon.SinonStub<[], Promise<Options>>;
+    let configStub: sinon.SinonStub<[boolean?], Promise<Options>>;
 
     beforeEach(() => {
       bootstrapper = new GCFBootstrapper();

--- a/packages/gcf-utils/test/logging-octokit-plugin.ts
+++ b/packages/gcf-utils/test/logging-octokit-plugin.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {describe, beforeEach, it} from 'mocha';
+// eslint-disable-next-line node/no-extraneous-import
 import {Octokit} from '@octokit/rest';
 import assert from 'assert';
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/merge-on-green/package.json
+++ b/packages/merge-on-green/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@google-cloud/datastore": "^6.0.0",
-    "gcf-utils": "^5.2.3"
+    "gcf-utils": "^5.2.6"
   },
   "devDependencies": {
     "@types/sinon": "^9.0.0",

--- a/packages/merge-on-green/src/app.ts
+++ b/packages/merge-on-green/src/app.ts
@@ -20,4 +20,5 @@ module.exports['merge_on_green'] = bootstrap.gcf(appFn, {
   // By default jobs are managed in background cloud tasks queue, we
   // shouldn't do this for merge on green, as it already retries on a cron:
   background: false,
+  logging: false,
 });

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@octokit/rest": "^18.0.0",
     "@octokit/webhooks": "^7.1.1",
-    "gcf-utils": "^5.0.0",
+    "gcf-utils": "^5.2.4",
     "probot": "^9.11.2",
     "release-please": "^5.5.0"
   },

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@octokit/rest": "^18.0.0",
     "@octokit/webhooks": "^7.1.1",
-    "gcf-utils": "^5.2.6",
+    "gcf-utils": "5.2.2",
     "probot": "^9.11.2",
     "release-please": "^5.5.0"
   },

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -29,8 +29,9 @@
   },
   "dependencies": {
     "@octokit/rest": "^18.0.0",
+    "@octokit/types": "5.1.0",
     "@octokit/webhooks": "^7.1.1",
-    "gcf-utils": "5.2.2",
+    "gcf-utils": "^5.2.6",
     "probot": "^9.11.2",
     "release-please": "^5.5.0"
   },

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@octokit/rest": "^18.0.0",
     "@octokit/webhooks": "^7.1.1",
-    "gcf-utils": "^5.2.4",
+    "gcf-utils": "^5.2.6",
     "probot": "^9.11.2",
     "release-please": "^5.5.0"
   },

--- a/packages/release-please/src/app.ts
+++ b/packages/release-please/src/app.ts
@@ -16,4 +16,7 @@ import {GCFBootstrapper} from 'gcf-utils';
 import appFn from './release-please';
 
 const bootstrap = new GCFBootstrapper();
-module.exports.release_please = bootstrap.gcf(appFn);
+module.exports.release_please = bootstrap.gcf(appFn, {
+  background: true, // release please should be scheduled in tasks.
+  logging: false, // the custom logger instance does not yet work with release-please
+});

--- a/packages/release-please/src/app.ts
+++ b/packages/release-please/src/app.ts
@@ -16,7 +16,4 @@ import {GCFBootstrapper} from 'gcf-utils';
 import appFn from './release-please';
 
 const bootstrap = new GCFBootstrapper();
-module.exports.release_please = bootstrap.gcf(appFn, {
-  background: true, // release please should be scheduled in tasks.
-  logging: false, // the custom logger instance does not yet work with release-please
-});
+module.exports.release_please = bootstrap.gcf(appFn);


### PR DESCRIPTION
The release of `gcf-utils` with a custom logger seems to be causing issues with `release-please`.

I think this is probably a snowflake, because release-please bot passes the GitHub instance around, and uses many more methods than most of our bots. However, I still think we should try rolling out the logger gradually given this hiccup.

A bot can simply opt in via:

```js
gcf(handler, {
  background: true,
  logging: true
})
```

_Note: I've already tested this code with release-please._


**I've turned logging on for build cop to start, since it already had configuration, let's QA this tomorrow @azizsonawalla.**