### PR TITLE
fix: use console.error for errors

### DIFF
--- a/packages/auto-label/.gitignore
+++ b/packages/auto-label/.gitignore
@@ -1,0 +1,3 @@
+coverage/
+build/
+node_modules/

--- a/packages/auto-label/src/auto-label.ts
+++ b/packages/auto-label/src/auto-label.ts
@@ -137,7 +137,7 @@ handler.checkIfFileIsEmpty = async function checkIfFileIsEmpty(
   jsonData: string
 ) {
   if (jsonData.length === 0) {
-    console.error('JSON file downloaded from Cloud Storage was empty');
+    console.error(new Error('JSON file downloaded from Cloud Storage was empty'));
     return null;
   } else {
     const jsonArray = JSON.parse(jsonData).repos;

--- a/packages/auto-label/src/auto-label.ts
+++ b/packages/auto-label/src/auto-label.ts
@@ -137,7 +137,9 @@ handler.checkIfFileIsEmpty = async function checkIfFileIsEmpty(
   jsonData: string
 ) {
   if (jsonData.length === 0) {
-    console.error(new Error('JSON file downloaded from Cloud Storage was empty'));
+    console.error(
+      new Error('JSON file downloaded from Cloud Storage was empty')
+    );
     return null;
   } else {
     const jsonArray = JSON.parse(jsonData).repos;

--- a/packages/auto-label/src/auto-label.ts
+++ b/packages/auto-label/src/auto-label.ts
@@ -48,7 +48,7 @@ handler.addLabels = async function addLabels(
     });
     return data;
   } catch (err) {
-    console.log(err);
+    console.error(err);
     return null;
   }
 };
@@ -68,7 +68,7 @@ handler.checkExistingLabels = async function checkExistingLabels(
     });
     return data.data.name;
   } catch (err) {
-    console.log(err);
+    console.error(err);
     return null;
   }
 };
@@ -90,7 +90,7 @@ handler.createLabel = async function createLabel(
     });
     return data;
   } catch (err) {
-    console.log(err);
+    console.error(err);
     return null;
   }
 };
@@ -114,7 +114,7 @@ handler.checkExistingIssueLabels = async function checkExistingIssueLabels(
       return data.data;
     }
   } catch (err) {
-    console.log(err);
+    console.error(err);
     return null;
   }
 };
@@ -137,7 +137,7 @@ handler.checkIfFileIsEmpty = async function checkIfFileIsEmpty(
   jsonData: string
 ) {
   if (jsonData.length === 0) {
-    console.log('JSON file downloaded from Cloud Storage was empty');
+    console.error('JSON file downloaded from Cloud Storage was empty');
     return null;
   } else {
     const jsonArray = JSON.parse(jsonData).repos;
@@ -201,7 +201,7 @@ handler.addLabeltoRepoAndIssue = async function addLabeltoRepoAndIssue(
   github: GitHubAPI
 ) {
   if (!jsonArray) {
-    console.log('terminating execution of auto-label since JSON file is empty');
+    console.error('terminating execution of auto-label since JSON file is empty');
     return;
   }
   const objectInJsonArray = handler.checkIfElementIsInArray(

--- a/packages/auto-label/src/auto-label.ts
+++ b/packages/auto-label/src/auto-label.ts
@@ -201,7 +201,9 @@ handler.addLabeltoRepoAndIssue = async function addLabeltoRepoAndIssue(
   github: GitHubAPI
 ) {
   if (!jsonArray) {
-    console.error('terminating execution of auto-label since JSON file is empty');
+    console.error(
+      'terminating execution of auto-label since JSON file is empty'
+    );
     return;
   }
   const objectInJsonArray = handler.checkIfElementIsInArray(

--- a/packages/auto-label/test/auto-label.ts
+++ b/packages/auto-label/test/auto-label.ts
@@ -48,7 +48,7 @@ describe('auto-label', () => {
       // use a bare instance of octokit, the default version
       // enables retries which makes testing difficult.
       // eslint-disable-next-line node/no-extraneous-require
-      Octokit: require('@octokit/rest'),
+      Octokit: require('@octokit/rest').Octokit,
     });
     probot.app = {
       getSignedJsonWebToken() {

--- a/packages/conventional-commit-lint/src/conventional-commit-lint.ts
+++ b/packages/conventional-commit-lint/src/conventional-commit-lint.ts
@@ -54,7 +54,7 @@ export = (app: Application) => {
 
     const commits = commitsResponse.data;
     if (commits.length === 0) {
-      console.error(
+      console.log(
         `Pull request ${context.payload.pull_request.html_url} has no commits!`
       );
       return;

--- a/packages/label-sync/src/label-sync.ts
+++ b/packages/label-sync/src/label-sync.ts
@@ -44,11 +44,11 @@ async function getLabels(github: GitHubAPI, repoPath: string): Promise<Labels> {
   const apiLabelsRes = await getApiLabels(repoPath);
   apiLabelsRes.apis.forEach(api => {
     if (!api.github_label || !api.api_shortname) {
-      console.log(`
+      console.error(`
         Missing expected fields for a given API label returned from GCS.
         This object was expected to have a 'github_label' and 'api_shortname'
         property, but it is missing at least one of them.`);
-      console.log(util.inspect(api));
+      console.error(util.inspect(api));
       return;
     }
     labels.labels.push({

--- a/packages/label-sync/src/label-sync.ts
+++ b/packages/label-sync/src/label-sync.ts
@@ -196,8 +196,8 @@ async function reconcileLabels(github: GitHubAPI, owner: string, repo: string) {
             color: l.color,
           })
           .catch(e => {
-            console.error(`Error updating label ${l.name} in ${owner}/${repo}`);
-            console.error(e.stack);
+            e.message = `Error updating label ${l.name} in ${owner}/${repo}\n\n${e.message}`;
+            console.error(e);
           });
       }
     } else {
@@ -217,8 +217,8 @@ async function reconcileLabels(github: GitHubAPI, owner: string, repo: string) {
             !Array.isArray(e.errors) ||
             e.errors[0].code !== 'already_exists'
           ) {
-            console.error(`Error creating label ${l.name} in ${owner}/${repo}`);
-            console.error(e.stack);
+            e.message = `Error creating label ${l.name} in ${owner}/${repo}\n\n${e.message}`;
+            console.error(e);
           }
         });
     }
@@ -245,8 +245,8 @@ async function reconcileLabels(github: GitHubAPI, owner: string, repo: string) {
           console.log(`Deleted '${l.name}' from ${owner}/${repo}`);
         })
         .catch(e => {
-          console.error(`Error deleting label ${l.name} in ${owner}/${repo}`);
-          console.error(e.stack);
+          e.message = `Error deleting label ${l.name} in ${owner}/${repo}\n\n${e.message}`;
+          console.error(e);
         });
     }
   }

--- a/packages/merge-on-green/src/merge-logic.ts
+++ b/packages/merge-on-green/src/merge-logic.ts
@@ -180,7 +180,7 @@ mergeOnGreen.hasMOGLabel = async function hasMOGLabel(
     )?.name;
     return mog;
   } catch (err) {
-    console.log(`Error in getting MOG label: ${err}`);
+    console.error(`Error in getting MOG label: ${err}`);
     return undefined;
   }
 };
@@ -210,7 +210,7 @@ mergeOnGreen.getBranchProtection = async function getBranchProtection(
     );
     return branchProtection;
   } catch (err) {
-    console.log(`Error in getting branch protection: ${err}`);
+    console.error(`Error in getting branch protection: ${err}`);
     return [];
   }
 };
@@ -249,7 +249,7 @@ mergeOnGreen.getStatusi = async function getStatusi(
     );
     return data;
   } catch (err) {
-    console.log(`Error in getting statuses: ${err}`);
+    console.error(`Error in getting statuses: ${err}`);
     return [];
   }
 };
@@ -472,7 +472,8 @@ mergeOnGreen.getReviewsCompleted = async function getReviewsCompleted(
     });
     return reviewsCompleted.data;
   } catch (err) {
-    console.log(`Error getting reviews completed ${err}`);
+    console.error(`Error getting reviews completed ${err}`);
+    console.error(err);
     return [];
   }
 };
@@ -559,7 +560,7 @@ mergeOnGreen.checkReviews = async function checkReviews(
               message:
                 'This review does not reference the most recent commit, and you are using the secure version of merge-on-green. Please re-review the most recent commit.',
             })
-            .catch(err => console.log(err));
+            .catch(err => console.error(err));
           reviewsPassed = false;
         }
       });
@@ -625,7 +626,8 @@ mergeOnGreen.updateBranch = async function updateBranch(
     ).data as Update;
     return update;
   } catch (err) {
-    console.log(`Error in updating branch: ${err}`);
+    console.error(`Error in updating branch: ${err}`);
+    console.error(err);
     return null;
   }
 };
@@ -655,7 +657,8 @@ mergeOnGreen.commentOnPR = async function commentOnPR(
     });
     return data;
   } catch (err) {
-    console.log(`There was an issue commenting on ${owner}/${repo} PR ${pr}`);
+    console.error(`There was an issue commenting on ${owner}/${repo} PR ${pr}`);
+    console.error(err);
     return null;
   }
 };
@@ -684,9 +687,10 @@ mergeOnGreen.removeLabel = async function removeLabel(
       name,
     });
   } catch (err) {
-    console.log(
+    console.error(
       `There was an issue removing the automerge label on ${owner}/${repo} PR ${issue_number}`
     );
+    console.error(err);
   }
 };
 

--- a/packages/merge-on-green/src/merge-logic.ts
+++ b/packages/merge-on-green/src/merge-logic.ts
@@ -180,7 +180,8 @@ mergeOnGreen.hasMOGLabel = async function hasMOGLabel(
     )?.name;
     return mog;
   } catch (err) {
-    console.error(`Error in getting MOG label: ${err}`);
+    err.message = `Error in getting MOG label\n\n ${err.message}`;
+    console.error(err);
     return undefined;
   }
 };
@@ -210,7 +211,8 @@ mergeOnGreen.getBranchProtection = async function getBranchProtection(
     );
     return branchProtection;
   } catch (err) {
-    console.error(`Error in getting branch protection: ${err}`);
+    err.message = `Error in getting branch protection\n\n${err.message}`;
+    console.error(err);
     return [];
   }
 };
@@ -249,7 +251,8 @@ mergeOnGreen.getStatusi = async function getStatusi(
     );
     return data;
   } catch (err) {
-    console.error(`Error in getting statuses: ${err}`);
+    err.message = `Error in getting statuses\n\n${err.message}`;
+    console.error(err);
     return [];
   }
 };
@@ -472,7 +475,7 @@ mergeOnGreen.getReviewsCompleted = async function getReviewsCompleted(
     });
     return reviewsCompleted.data;
   } catch (err) {
-    console.error(`Error getting reviews completed ${err}`);
+    err.message = `Error getting reviews completed\n\n${err.message}`;
     console.error(err);
     return [];
   }
@@ -560,7 +563,7 @@ mergeOnGreen.checkReviews = async function checkReviews(
               message:
                 'This review does not reference the most recent commit, and you are using the secure version of merge-on-green. Please re-review the most recent commit.',
             })
-            .catch(err => console.error(err));
+            .catch(console.error);
           reviewsPassed = false;
         }
       });
@@ -626,7 +629,7 @@ mergeOnGreen.updateBranch = async function updateBranch(
     ).data as Update;
     return update;
   } catch (err) {
-    console.error(`Error in updating branch: ${err}`);
+    err.message = `Error in updating branch: \n\n${err.message}`;
     console.error(err);
     return null;
   }
@@ -657,7 +660,7 @@ mergeOnGreen.commentOnPR = async function commentOnPR(
     });
     return data;
   } catch (err) {
-    console.error(`There was an issue commenting on ${owner}/${repo} PR ${pr}`);
+    err.message = `There was an issue commenting on ${owner}/${repo} PR ${pr} \n\n${err.message}`;
     console.error(err);
     return null;
   }
@@ -687,9 +690,7 @@ mergeOnGreen.removeLabel = async function removeLabel(
       name,
     });
   } catch (err) {
-    console.error(
-      `There was an issue removing the automerge label on ${owner}/${repo} PR ${issue_number}`
-    );
+    err.message = `There was an issue removing the automerge label on ${owner}/${repo} PR ${issue_number}\n\n${err.message}`;
     console.error(err);
   }
 };
@@ -803,17 +804,15 @@ export async function mergeOnGreen(
       console.info(
         `Is ${owner}/${repo}/${pr} mergeable?: ${prInfo.mergeable} Mergeable_state?: ${prInfo.mergeable_state}`
       );
-      console.error(
-        `failed to merge "${err.message}: " ${owner}/${repo}/${pr}`
-      );
+      err.message = `Failed to merge "${err.message}: " ${owner}/${repo}/${pr}\n\n${err.message}`;
+      console.error(err);
       if (prInfo.mergeable_state === 'behind') {
         console.info(`Attempting to update branch ${owner}/${repo}/${pr}`);
         try {
           await mergeOnGreen.updateBranch(owner, repo, pr, github);
         } catch (err) {
-          console.error(
-            `failed to update branch "${err.message}" ${owner}/${repo}/${pr}`
-          );
+          err.message = `failed to update branch ${owner}/${repo}/${pr}\n\n${err.message}`;
+          console.error(err);
         }
       } else if (prInfo.mergeable_state === 'dirty') {
         console.info(

--- a/packages/merge-on-green/src/merge-on-green.ts
+++ b/packages/merge-on-green/src/merge-on-green.ts
@@ -148,7 +148,8 @@ function handler(app: Application) {
               handler.removePR(wp.url);
             }
           } catch (err) {
-            console.log(`Error in merge-on-green: ${err}`);
+            console.error(`Error in merge-on-green: ${err}`);
+            console.error(err);
             if (wp.state === 'stop') {
               handler.removePR(wp.url);
             }

--- a/packages/merge-on-green/src/merge-on-green.ts
+++ b/packages/merge-on-green/src/merge-on-green.ts
@@ -148,7 +148,7 @@ function handler(app: Application) {
               handler.removePR(wp.url);
             }
           } catch (err) {
-            console.error(`Error in merge-on-green: ${err}`);
+            err.message = `Error in merge-on-green: \n\n${err.message}`;
             console.error(err);
             if (wp.state === 'stop') {
               handler.removePR(wp.url);

--- a/packages/monitoring-system/data-processor/src/data-processor-factory.ts
+++ b/packages/monitoring-system/data-processor/src/data-processor-factory.ts
@@ -40,7 +40,7 @@ export class DataProcessorFactory implements Factory {
       case Task.ProcessGitHub:
         return new GitHubProcessor();
       default:
-        console.log(`Couldn't identify a data processor for task: ${task}`)
+        console.error(`Couldn't identify a data processor for task: ${task}`)
         throw new Error(`Couldn't identify a data processor for task: ${task}`);
     }
   }

--- a/packages/publish/test/publish.ts
+++ b/packages/publish/test/publish.ts
@@ -116,7 +116,7 @@ describe('publish', () => {
 
     let observedPkgPath: string | undefined = undefined;
     handler.publish = async (opts: PublishOpts) => {
-      const {npmRc, pkgPath, app, prerelease} = opts;
+      const {npmRc, pkgPath} = opts;
       snapshot(npmRc);
       observedPkgPath = pkgPath;
     };
@@ -197,7 +197,7 @@ describe('publish', () => {
 
     let observedPkgPath: string | undefined = undefined;
     handler.publish = async (opts: PublishOpts) => {
-      const {npmRc, pkgPath, app, prerelease} = opts;
+      const {npmRc, pkgPath, prerelease} = opts;
       snapshot(npmRc);
       expect(prerelease).to.equal(true);
       observedPkgPath = pkgPath;
@@ -266,7 +266,7 @@ describe('publish', () => {
 
     let observedPkgPath: string | undefined = undefined;
     handler.publish = async (opts: PublishOpts) => {
-      const {npmRc, pkgPath, app, prerelease} = opts;
+      const {npmRc, pkgPath, prerelease} = opts;
       snapshot(npmRc);
       expect(prerelease).to.equal(true);
       observedPkgPath = pkgPath;

--- a/packages/slo-stat-bot/src/slo-stat-label.ts
+++ b/packages/slo-stat-bot/src/slo-stat-label.ts
@@ -229,9 +229,8 @@ handler.createCheck = async function createCheck(
   try {
     await context.github.checks.create(checkParams);
   } catch (err) {
-    console.error(
-      `Error creating check in repo ${context.payload.repository.name} \n ${err}`
-    );
+    err.message = `Error creating check in repo ${context.payload.repository.name} \n\n${err.message}`;
+    console.error(err);
     return;
   }
 };


### PR DESCRIPTION
If we're consistent about our usage of `console.error`, we can use this to build better alerting systems in the backend. 

===== UPDATE =====
Ok @bcoe @sofisl I learned something tonight!  Google Cloud Logging (and error reporting) will not automatically log `console.error` messages as a `ERROR` level in logs.  The only way to trigger that behavior is to specifically log an `Error` object.  This means we have to be _super_ careful about the way we log errors.  