### PR TITLE
fix(conventional-commit-lint): handle PRs with no commits

### DIFF
--- a/packages/conventional-commit-lint/src/conventional-commit-lint.ts
+++ b/packages/conventional-commit-lint/src/conventional-commit-lint.ts
@@ -51,7 +51,14 @@ export = (app: Application) => {
       app.log.error(err);
       return;
     }
+
     const commits = commitsResponse.data;
+    if (commits.length === 0) {
+      console.error(
+        `Pull request ${context.payload.pull_request.html_url} has no commits!`
+      );
+      return;
+    }
 
     let message = context.payload.pull_request.title;
     const hasAutomergeLabel = context.payload.pull_request.labels

--- a/packages/conventional-commit-lint/test/conventional-commit-lint.ts
+++ b/packages/conventional-commit-lint/test/conventional-commit-lint.ts
@@ -93,6 +93,18 @@ describe('ConventionalCommitLint', () => {
     requests.done();
   });
 
+  it('should handle a PR with no commits', async () => {
+    const payload = require(resolve(
+      fixturesPath,
+      './pull_request_synchronize'
+    ));
+    const requests = nock('https://api.github.com')
+      .get('/repos/bcoe/test-release-please/pulls/11/commits?per_page=100')
+      .reply(200, []);
+    await probot.receive({name: 'pull_request', payload, id: 'abc123'});
+    requests.done();
+  });
+
   describe('PR With Multiple Commits', () => {
     it('has a valid pull request title', async () => {
       const payload = require(resolve(


### PR DESCRIPTION
Looking in the logs, somehow we're running into situations where the list of commits on the PR appears to be empty?  When this situation comes up, specifically logging it as an error, but letting the program continue. 