### PR TITLE
build: upgrade and enable Octokit logging for auto-label

### DIFF
--- a/packages/auto-label/package.json
+++ b/packages/auto-label/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^5.0.0",
-    "gcf-utils": "^5.2.2"
+    "gcf-utils": "^5.2.6"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",

--- a/packages/auto-label/src/app.ts
+++ b/packages/auto-label/src/app.ts
@@ -17,4 +17,7 @@ import {GCFBootstrapper} from 'gcf-utils';
 import appFn from './auto-label';
 
 const bootstrap = new GCFBootstrapper();
-module.exports['auto_label'] = bootstrap.gcf(appFn, {background: true, logging: true});
+module.exports['auto_label'] = bootstrap.gcf(appFn, {
+  background: true,
+  logging: true,
+});

--- a/packages/auto-label/src/app.ts
+++ b/packages/auto-label/src/app.ts
@@ -17,4 +17,4 @@ import {GCFBootstrapper} from 'gcf-utils';
 import appFn from './auto-label';
 
 const bootstrap = new GCFBootstrapper();
-module.exports['auto_label'] = bootstrap.gcf(appFn);
+module.exports['auto_label'] = bootstrap.gcf(appFn, {background: true, logging: true});

--- a/packages/auto-label/test/auto-label.ts
+++ b/packages/auto-label/test/auto-label.ts
@@ -15,7 +15,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 // eslint-disable-next-line node/no-extraneous-import
-import {Probot, Octokit} from 'probot';
+import {Probot} from 'probot';
 import {describe, it, beforeEach} from 'mocha';
 import nock from 'nock';
 import * as assert from 'assert';


### PR DESCRIPTION
Enable Octokit logging for auto-label. This one is the guinea pig, and if everything looks solid I'll do another PR to upgrade a few more bots, and then all.