### PR TITLE
fix(release-please): now pinning @octokit/types breaks compile

### DIFF
--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@octokit/rest": "^18.0.0",
-    "@octokit/types": "5.1.0",
     "@octokit/webhooks": "^7.1.1",
     "gcf-utils": "^5.2.6",
     "probot": "^9.11.2",


### PR DESCRIPTION
Now it seems that `@octokit/types` would prefer not to be pinned.