### PR TITLE
chore(sync-repo-settings): ignore release-please

### DIFF
--- a/packages/sync-repo-settings/src/required-checks.json
+++ b/packages/sync-repo-settings/src/required-checks.json
@@ -245,7 +245,8 @@
       "googleapis/repo-automation-bots",
       "googleapis/google-cloud-node",
       "googleapis/gapic-generator-typescript",
-      "googleapis/aip"
+      "googleapis/aip",
+      "googleapis/release-please"
     ]
   },
   "ruby": {


### PR DESCRIPTION
release-please is a slightly different shape than other repos, in terms of the required checks needed.