### PR TITLE
refactor(repo-automation-bots): migrate some bots from console logging to GCF Logger

### DIFF
--- a/packages/auto-label/src/auto-label.ts
+++ b/packages/auto-label/src/auto-label.ts
@@ -16,7 +16,7 @@
 import {Storage} from '@google-cloud/storage';
 // eslint-disable-next-line node/no-extraneous-import
 import {Application, GitHubAPI} from 'probot';
-import { logger } from 'gcf-utils';
+import {logger} from 'gcf-utils';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const colorsData = require('./colors.json');

--- a/packages/auto-label/src/auto-label.ts
+++ b/packages/auto-label/src/auto-label.ts
@@ -16,6 +16,7 @@
 import {Storage} from '@google-cloud/storage';
 // eslint-disable-next-line node/no-extraneous-import
 import {Application, GitHubAPI} from 'probot';
+import { logger } from 'gcf-utils';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const colorsData = require('./colors.json');
@@ -48,7 +49,7 @@ handler.addLabels = async function addLabels(
     });
     return data;
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     return null;
   }
 };
@@ -68,7 +69,7 @@ handler.checkExistingLabels = async function checkExistingLabels(
     });
     return data.data.name;
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     return null;
   }
 };
@@ -90,7 +91,7 @@ handler.createLabel = async function createLabel(
     });
     return data;
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     return null;
   }
 };
@@ -114,7 +115,7 @@ handler.checkExistingIssueLabels = async function checkExistingIssueLabels(
       return data.data;
     }
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     return null;
   }
 };
@@ -137,7 +138,7 @@ handler.checkIfFileIsEmpty = async function checkIfFileIsEmpty(
   jsonData: string
 ) {
   if (jsonData.length === 0) {
-    console.error(
+    logger.error(
       new Error('JSON file downloaded from Cloud Storage was empty')
     );
     return null;
@@ -203,7 +204,7 @@ handler.addLabeltoRepoAndIssue = async function addLabeltoRepoAndIssue(
   github: GitHubAPI
 ) {
   if (!jsonArray) {
-    console.error(
+    logger.error(
       'terminating execution of auto-label since JSON file is empty'
     );
     return;
@@ -225,7 +226,7 @@ handler.addLabeltoRepoAndIssue = async function addLabeltoRepoAndIssue(
   let autoDetectedLabel: string | undefined;
 
   if (!objectInJsonArray?.github_label) {
-    console.log(
+    logger.info(
       `There was no configured match for the repo ${repo}, trying to auto-detect the right label`
     );
     autoDetectedLabel = handler.autoDetectLabel(jsonArray, issueTitle);
@@ -246,7 +247,7 @@ handler.addLabeltoRepoAndIssue = async function addLabeltoRepoAndIssue(
       githubLabel,
       colorsData[colorNumber].color
     );
-    console.log(`Label added to ${owner}/${repo} is ${githubLabel}`);
+    logger.info(`Label added to ${owner}/${repo} is ${githubLabel}`);
     if (labelsOnIssue) {
       const foundAPIName = labelsOnIssue.find(
         (element: Label) => element.name === githubLabel
@@ -258,12 +259,12 @@ handler.addLabeltoRepoAndIssue = async function addLabeltoRepoAndIssue(
           element.name !== autoDetectedLabel
       );
       if (foundAPIName) {
-        console.log('The label already exists on this issue');
+        logger.info('The label already exists on this issue');
       } else {
         await handler.addLabels(github, owner, repo, issueNumber, [
           githubLabel,
         ]);
-        console.log(
+        logger.info(
           `Label added to ${owner}/${repo} for issue ${issueNumber} is ${githubLabel}`
         );
         wasNotAdded = false;
@@ -276,11 +277,11 @@ handler.addLabeltoRepoAndIssue = async function addLabeltoRepoAndIssue(
             issue_number: issueNumber,
             name: dirtyLabel.name,
           })
-          .catch(console.error);
+          .catch(logger.error);
       }
     } else {
       await handler.addLabels(github, owner, repo, issueNumber, [githubLabel]);
-      console.log(
+      logger.info(
         `Label added to ${owner}/${repo} for issue ${issueNumber} is ${githubLabel}`
       );
       wasNotAdded = false;
@@ -302,7 +303,7 @@ handler.addLabeltoRepoAndIssue = async function addLabeltoRepoAndIssue(
       colorsData[colorNumber].color
     );
     await handler.addLabels(github, owner, repo, issueNumber, ['sample']);
-    console.log(
+    logger.info(
       `Issue ${issueNumber} is in a samples repo but does not have a sample tag, adding it to the repo and issue`
     );
     wasNotAdded = false;
@@ -315,11 +316,11 @@ handler.addLabeltoRepoAndIssue = async function addLabeltoRepoAndIssue(
 function handler(app: Application) {
   //nightly cron that backfills and corrects api labels
   app.on(['schedule.repository'], async context => {
-    console.info(`running for org ${context.payload.cron_org}`);
+    logger.info(`running for org ${context.payload.cron_org}`);
     const owner = context.payload.organization.login;
     const repo = context.payload.repository.name;
     if (context.payload.cron_org !== owner) {
-      console.log(`skipping run for ${context.payload.cron_org}`);
+      logger.info(`skipping run for ${context.payload.cron_org}`);
       return;
     }
     const jsonData = await handler.callStorage(
@@ -347,14 +348,14 @@ function handler(app: Application) {
             context.github
           );
           if (wasNotAdded) {
-            console.log(
+            logger.info(
               `label for ${issue.number} in ${owner}/${repo} was not added`
             );
             labelWasNotAddedCount++;
           }
         }
         if (labelWasNotAddedCount > 5) {
-          console.log(
+          logger.info(
             `${
               owner / repo
             } has 5 issues where labels were not added; skipping the rest of this repo check.`

--- a/packages/conventional-commit-lint/src/conventional-commit-lint.ts
+++ b/packages/conventional-commit-lint/src/conventional-commit-lint.ts
@@ -17,6 +17,7 @@ import {Application, Octokit} from 'probot';
 import lint from '@commitlint/lint';
 
 import {rules} from '@commitlint/config-conventional';
+import { logger } from 'gcf-utils';
 // modify rules slightly:
 // see: https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/index.js
 delete rules['type-enum'];
@@ -54,7 +55,7 @@ export = (app: Application) => {
 
     const commits = commitsResponse.data;
     if (commits.length === 0) {
-      console.log(
+      logger.info(
         `Pull request ${context.payload.pull_request.html_url} has no commits!`
       );
       return;

--- a/packages/conventional-commit-lint/src/conventional-commit-lint.ts
+++ b/packages/conventional-commit-lint/src/conventional-commit-lint.ts
@@ -17,7 +17,7 @@ import {Application, Octokit} from 'probot';
 import lint from '@commitlint/lint';
 
 import {rules} from '@commitlint/config-conventional';
-import { logger } from 'gcf-utils';
+import {logger} from 'gcf-utils';
 // modify rules slightly:
 // see: https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/index.js
 delete rules['type-enum'];

--- a/packages/failurechecker/src/failurechecker.ts
+++ b/packages/failurechecker/src/failurechecker.ts
@@ -20,6 +20,7 @@
 import {Application} from 'probot';
 // eslint-disable-next-line node/no-extraneous-import
 import {GitHubAPI} from 'probot/lib/github';
+import { logger } from 'gcf-utils';
 // labels indicative of the fact that a release has not completed yet.
 const RELEASE_LABELS = [
   'autorelease: pending',
@@ -78,7 +79,7 @@ export function failureChecker(app: Application) {
       }
       app.log(`it's alive! event for ${repo}`);
     } catch (err) {
-      console.info(err);
+      logger.info(err);
       app.log.error(`${err.message} processing ${repo}`);
     }
   });

--- a/packages/failurechecker/src/failurechecker.ts
+++ b/packages/failurechecker/src/failurechecker.ts
@@ -20,7 +20,7 @@
 import {Application} from 'probot';
 // eslint-disable-next-line node/no-extraneous-import
 import {GitHubAPI} from 'probot/lib/github';
-import { logger } from 'gcf-utils';
+import {logger} from 'gcf-utils';
 // labels indicative of the fact that a release has not completed yet.
 const RELEASE_LABELS = [
   'autorelease: pending',

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -196,11 +196,11 @@ export class GCFBootstrapper {
     }
     const config = JSON.parse(payload);
     if (logging) {
-      console.info('custom logging instance enabled');
+      logger.info('custom logging instance enabled');
       const LoggingOctokit = Octokit.plugin(LoggingOctokitPlugin);
       return {...config, Octokit: LoggingOctokit} as Options;
     } else {
-      console.info('custom logging instance not enabled');
+      logger.info('custom logging instance not enabled');
       return config as Options;
     }
   }
@@ -327,12 +327,12 @@ export class GCFBootstrapper {
         // installation ID:
         try {
           if (wrapOptions?.background) {
-            console.info(`${id}: scheduling cloud task`);
+            logger.info(`${id}: scheduling cloud task`);
             await this.handleScheduled(id, request, name, signature);
           } else {
             // a bot can opt out of running through tasks, some bots do this
             // due to large payload sizes:
-            console.info(`${id}: skipping cloud tasks`);
+            logger.info(`${id}: skipping cloud tasks`);
             await this.probot.receive({
               name,
               id,
@@ -355,7 +355,7 @@ export class GCFBootstrapper {
             // by default, jobs are run through a background task, this has
             // the benefit of supporting retries, and giving us more insight
             // into failing payloads:
-            console.info('scheduling cloud task');
+            logger.info('scheduling cloud task');
             await this.enqueueTask({
               id,
               name,
@@ -365,7 +365,7 @@ export class GCFBootstrapper {
           } else {
             // a bot can opt out of running through tasks, some bots do this
             // due to large payload sizes:
-            console.info('skipping cloud tasks');
+            logger.info('skipping cloud tasks');
             await this.probot.receive({
               name,
               id,
@@ -490,7 +490,7 @@ export class GCFBootstrapper {
         body: JSON.stringify(payload),
       });
     } catch (err) {
-      console.warn(err.message);
+      logger.warn(err.message);
     }
   }
 
@@ -506,7 +506,7 @@ export class GCFBootstrapper {
     const queuePath = client.queuePath(projectId, location, queueName);
     // https://us-central1-repo-automation-bots.cloudfunctions.net/merge_on_green:
     const url = `https://${location}-${projectId}.cloudfunctions.net/${process.env.GCF_SHORT_FUNCTION_NAME}`;
-    console.info(`scheduling task in queue ${queueName}`);
+    logger.info(`scheduling task in queue ${queueName}`);
     if (params.body) {
       await client.createTask({
         parent: queuePath,

--- a/packages/label-sync/src/label-sync.ts
+++ b/packages/label-sync/src/label-sync.ts
@@ -17,6 +17,7 @@ import {Application, GitHubAPI, Octokit} from 'probot';
 import {createHash} from 'crypto';
 import {Storage} from '@google-cloud/storage';
 import * as util from 'util';
+import { logger } from 'gcf-utils';
 
 const storage = new Storage();
 
@@ -44,11 +45,11 @@ async function getLabels(github: GitHubAPI, repoPath: string): Promise<Labels> {
   const apiLabelsRes = await getApiLabels(repoPath);
   apiLabelsRes.apis.forEach(api => {
     if (!api.github_label || !api.api_shortname) {
-      console.error(`
+      logger.error(`
         Missing expected fields for a given API label returned from GCS.
         This object was expected to have a 'github_label' and 'api_shortname'
         property, but it is missing at least one of them.`);
-      console.error(util.inspect(api));
+      logger.error(util.inspect(api));
       return;
     }
     labels.labels.push({
@@ -138,7 +139,7 @@ export const getApiLabels = async (
   if (repo) {
     // for split-repos we populate only the label associated with the
     // product the repo is associated with:
-    console.log(`populating ${repo.github_label} label for ${repoPath}`);
+    logger.info(`populating ${repo.github_label} label for ${repoPath}`);
     return {
       apis: [
         {
@@ -151,13 +152,13 @@ export const getApiLabels = async (
   }
   // for mono-repos we populate a list of all apis and products,
   // since each repo might include multiple products:
-  console.log(`populating all api labels for ${repoPath}`);
+  logger.info(`populating all api labels for ${repoPath}`);
   const apis = await storage
     .bucket('devrel-prod-settings')
     .file('apis.json')
     .download();
   const parsedResponse = JSON.parse(apis[0].toString()) as GetApiLabelsResponse;
-  console.log(`Detected ${parsedResponse.apis.length} API labels from DRIFT.`);
+  logger.info(`Detected ${parsedResponse.apis.length} API labels from DRIFT.`);
   return parsedResponse;
 };
 
@@ -183,7 +184,7 @@ async function reconcileLabels(github: GitHubAPI, owner: string, repo: string) {
     if (match) {
       // check to see if the color matches
       if (match.color !== l.color || match.description !== l.description) {
-        console.log(
+        logger.info(
           `Updating ${match.name} from ${match.color} to ${l.color} and ${match.description} to ${l.description}.`
         );
         await github.issues
@@ -197,12 +198,12 @@ async function reconcileLabels(github: GitHubAPI, owner: string, repo: string) {
           })
           .catch(e => {
             e.message = `Error updating label ${l.name} in ${owner}/${repo}\n\n${e.message}`;
-            console.error(e);
+            logger.error(e);
           });
       }
     } else {
       // there was no match, go ahead and add it
-      console.log(`Creating label for ${l.name}.`);
+      logger.info(`Creating label for ${l.name}.`);
       await github.issues
         .createLabel({
           repo,
@@ -218,7 +219,7 @@ async function reconcileLabels(github: GitHubAPI, owner: string, repo: string) {
             e.errors[0].code !== 'already_exists'
           ) {
             e.message = `Error creating label ${l.name} in ${owner}/${repo}\n\n${e.message}`;
-            console.error(e);
+            logger.error(e);
           }
         });
     }
@@ -242,11 +243,11 @@ async function reconcileLabels(github: GitHubAPI, owner: string, repo: string) {
           repo,
         })
         .then(() => {
-          console.log(`Deleted '${l.name}' from ${owner}/${repo}`);
+          logger.info(`Deleted '${l.name}' from ${owner}/${repo}`);
         })
         .catch(e => {
           e.message = `Error deleting label ${l.name} in ${owner}/${repo}\n\n${e.message}`;
-          console.error(e);
+          logger.error(e);
         });
     }
   }

--- a/packages/label-sync/src/label-sync.ts
+++ b/packages/label-sync/src/label-sync.ts
@@ -17,7 +17,7 @@ import {Application, GitHubAPI, Octokit} from 'probot';
 import {createHash} from 'crypto';
 import {Storage} from '@google-cloud/storage';
 import * as util from 'util';
-import { logger } from 'gcf-utils';
+import {logger} from 'gcf-utils';
 
 const storage = new Storage();
 

--- a/packages/merge-on-green/src/merge-logic.ts
+++ b/packages/merge-on-green/src/merge-logic.ts
@@ -14,7 +14,7 @@
 
 // eslint-disable-next-line node/no-extraneous-import
 import {GitHubAPI} from 'probot/lib/github';
-import { logger } from 'gcf-utils';
+import {logger} from 'gcf-utils';
 
 interface CheckRun {
   name: string;

--- a/packages/merge-on-green/src/merge-logic.ts
+++ b/packages/merge-on-green/src/merge-logic.ts
@@ -14,6 +14,7 @@
 
 // eslint-disable-next-line node/no-extraneous-import
 import {GitHubAPI} from 'probot/lib/github';
+import { logger } from 'gcf-utils';
 
 interface CheckRun {
   name: string;
@@ -172,7 +173,7 @@ mergeOnGreen.hasMOGLabel = async function hasMOGLabel(
       issue_number: pr,
     });
     const labelArray = labels.data;
-    console.info(
+    logger.info(
       `checked hasMOGLabel in ${Date.now() - start}ms ${owner}/${repo}/${pr}`
     );
     const mog = labelArray?.find(prLabel =>
@@ -181,7 +182,7 @@ mergeOnGreen.hasMOGLabel = async function hasMOGLabel(
     return mog;
   } catch (err) {
     err.message = `Error in getting MOG label\n\n ${err.message}`;
-    console.error(err);
+    logger.error(err);
     return undefined;
   }
 };
@@ -206,13 +207,13 @@ mergeOnGreen.getBranchProtection = async function getBranchProtection(
         branch: 'master',
       })
     ).data.required_status_checks.contexts;
-    console.log(
+    logger.info(
       `checking branch protection for ${owner}/${repo}: ${branchProtection}`
     );
     return branchProtection;
   } catch (err) {
     err.message = `Error in getting branch protection\n\n${err.message}`;
-    console.error(err);
+    logger.error(err);
     return [];
   }
 };
@@ -243,16 +244,16 @@ mergeOnGreen.getStatusi = async function getStatusi(
       page: num,
     });
     if (!data[0]?.context) {
-      console.info('no further page data');
+      logger.info('no further page data');
       return [];
     }
-    console.info(
+    logger.info(
       `called getStatuses in ${Date.now() - start}ms ${owner}/${repo}`
     );
     return data;
   } catch (err) {
     err.message = `Error in getting statuses\n\n${err.message}`;
-    console.error(err);
+    logger.error(err);
     return [];
   }
 };
@@ -308,10 +309,10 @@ mergeOnGreen.getCheckRuns = async function getCheckRuns(
       page: num,
     });
     if (!checkRuns.data.check_runs[0]) {
-      console.info('no further page data');
+      logger.info('no further page data');
       return [];
     }
-    console.info(
+    logger.info(
       `called getCheckRuns in ${Date.now() - start}ms ${owner}/${repo}`
     );
     return checkRuns.data.check_runs;
@@ -401,16 +402,16 @@ mergeOnGreen.statusesForRef = async function statusesForRef(
     github,
     headSha
   );
-  console.info(
+  logger.info(
     `fetched statusesForRef in ${Date.now() - start}ms ${owner}/${repo}/${pr}`
   );
 
   let mergeable = true;
   let checkRuns;
   if (headSha.length !== 0) {
-    console.info(`=== checking required checks for ${owner}/${repo}/${pr} ===`);
+    logger.info(`=== checking required checks for ${owner}/${repo}/${pr} ===`);
     for (const check of requiredChecks) {
-      console.log(
+      logger.info(
         `Looking for required checks in status checks for ${owner}/${repo}/${pr}.`
       );
       //since find function finds the value of the first element in the array, that will take care of the chronological order of the tests
@@ -418,7 +419,7 @@ mergeOnGreen.statusesForRef = async function statusesForRef(
         element.context.startsWith(check)
       );
       if (!checkCompleted) {
-        console.log(
+        logger.info(
           'The status checks do not include your required checks. We will check in check runs.'
         );
         //if we can't find it in the statuses, let's check under check runs
@@ -432,20 +433,20 @@ mergeOnGreen.statusesForRef = async function statusesForRef(
         }
         mergeable = mergeOnGreen.checkForRequiredSC(checkRuns, check);
         if (!mergeable) {
-          console.log(
+          logger.info(
             'We could not find your required checks in check runs. You have no statuses or checks that match your required checks.'
           );
           return false;
         }
       } else if (checkCompleted.state !== 'success') {
-        console.info(
+        logger.info(
           `Setting mergeable false due to ${checkCompleted.context} = ${checkCompleted.state}`
         );
         return false;
       }
     }
   } else {
-    console.log(
+    logger.info(
       `Either you have no head sha, or no required checks for ${owner}/${repo} PR ${pr}`
     );
     return false;
@@ -476,7 +477,7 @@ mergeOnGreen.getReviewsCompleted = async function getReviewsCompleted(
     return reviewsCompleted.data;
   } catch (err) {
     err.message = `Error getting reviews completed\n\n${err.message}`;
-    console.error(err);
+    logger.error(err);
     return [];
   }
 };
@@ -523,7 +524,7 @@ mergeOnGreen.checkReviews = async function checkReviews(
   github: GitHubAPI
 ): Promise<boolean> {
   const start = Date.now();
-  console.info(`=== checking required reviews ${owner}/${repo}/${pr} ===`);
+  logger.info(`=== checking required reviews ${owner}/${repo}/${pr} ===`);
   const reviewsCompletedDirty = await mergeOnGreen.getReviewsCompleted(
     owner,
     repo,
@@ -532,7 +533,7 @@ mergeOnGreen.checkReviews = async function checkReviews(
   );
   let reviewsPassed = true;
   const reviewsCompleted = mergeOnGreen.cleanReviews(reviewsCompletedDirty);
-  console.info(
+  logger.info(
     `fetched completed reviews in ${
       Date.now() - start
     }ms ${owner}/${repo}/${pr}`
@@ -540,7 +541,7 @@ mergeOnGreen.checkReviews = async function checkReviews(
   if (reviewsCompleted.length !== 0) {
     reviewsCompleted.forEach(review => {
       if (review.state !== 'APPROVED' && review.user.login !== author) {
-        console.log(
+        logger.info(
           `One of your reviewers did not approve the PR ${owner}/${repo}/${pr} state = ${review.state}`
         );
         reviewsPassed = false;
@@ -551,7 +552,7 @@ mergeOnGreen.checkReviews = async function checkReviews(
       //if we get to here, it means that all the reviews are in the approved state
       reviewsCompleted.forEach(async review => {
         if (review.commit_id !== headSha) {
-          console.log(
+          logger.info(
             `${review.user.login} didn't review the latest commit for ${owner}/${repo}/${pr} commit = ${headSha}; will dismiss review.`
           );
           await github.pulls
@@ -563,14 +564,14 @@ mergeOnGreen.checkReviews = async function checkReviews(
               message:
                 'This review does not reference the most recent commit, and you are using the secure version of merge-on-green. Please re-review the most recent commit.',
             })
-            .catch(console.error);
+            .catch(logger.error);
           reviewsPassed = false;
         }
       });
     }
   } else {
     //if no one has reviewed it, fail the merge
-    console.log(`No one has reviewed your PR ${owner}/${repo}/${pr}`);
+    logger.info(`No one has reviewed your PR ${owner}/${repo}/${pr}`);
     return false;
   }
   return reviewsPassed;
@@ -630,7 +631,7 @@ mergeOnGreen.updateBranch = async function updateBranch(
     return update;
   } catch (err) {
     err.message = `Error in updating branch: \n\n${err.message}`;
-    console.error(err);
+    logger.error(err);
     return null;
   }
 };
@@ -661,7 +662,7 @@ mergeOnGreen.commentOnPR = async function commentOnPR(
     return data;
   } catch (err) {
     err.message = `There was an issue commenting on ${owner}/${repo} PR ${pr} \n\n${err.message}`;
-    console.error(err);
+    logger.error(err);
     return null;
   }
 };
@@ -691,7 +692,7 @@ mergeOnGreen.removeLabel = async function removeLabel(
     });
   } catch (err) {
     err.message = `There was an issue removing the automerge label on ${owner}/${repo} PR ${issue_number}\n\n${err.message}`;
-    console.error(err);
+    logger.error(err);
   }
 };
 
@@ -714,7 +715,7 @@ export async function mergeOnGreen(
   state: string,
   github: GitHubAPI
 ): Promise<boolean | undefined> {
-  console.info(`${owner}/${repo} checking merge on green PR status`);
+  logger.info(`${owner}/${repo} checking merge on green PR status`);
   const [prInfo, requiredChecks, mogLabel, headSha] = await Promise.all([
     await mergeOnGreen.getPR(owner, repo, pr, github),
     await mergeOnGreen.getBranchProtection(owner, repo, github),
@@ -723,11 +724,11 @@ export async function mergeOnGreen(
   ]);
 
   if (prInfo.state === 'closed') {
-    console.log(`${owner}/${repo}/${pr} is closed`);
+    logger.info(`${owner}/${repo}/${pr} is closed`);
     return true;
   }
   if (requiredChecks.length === 0) {
-    console.log(`${owner}/${repo}/${pr} has no required status checks`);
+    logger.info(`${owner}/${repo}/${pr} has no required status checks`);
     await mergeOnGreen.commentOnPR(
       owner,
       repo,
@@ -739,7 +740,7 @@ export async function mergeOnGreen(
   }
 
   if (!mogLabel) {
-    console.log(`${owner}/${repo}/${pr} does not have the required labels`);
+    logger.info(`${owner}/${repo}/${pr} does not have the required labels`);
     return true;
   }
 
@@ -774,14 +775,14 @@ export async function mergeOnGreen(
   const notAuthorizedMessage =
     'Merge-on-green is not authorized to push to this branch. Visit https://help.github.com/en/github/administering-a-repository/enabling-branch-restrictions to give gcf-merge-on-green permission to push to this branch.';
 
-  console.info(
+  logger.info(
     `checkReview = ${checkReview} checkStatus = ${checkStatus} state = ${state} ${owner}/${repo}/${pr}`
   );
 
   if (checkReview === true && checkStatus === true) {
     let merged = false;
     try {
-      console.info(`attempt to merge ${owner}/${repo}/${pr}`);
+      logger.info(`attempt to merge ${owner}/${repo}/${pr}`);
       await mergeOnGreen.merge(owner, repo, pr, prInfo, github);
       merged = true;
     } catch (err) {
@@ -801,21 +802,21 @@ export async function mergeOnGreen(
           );
         }
       }
-      console.info(
+      logger.info(
         `Is ${owner}/${repo}/${pr} mergeable?: ${prInfo.mergeable} Mergeable_state?: ${prInfo.mergeable_state}`
       );
       err.message = `Failed to merge "${err.message}: " ${owner}/${repo}/${pr}\n\n${err.message}`;
-      console.error(err);
+      logger.error(err);
       if (prInfo.mergeable_state === 'behind') {
-        console.info(`Attempting to update branch ${owner}/${repo}/${pr}`);
+        logger.info(`Attempting to update branch ${owner}/${repo}/${pr}`);
         try {
           await mergeOnGreen.updateBranch(owner, repo, pr, github);
         } catch (err) {
           err.message = `failed to update branch ${owner}/${repo}/${pr}\n\n${err.message}`;
-          console.error(err);
+          logger.error(err);
         }
       } else if (prInfo.mergeable_state === 'dirty') {
-        console.info(
+        logger.info(
           `There are conflicts in the base branch of ${owner}/${repo}/${pr}`
         );
         const isCommented = commentsOnPR?.find(element =>
@@ -834,7 +835,7 @@ export async function mergeOnGreen(
     }
     return merged;
   } else if (state === 'stop') {
-    console.log(
+    logger.info(
       `${owner}/${repo}/${pr} timed out before its statuses & reviews passed`
     );
     await mergeOnGreen.commentOnPR(owner, repo, pr, failedMesssage, github);
@@ -847,10 +848,10 @@ export async function mergeOnGreen(
     if (!isCommented) {
       await mergeOnGreen.commentOnPR(owner, repo, pr, continueMesssage, github);
     }
-    console.log(`${owner}/${repo}/${pr} is halfway through its check`);
+    logger.info(`${owner}/${repo}/${pr} is halfway through its check`);
     return false;
   } else {
-    console.log(
+    logger.info(
       `Statuses and/or checks failed for ${owner}/${repo}/${pr}, will check again`
     );
     return false;

--- a/packages/merge-on-green/src/merge-on-green.ts
+++ b/packages/merge-on-green/src/merge-on-green.ts
@@ -16,6 +16,7 @@
 import {Application} from 'probot';
 import {Datastore} from '@google-cloud/datastore';
 import {mergeOnGreen} from './merge-logic';
+import { logger } from 'gcf-utils';
 
 const TABLE = 'mog-prs';
 const datastore = new Datastore();
@@ -89,7 +90,7 @@ handler.listPRs = async function listPRs(): Promise<WatchPR[]> {
 handler.removePR = async function removePR(url: string) {
   const key = datastore.key([TABLE, url]);
   await datastore.delete(key);
-  console.log(`PR ${url} was removed`);
+  logger.info(`PR ${url} was removed`);
 };
 
 /**
@@ -126,7 +127,7 @@ function handler(app: Application) {
   app.on(['schedule.repository'], async context => {
     const watchedPRs = await handler.listPRs();
     const start = Date.now();
-    console.info(`running for org ${context.payload.org}`);
+    logger.info(`running for org ${context.payload.org}`);
     const filteredPRs = watchedPRs.filter(value => {
       return value.owner.startsWith(context.payload.org);
     });
@@ -134,7 +135,7 @@ function handler(app: Application) {
       const work = filteredPRs.splice(0, WORKER_SIZE);
       await Promise.all(
         work.map(async wp => {
-          console.log(`checking ${wp.url}`);
+          logger.info(`checking ${wp.url}`);
           try {
             const remove = await mergeOnGreen(
               wp.owner,
@@ -149,7 +150,7 @@ function handler(app: Application) {
             }
           } catch (err) {
             err.message = `Error in merge-on-green: \n\n${err.message}`;
-            console.error(err);
+            logger.error(err);
             if (wp.state === 'stop') {
               handler.removePR(wp.url);
             }
@@ -157,7 +158,7 @@ function handler(app: Application) {
         })
       );
     }
-    console.info(`mergeOnGreen check took ${Date.now() - start}ms`);
+    logger.info(`mergeOnGreen check took ${Date.now() - start}ms`);
   });
 
   app.on('pull_request.labeled', async context => {
@@ -180,7 +181,7 @@ function handler(app: Application) {
     const prNumber = context.payload.pull_request.number;
     const owner = context.payload.repository.owner.login;
     const repo = context.payload.repository.name;
-    console.info(`${prNumber} ${owner} ${repo}`);
+    logger.info(`${prNumber} ${owner} ${repo}`);
     //TODO: we can likely split the database functionality into its own file and
     //import these helper functions for use in the main bot event handling.
     await handler.addPR(

--- a/packages/merge-on-green/src/merge-on-green.ts
+++ b/packages/merge-on-green/src/merge-on-green.ts
@@ -16,7 +16,7 @@
 import {Application} from 'probot';
 import {Datastore} from '@google-cloud/datastore';
 import {mergeOnGreen} from './merge-logic';
-import { logger } from 'gcf-utils';
+import {logger} from 'gcf-utils';
 
 const TABLE = 'mog-prs';
 const datastore = new Datastore();


### PR DESCRIPTION
Migrate some of the bots to the logging API available in gcf-utils. Doing this in 2 stages so as to not make this one massive PR.

`console.log()` --> `logger.info()`
`console.*()` --> `logger.*()`