### PR TITLE
build: use release-please/publish for gcf-utils

### DIFF
--- a/.github/publish.yml
+++ b/.github/publish.yml
@@ -1,0 +1,1 @@
+path: packages/gcf-utils

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,3 @@
+releaseType: node
+handleGHRelease: true
+path: packages/gcf-utils

--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "compile": "tsc -p .",
     "pretest": "npm run compile",
+    "prepare": "npm run compile",
     "test": "cross-env LOG_LEVEL=fatal c8 mocha ./build/test",
     "system-test": "npm run pretest && cross-env LOG_LEVEL=fatal mocha ./build/test/integration",
     "fix": "gts fix",

--- a/packages/publish/src/publish.ts
+++ b/packages/publish/src/publish.ts
@@ -105,7 +105,9 @@ function handler(app: Application) {
       });
       // Allow a path other than the root directory to be specified for publication
       // this allows us to publish from a folder, e.g., packages/gcf-utils:
-      let pkgPath = remoteConfiguration.path ? `${unpackPath}/${remoteConfiguration.path}` : unpackPath;
+      let pkgPath = remoteConfiguration.path
+        ? `${unpackPath}/${remoteConfiguration.path}`
+        : unpackPath;
       if (files.length === 1 && files[0].isDirectory()) {
         pkgPath = `${pkgPath}/${files[0].name}`;
       }

--- a/packages/publish/src/publish.ts
+++ b/packages/publish/src/publish.ts
@@ -105,7 +105,7 @@ function handler(app: Application) {
       });
       // Allow a path other than the root directory to be specified for publication
       // this allows us to publish from a folder, e.g., packages/gcf-utils:
-      let pkgPath = remoteConfiguration.path ? `${unpackPath}/remoteConfiguration.path` : unpackPath;
+      let pkgPath = remoteConfiguration.path ? `${unpackPath}/${remoteConfiguration.path}` : unpackPath;
       if (files.length === 1 && files[0].isDirectory()) {
         pkgPath = `${pkgPath}/${files[0].name}`;
       }

--- a/packages/publish/src/publish.ts
+++ b/packages/publish/src/publish.ts
@@ -32,6 +32,7 @@ const CONFIGURATION_FILE_PATH = 'publish.yml';
 interface Configuration {
   project?: string;
   secretId?: string;
+  path?: string;
 }
 
 interface PublishConfig {
@@ -102,7 +103,9 @@ function handler(app: Application) {
       const files = await fs.readdir(unpackPath, {
         withFileTypes: true,
       });
-      let pkgPath = unpackPath;
+      // Allow a path other than the root directory to be specified for publication
+      // this allows us to publish from a folder, e.g., packages/gcf-utils:
+      let pkgPath = remoteConfiguration.path ? `${unpackPath}/remoteConfiguration.path` : unpackPath;
       if (files.length === 1 && files[0].isDirectory()) {
         pkgPath = `${pkgPath}/${files[0].name}`;
       }

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -32,7 +32,7 @@
     "@octokit/webhooks": "^7.1.1",
     "gcf-utils": "^5.2.6",
     "probot": "^9.11.2",
-    "release-please": "^5.5.0"
+    "release-please": "^5.6.0"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.6",

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -77,7 +77,7 @@ async function createReleasePR(
   releaseLabels?: string[],
   bumpMinorPreMajor?: boolean,
   snapshot?: boolean,
-  path?: string,
+  path?: string
 ) {
   const buildOptions: BuildOptions = {
     packageName,
@@ -91,7 +91,7 @@ async function createReleasePR(
     },
     bumpMinorPreMajor,
     snapshot,
-    path
+    path,
   };
   if (releaseLabels) {
     buildOptions.label = releaseLabels.join(',');
@@ -118,7 +118,7 @@ async function createGitHubRelease(
       graphql: github.graphql,
       request: github.request,
     },
-    path
+    path,
   };
   const ghr = new GitHubRelease(releaseOptions);
   await Runner.releaser(ghr);
@@ -167,7 +167,7 @@ export = (app: Application) => {
       configuration.releaseLabels,
       configuration.bumpMinorPreMajor,
       false,
-      configuration.path,
+      configuration.path
     );
 
     // release-please can handle creating a release on GitHub, we opt not to do
@@ -178,7 +178,7 @@ export = (app: Application) => {
         configuration.packageName || repoName,
         repoUrl,
         context.github,
-        path: configuration.path,
+        configuration.path
       );
     }
   });

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -35,6 +35,7 @@ interface ConfigurationOptions {
   packageName?: string;
   handleGHRelease?: boolean;
   bumpMinorPreMajor?: boolean;
+  path?: string;
 }
 
 const DEFAULT_API_URL = 'https://api.github.com';
@@ -75,7 +76,8 @@ async function createReleasePR(
   github: GitHubAPI,
   releaseLabels?: string[],
   bumpMinorPreMajor?: boolean,
-  snapshot?: boolean
+  snapshot?: boolean,
+  path?: string,
 ) {
   const buildOptions: BuildOptions = {
     packageName,
@@ -89,6 +91,7 @@ async function createReleasePR(
     },
     bumpMinorPreMajor,
     snapshot,
+    path
   };
   if (releaseLabels) {
     buildOptions.label = releaseLabels.join(',');
@@ -160,7 +163,9 @@ export = (app: Application) => {
       repoUrl,
       context.github,
       configuration.releaseLabels,
-      configuration.bumpMinorPreMajor
+      configuration.bumpMinorPreMajor,
+      false,
+      configuration.path,
     );
 
     // release-please can handle creating a release on GitHub, we opt not to do
@@ -208,7 +213,8 @@ export = (app: Application) => {
       context.github,
       configuration.releaseLabels,
       configuration.bumpMinorPreMajor,
-      true
+      true,
+      configuration.path
     );
   });
 
@@ -269,7 +275,9 @@ export = (app: Application) => {
       repoUrl,
       context.github,
       configuration.releaseLabels,
-      configuration.bumpMinorPreMajor
+      configuration.bumpMinorPreMajor,
+      false,
+      configuration.path
     );
   });
 };

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -104,7 +104,8 @@ async function createReleasePR(
 async function createGitHubRelease(
   packageName: string,
   repoUrl: string,
-  github: GitHubAPI
+  github: GitHubAPI,
+  path?: string
 ) {
   const releaseOptions: GitHubReleaseOptions = {
     label: 'autorelease: pending',
@@ -117,6 +118,7 @@ async function createGitHubRelease(
       graphql: github.graphql,
       request: github.request,
     },
+    path
   };
   const ghr = new GitHubRelease(releaseOptions);
   await Runner.releaser(ghr);
@@ -175,7 +177,8 @@ export = (app: Application) => {
       createGitHubRelease(
         configuration.packageName || repoName,
         repoUrl,
-        context.github
+        context.github,
+        path: configuration.path,
       );
     }
   });


### PR DESCRIPTION
`release-please` now has support for generating a release from a folder other than root.

This PR adds similar support to `publish` bot, and enables the automated publication of `gcf-utils`.