### PR TITLE
fix: append opts.path at end of install path

### DIFF
--- a/packages/publish/src/publish.ts
+++ b/packages/publish/src/publish.ts
@@ -105,11 +105,14 @@ function handler(app: Application) {
       });
       // Allow a path other than the root directory to be specified for publication
       // this allows us to publish from a folder, e.g., packages/gcf-utils:
-      let pkgPath = remoteConfiguration.path
-        ? `${unpackPath}/${remoteConfiguration.path}`
-        : unpackPath;
+      let pkgPath = unpackPath;
+      // Tarballs returned by GitHub are nested a folder deep, we should traverse
+      // into this folder:
       if (files.length === 1 && files[0].isDirectory()) {
         pkgPath = `${pkgPath}/${files[0].name}`;
+      }
+      if (remoteConfiguration.path) {
+        pkgPath = `${pkgPath}/${remoteConfiguration.path}`
       }
 
       const secret: Secret = await handler.getPublicationSecrets(
@@ -404,6 +407,7 @@ handler.publish = async (opts: PublishOpts) => {
     );
   } catch (err) {
     app.log.error(err);
+    throw err;
   }
 };
 

--- a/packages/publish/src/publish.ts
+++ b/packages/publish/src/publish.ts
@@ -112,7 +112,7 @@ function handler(app: Application) {
         pkgPath = `${pkgPath}/${files[0].name}`;
       }
       if (remoteConfiguration.path) {
-        pkgPath = `${pkgPath}/${remoteConfiguration.path}`
+        pkgPath = `${pkgPath}/${remoteConfiguration.path}`;
       }
 
       const secret: Secret = await handler.getPublicationSecrets(


### PR DESCRIPTION
* we were appending `opts.path` before traversing into the top level folder in tarballs returned by GitHub.
* also noticed we suppress errors from npm, let's not do this as it can hide broken publishes.