### PR TITLE
fix(sync-repo-settings): send magic header

### DIFF
--- a/packages/sync-repo-settings/src/sync-repo-settings.ts
+++ b/packages/sync-repo-settings/src/sync-repo-settings.ts
@@ -176,6 +176,9 @@ async function updateMasterBranchProtection(
       },
       enforce_admins: rule.isAdminEnforced!,
       restrictions: null!,
+      headers: {
+        accept: 'application/vnd.github.luke-cage-preview+json',
+      },
     });
   } catch (err) {
     if (err.status === 401) {


### PR DESCRIPTION
The API call I was making here required a fancy header based on the use of the `required_approving_review_count` field.  Sorry bout that 🙃 