### PR TITLE
fix(buildcop): add support for Ruby logs

### DIFF
--- a/packages/buildcop/__snapshots__/buildcop.js
+++ b/packages/buildcop/__snapshots__/buildcop.js
@@ -252,3 +252,13 @@ exports['buildcop app xunitXML Grouped issues closes an individual issue and kee
 exports['buildcop app xunitXML Grouped issues closes an individual issue and keeps grouped issue open 3'] = {
   "state": "closed"
 }
+
+exports['buildcop app xunitXML opens an issue [Ruby] 1'] = {
+  "title": "Minitest::Result: test_0001_lists entries of a log failed",
+  "body": "This test failed!\n\nTo configure my behavior, see [the Build Cop Bot documentation](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop).\n\nIf I'm commenting on this issue too often, add the `buildcop: quiet` label and\nI will stop commenting.\n\n---\n\ncommit: 123\nbuildURL: http://example.com\nstatus: failed\n<details><summary>Test output</summary><br><pre>/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/assertions.rb:183:in `assert'\n/tmpfs/src/github/ruby-docs-samples/logging/acceptance/sample_test.rb:126:in `block (3 levels) in <top (required)>'\n/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:98:in `block (3 levels) in run'\n/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:195:in `capture_exceptions'\n/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:95:in `block (2 levels) in run'\n/usr/local/bundle/gems/minitest-5.14.1/lib/minitest.rb:272:in `time_it'\n/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:94:in `block in run'\n/usr/local/bundle/gems/minitest-5.14.1/lib/minitest.rb:367:in `on_signal'\n/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:211:in `with_info_handler'\n/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:93:in `run'\n/usr/local/bundle/gems/minitest-5.14.1/lib/minitest.rb:1029:in `run_one_method'\n/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/parallel.rb:33:in `block (2 levels) in start'</pre></details>",
+  "labels": [
+    "type: bug",
+    "priority: p1",
+    "buildcop: issue"
+  ]
+}

--- a/packages/buildcop/src/buildcop.ts
+++ b/packages/buildcop/src/buildcop.ts
@@ -809,7 +809,8 @@ buildcop.findTestResults = (xml: string): TestResults => {
     testsuites = [testsuites];
   }
   for (const suite of testsuites) {
-    const testsuiteName = suite['_attributes'].name;
+    // Ruby doesn't always have _attributes.
+    const testsuiteName = suite['_attributes']?.name;
     let testcases = suite['testcase'];
     // If there were no tests in the package, continue.
     if (testcases === undefined) {
@@ -821,7 +822,11 @@ buildcop.findTestResults = (xml: string): TestResults => {
     }
     for (const testcase of testcases) {
       let pkg = testsuiteName;
-      if (testsuiteName === 'pytest' || testsuiteName === 'Mocha Tests') {
+      if (
+        !testsuiteName ||
+        testsuiteName === 'pytest' ||
+        testsuiteName === 'Mocha Tests'
+      ) {
         pkg = testcase['_attributes'].classname;
       }
       // Ignore skipped tests. They didn't pass and they didn't fail.

--- a/packages/buildcop/test/buildcop.ts
+++ b/packages/buildcop/test/buildcop.ts
@@ -431,6 +431,22 @@ describe('buildcop', () => {
         scopes.forEach(s => s.done());
       });
 
+      it('opens an issue [Ruby]', async () => {
+        const payload = buildPayload(
+          'ruby_one_failed.xml',
+          'ruby-docs-samples'
+        );
+
+        const scopes = [
+          nockIssues('ruby-docs-samples'),
+          nockNewIssue('ruby-docs-samples'),
+        ];
+
+        await probot.receive({name: 'pubsub.message', payload, id: 'abc123'});
+
+        scopes.forEach(s => s.done());
+      });
+
       it('comments on existing issue', async () => {
         const payload = buildPayload('one_failed.xml', 'golang-samples');
 

--- a/packages/buildcop/test/fixtures/testdata/ruby_one_failed.xml
+++ b/packages/buildcop/test/fixtures/testdata/ruby_one_failed.xml
@@ -1,0 +1,23 @@
+<testsuite>
+<testcase classname="Minitest::Result" name="test_0001_creates a logging client" time="0.042767159999982596" assertions="1"></testcase>
+<testcase classname="Minitest::Result" name="test_0001_changes the destination of a sink" time="5.077616300000045" assertions="2"></testcase>
+<testcase classname="Minitest::Result" name="test_0001_writes a log entry" time="120.28082069800001" assertions="2"></testcase>
+<testcase classname="Minitest::Result" name="test_0001_creates a new log entry" time="120.08190159999998" assertions="2"></testcase>
+<testcase classname="Minitest::Result" name="test_0001_creates a log sink" time="2.869683899999984" assertions="4"></testcase>
+<testcase classname="Minitest::Result" name="test_0001_lists the log sinks" time="2.7439611350000064" assertions="2"></testcase>
+<testcase classname="Minitest::Result" name="test_0001_writes an entry to a log" time="120.02962853899999" assertions="3"></testcase>
+<testcase classname="Minitest::Result" name="test_0001_changes the destination of a sink" time="3.315922103999924" assertions="3"></testcase>
+<testcase classname="Minitest::Result" name="test_0001_deletes a log" time="429.4346963400001" assertions="3"></testcase>
+<testcase classname="Minitest::Result" name="test_0001_lists entries of a log" time="233.43151779999994" assertions="1"><failure message="Failure:&#10;Logging Samples::list_log_entries#test_0001_lists entries of a log [/tmpfs/src/github/ruby-docs-samples/logging/acceptance/sample_test.rb:126]:&#10;Expected false to be truthy.&#10;">/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/assertions.rb:183:in `assert'
+/tmpfs/src/github/ruby-docs-samples/logging/acceptance/sample_test.rb:126:in `block (3 levels) in &lt;top (required)&gt;'
+/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:98:in `block (3 levels) in run'
+/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:195:in `capture_exceptions'
+/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:95:in `block (2 levels) in run'
+/usr/local/bundle/gems/minitest-5.14.1/lib/minitest.rb:272:in `time_it'
+/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:94:in `block in run'
+/usr/local/bundle/gems/minitest-5.14.1/lib/minitest.rb:367:in `on_signal'
+/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:211:in `with_info_handler'
+/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/test.rb:93:in `run'
+/usr/local/bundle/gems/minitest-5.14.1/lib/minitest.rb:1029:in `run_one_method'
+/usr/local/bundle/gems/minitest-5.14.1/lib/minitest/parallel.rb:33:in `block (2 levels) in start'</failure></testcase>
+</testsuite>


### PR DESCRIPTION
I confirmed the test case failed with the same error message as #768 before making the corresponding src/buildcop.ts changes.

Fixes #768.