### PR TITLE
fix(merge-on-green): payload switches between Buffer and object

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -368,7 +368,14 @@ export class GCFBootstrapper {
             logger.info(`${id}: skipping Cloud Tasks`);
           }
           let payload = request.body;
-          if (triggerType === TriggerType.PUBSUB) {
+          if (
+            triggerType === TriggerType.PUBSUB ||
+            triggerType === TriggerType.SCHEDULER
+          ) {
+            // TODO(sofisl): investigate why TriggerType.SCHEDULER sometimes has a Buffer
+            // for its payload, and other times has an already parsed object.
+            //
+            // TODO: add unit tests for both forms of payload.
             payload = this.parsePubSubPayload(request);
           }
           await this.probot.receive({


### PR DESCRIPTION
In debugging the issues with merge on green on GoogleCloudPlatform,
we ultimately were able to isolate the problem to the fact that
Cloud Scheduler tasks for googlapis were parsed as objects upon
arrival to our Cloud Function, whereas payloads for GoogleCloudPlatform
were still a Buffer.

We already have a helper that conditionally decodes the payload
appropriately let's use this.

Note: we should still try to root cause this, if only because it's
bizarre.