### PR TITLE
build(release-please): remove caret from webhooks import

### DIFF
--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^18.0.0",
-    "@octokit/webhooks": "^7.1.1",
+    "@octokit/webhooks": "7.1.1",
     "gcf-utils": "^5.3.0",
     "probot": "^9.11.2",
     "release-please": "^5.6.0"


### PR DESCRIPTION
Remove the caret on release-please's @octokit/webhooks dependency to not pull in a newer version which causes tests to break. Full explanation here: https://github.com/googleapis/repo-automation-bots/issues/792

This is a temporary fix to unblock some PRs until we fully support the newer versions