### PR TITLE
feat(gcf-utils): add trigger info as bindings to all log statements

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -214,10 +214,12 @@ export class GCFBootstrapper {
       );
 
       const triggerInfo = buildTriggerInfo(triggerType, id, request.body);
-      logger.metric(triggerInfo);
+      GCFBootstrapper.bindPropertiesToLogger(triggerInfo); // no message in triggerInfo
 
-      delete triggerInfo.message; // we don't want to bind the message to every log entry
-      GCFBootstrapper.bindPropertiesToLogger(triggerInfo);
+      logger.metric({
+        message: `Execution started by ${triggerType}`,
+        ...triggerInfo,
+      });
 
       try {
         if (triggerType === TriggerType.UNKNOWN) {

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -184,16 +184,16 @@ export class GCFBootstrapper {
   /**
    * Binds the trigger info to the logger so that every logged statement
    * includes the trigger info. Does not bind the message property.
-   * 
+   *
    * NOTE: statements logged before this method is called will not include
    * the trigger info
    * NOTE: this method modifies the triggerInfo parameter given
-   * 
+   *
    * @param triggerInfo trigger information for current execution
    */
   private static bindTriggerInfoToLogger(triggerInfo: TriggerInfo) {
     delete triggerInfo.message;
-    logger = initLogger({bindings: triggerInfo});
+    logger = logger.child(triggerInfo);
   }
 
   gcf(

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -214,12 +214,8 @@ export class GCFBootstrapper {
       );
 
       const triggerInfo = buildTriggerInfo(triggerType, id, request.body);
-      GCFBootstrapper.bindPropertiesToLogger(triggerInfo); // no message in triggerInfo
-
-      logger.metric({
-        message: `Execution started by ${triggerType}`,
-        ...triggerInfo,
-      });
+      GCFBootstrapper.bindPropertiesToLogger(triggerInfo);
+      logger.metric(`Execution started by ${triggerType}`);
 
       try {
         if (triggerType === TriggerType.UNKNOWN) {

--- a/packages/gcf-utils/src/logging/trigger-info-builder.ts
+++ b/packages/gcf-utils/src/logging/trigger-info-builder.ts
@@ -18,7 +18,8 @@ import crypto from 'crypto';
 /**
  * Information on GCF execution trigger
  */
-interface TriggerInfo {
+export interface TriggerInfo {
+  message: string;
   trigger: {
     trigger_type: TriggerType;
     trigger_sender?: string;
@@ -37,7 +38,6 @@ interface TriggerInfo {
       repo_name: string;
       url: string;
     };
-    message: string;
   };
 }
 
@@ -56,9 +56,9 @@ export function buildTriggerInfo(
   const UNKNOWN = 'UNKNOWN';
 
   const triggerInfo: TriggerInfo = {
+    message: `Execution started by ${triggerType}`,
     trigger: {
       trigger_type: triggerType,
-      message: `Execution started by ${triggerType}`,
     },
   };
 

--- a/packages/gcf-utils/src/logging/trigger-info-builder.ts
+++ b/packages/gcf-utils/src/logging/trigger-info-builder.ts
@@ -19,7 +19,6 @@ import crypto from 'crypto';
  * Information on GCF execution trigger
  */
 export interface TriggerInfo {
-  message: string;
   trigger: {
     trigger_type: TriggerType;
     trigger_sender?: string;
@@ -56,7 +55,6 @@ export function buildTriggerInfo(
   const UNKNOWN = 'UNKNOWN';
 
   const triggerInfo: TriggerInfo = {
-    message: `Execution started by ${triggerType}`,
     trigger: {
       trigger_type: triggerType,
     },

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -21,7 +21,6 @@ import sinon from 'sinon';
 import nock from 'nock';
 import assert from 'assert';
 import {v1} from '@google-cloud/secret-manager';
-import {TriggerInfo} from '../src/logging/trigger-info-builder';
 
 nock.disableNetConnect();
 
@@ -369,8 +368,8 @@ describe('GCFBootstrapper', () => {
     });
   });
 
-  describe('bindTriggerInfoToLogger', () => {
-    it('binds all trigger info properties except message', () => {
+  describe('bindPropertiesToLogger', () => {
+    it('binds given properties', () => {
       const triggerInfoWithoutMessage = {
         trigger: {
           trigger_type: 'GITHUB_WEBHOOK',
@@ -386,12 +385,7 @@ describe('GCFBootstrapper', () => {
         },
       };
 
-      const triggerInfo = {
-        ...triggerInfoWithoutMessage,
-        message: 'some message',
-      };
-
-      GCFBootstrapper['bindTriggerInfoToLogger'](triggerInfo as TriggerInfo);
+      GCFBootstrapper['bindPropertiesToLogger'](triggerInfoWithoutMessage);
       assert.deepEqual(logger.bindings(), triggerInfoWithoutMessage);
     });
   });

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {GCFBootstrapper, WrapOptions} from '../src/gcf-utils';
-import {describe, beforeEach, afterEach, it} from 'mocha';
-import {GitHubAPI} from 'probot/lib/github';
-import {Options} from 'probot';
+import { GCFBootstrapper, WrapOptions, logger} from '../src/gcf-utils';
+import { describe, beforeEach, afterEach, it } from 'mocha';
+import { GitHubAPI } from 'probot/lib/github';
+import { Options } from 'probot';
 import * as express from 'express';
 import sinon from 'sinon';
 import nock from 'nock';
 import assert from 'assert';
-import {v1} from '@google-cloud/secret-manager';
+import { v1 } from '@google-cloud/secret-manager';
+import { TriggerInfo } from '../src/logging/trigger-info-builder';
 
 nock.disableNetConnect();
 
@@ -65,7 +66,7 @@ describe('GCFBootstrapper', () => {
       bootstrapper = new GCFBootstrapper();
       configStub = sinon
         .stub(bootstrapper, 'getProbotConfig')
-        .resolves({id: 1234, secret: 'foo', webhookPath: 'bar'});
+        .resolves({ id: 1234, secret: 'foo', webhookPath: 'bar' });
 
       enqueueTask = sinon.stub(bootstrapper, 'enqueueTask');
       sinon.stub(bootstrapper, 'getInstallationToken');
@@ -91,7 +92,7 @@ describe('GCFBootstrapper', () => {
     it('calls the event handler', async () => {
       await mockBootstrapper();
       req.body = {
-        installation: {id: 1},
+        installation: { id: 1 },
       };
       req.headers = {};
       req.headers['x-github-event'] = 'issues';
@@ -113,7 +114,7 @@ describe('GCFBootstrapper', () => {
         logging: true,
       });
       req.body = {
-        installation: {id: 1},
+        installation: { id: 1 },
       };
       req.headers = {};
       req.headers['x-github-event'] = 'issues';
@@ -130,7 +131,7 @@ describe('GCFBootstrapper', () => {
     it('does nothing if there are missing headers', async () => {
       await mockBootstrapper();
       req.body = {
-        installation: {id: 1},
+        installation: { id: 1 },
       };
       req.headers = {};
 
@@ -145,7 +146,7 @@ describe('GCFBootstrapper', () => {
     it('returns 500 on errors', async () => {
       await mockBootstrapper();
       req.body = {
-        installtion: {id: 1},
+        installtion: { id: 1 },
       };
       req.headers = {};
       req.headers['x-github-event'] = 'err';
@@ -163,7 +164,7 @@ describe('GCFBootstrapper', () => {
     it('ensures that task is enqueued when called by scheduler for one repo', async () => {
       await mockBootstrapper();
       req.body = {
-        installation: {id: 1},
+        installation: { id: 1 },
         repo: 'firstRepo',
       };
       req.headers = {};
@@ -179,7 +180,7 @@ describe('GCFBootstrapper', () => {
     it('ensures that task is enqueued when called by scheduler for many repos', async () => {
       await mockBootstrapper();
       req.body = {
-        installation: {id: 1},
+        installation: { id: 1 },
       };
       req.headers = {};
       req.headers['x-github-event'] = 'schedule.repository';
@@ -195,7 +196,7 @@ describe('GCFBootstrapper', () => {
     it('ensures that task is enqueued when called by Github', async () => {
       await mockBootstrapper();
       req.body = {
-        installtion: {id: 1},
+        installtion: { id: 1 },
       };
       req.headers = {};
       req.headers['x-github-event'] = 'another.name';
@@ -216,7 +217,7 @@ describe('GCFBootstrapper', () => {
       bootstrapper = new GCFBootstrapper();
       configStub = sinon
         .stub(bootstrapper, 'getProbotConfig')
-        .resolves({id: 1234, secret: 'foo', webhookPath: 'bar'});
+        .resolves({ id: 1234, secret: 'foo', webhookPath: 'bar' });
     });
 
     afterEach(() => {
@@ -280,7 +281,7 @@ describe('GCFBootstrapper', () => {
         ]);
       await bootstrapper.getProbotConfig();
       sinon.assert.calledOnce(secretsStub);
-      sinon.assert.calledOnceWithExactly(secretsStub, {name: 'foobar'});
+      sinon.assert.calledOnceWithExactly(secretsStub, { name: 'foobar' });
       sinon.assert.calledOnce(secretVersionNameStub);
     });
 
@@ -367,4 +368,28 @@ describe('GCFBootstrapper', () => {
       assert.strictEqual(latest, 'projects/foo/secrets/bar');
     });
   });
+
+  describe('bindTriggerInfoToLogger', () => {
+    it('binds all trigger info properties except message', () => {
+      const triggerInfoWithoutMessage = {
+        trigger: {
+          trigger_type: 'GITHUB_WEBHOOK',
+          trigger_sender: "some sender",
+          payload_hash: "123456",
+
+          trigger_source_repo: {
+            owner: "foo owner",
+            owner_type: "Org",
+            repo_name: "bar name",
+            url: "some url",
+          }
+        }
+      }
+
+      const triggerInfo = {...triggerInfoWithoutMessage, message: "some message" }
+
+      GCFBootstrapper['bindTriggerInfoToLogger'](triggerInfo as TriggerInfo);
+      assert.deepEqual(logger.bindings(), triggerInfoWithoutMessage)
+    })
+  })
 });

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GCFBootstrapper, WrapOptions, logger} from '../src/gcf-utils';
-import { describe, beforeEach, afterEach, it } from 'mocha';
-import { GitHubAPI } from 'probot/lib/github';
-import { Options } from 'probot';
+import {GCFBootstrapper, WrapOptions, logger} from '../src/gcf-utils';
+import {describe, beforeEach, afterEach, it} from 'mocha';
+import {GitHubAPI} from 'probot/lib/github';
+import {Options} from 'probot';
 import * as express from 'express';
 import sinon from 'sinon';
 import nock from 'nock';
 import assert from 'assert';
-import { v1 } from '@google-cloud/secret-manager';
-import { TriggerInfo } from '../src/logging/trigger-info-builder';
+import {v1} from '@google-cloud/secret-manager';
+import {TriggerInfo} from '../src/logging/trigger-info-builder';
 
 nock.disableNetConnect();
 
@@ -66,7 +66,7 @@ describe('GCFBootstrapper', () => {
       bootstrapper = new GCFBootstrapper();
       configStub = sinon
         .stub(bootstrapper, 'getProbotConfig')
-        .resolves({ id: 1234, secret: 'foo', webhookPath: 'bar' });
+        .resolves({id: 1234, secret: 'foo', webhookPath: 'bar'});
 
       enqueueTask = sinon.stub(bootstrapper, 'enqueueTask');
       sinon.stub(bootstrapper, 'getInstallationToken');
@@ -92,7 +92,7 @@ describe('GCFBootstrapper', () => {
     it('calls the event handler', async () => {
       await mockBootstrapper();
       req.body = {
-        installation: { id: 1 },
+        installation: {id: 1},
       };
       req.headers = {};
       req.headers['x-github-event'] = 'issues';
@@ -114,7 +114,7 @@ describe('GCFBootstrapper', () => {
         logging: true,
       });
       req.body = {
-        installation: { id: 1 },
+        installation: {id: 1},
       };
       req.headers = {};
       req.headers['x-github-event'] = 'issues';
@@ -131,7 +131,7 @@ describe('GCFBootstrapper', () => {
     it('does nothing if there are missing headers', async () => {
       await mockBootstrapper();
       req.body = {
-        installation: { id: 1 },
+        installation: {id: 1},
       };
       req.headers = {};
 
@@ -146,7 +146,7 @@ describe('GCFBootstrapper', () => {
     it('returns 500 on errors', async () => {
       await mockBootstrapper();
       req.body = {
-        installtion: { id: 1 },
+        installtion: {id: 1},
       };
       req.headers = {};
       req.headers['x-github-event'] = 'err';
@@ -164,7 +164,7 @@ describe('GCFBootstrapper', () => {
     it('ensures that task is enqueued when called by scheduler for one repo', async () => {
       await mockBootstrapper();
       req.body = {
-        installation: { id: 1 },
+        installation: {id: 1},
         repo: 'firstRepo',
       };
       req.headers = {};
@@ -180,7 +180,7 @@ describe('GCFBootstrapper', () => {
     it('ensures that task is enqueued when called by scheduler for many repos', async () => {
       await mockBootstrapper();
       req.body = {
-        installation: { id: 1 },
+        installation: {id: 1},
       };
       req.headers = {};
       req.headers['x-github-event'] = 'schedule.repository';
@@ -196,7 +196,7 @@ describe('GCFBootstrapper', () => {
     it('ensures that task is enqueued when called by Github', async () => {
       await mockBootstrapper();
       req.body = {
-        installtion: { id: 1 },
+        installtion: {id: 1},
       };
       req.headers = {};
       req.headers['x-github-event'] = 'another.name';
@@ -217,7 +217,7 @@ describe('GCFBootstrapper', () => {
       bootstrapper = new GCFBootstrapper();
       configStub = sinon
         .stub(bootstrapper, 'getProbotConfig')
-        .resolves({ id: 1234, secret: 'foo', webhookPath: 'bar' });
+        .resolves({id: 1234, secret: 'foo', webhookPath: 'bar'});
     });
 
     afterEach(() => {
@@ -281,7 +281,7 @@ describe('GCFBootstrapper', () => {
         ]);
       await bootstrapper.getProbotConfig();
       sinon.assert.calledOnce(secretsStub);
-      sinon.assert.calledOnceWithExactly(secretsStub, { name: 'foobar' });
+      sinon.assert.calledOnceWithExactly(secretsStub, {name: 'foobar'});
       sinon.assert.calledOnce(secretVersionNameStub);
     });
 
@@ -374,22 +374,25 @@ describe('GCFBootstrapper', () => {
       const triggerInfoWithoutMessage = {
         trigger: {
           trigger_type: 'GITHUB_WEBHOOK',
-          trigger_sender: "some sender",
-          payload_hash: "123456",
+          trigger_sender: 'some sender',
+          payload_hash: '123456',
 
           trigger_source_repo: {
-            owner: "foo owner",
-            owner_type: "Org",
-            repo_name: "bar name",
-            url: "some url",
-          }
-        }
-      }
+            owner: 'foo owner',
+            owner_type: 'Org',
+            repo_name: 'bar name',
+            url: 'some url',
+          },
+        },
+      };
 
-      const triggerInfo = {...triggerInfoWithoutMessage, message: "some message" }
+      const triggerInfo = {
+        ...triggerInfoWithoutMessage,
+        message: 'some message',
+      };
 
       GCFBootstrapper['bindTriggerInfoToLogger'](triggerInfo as TriggerInfo);
-      assert.deepEqual(logger.bindings(), triggerInfoWithoutMessage)
-    })
-  })
+      assert.deepEqual(logger.bindings(), triggerInfoWithoutMessage);
+    });
+  });
 });

--- a/packages/gcf-utils/test/gcf-logger.ts
+++ b/packages/gcf-utils/test/gcf-logger.ts
@@ -26,7 +26,9 @@ describe('GCFLogger', () => {
   });
   describe('logger instance', () => {
     let destination: ObjectWritableMock;
-    let logger: GCFLogger & {[key: string]: Function};
+    let loggerNoBindings: GCFLogger & {[key: string]: Function};
+    let loggerWithBindings: GCFLogger & {[key: string]: Function};
+    const bindings = {'foo': 'bar-binding'};
 
     function readLogsAsObjects(writeStream: ObjectWritableMock): LogLine[] {
       try {
@@ -41,13 +43,13 @@ describe('GCFLogger', () => {
     function testAllLevels() {
       for (const level of Object.keys(logLevels)) {
         it(`logs ${level} level string`, () => {
-          logger[level]('hello world');
+          loggerNoBindings[level]('hello world');
           const loggedLines: LogLine[] = readLogsAsObjects(destination);
           validateLogs(loggedLines, 1, ['hello world'], [], logLevels[level]);
         });
 
         it(`logs ${level} level json`, () => {
-          logger[level]({hello: 'world'});
+          loggerNoBindings[level]({hello: 'world'});
           const loggedLines: LogLine[] = readLogsAsObjects(destination);
           validateLogs(
             loggedLines,
@@ -57,12 +59,31 @@ describe('GCFLogger', () => {
             logLevels[level]
           );
         });
+
+        it(`logs ${level} level string with bindings`, () => {
+          loggerWithBindings[level]('hello world');
+          const loggedLines: LogLine[] = readLogsAsObjects(destination);
+          validateLogs(loggedLines, 1, ['hello world'], [bindings], logLevels[level]);
+        });
+
+        it(`logs ${level} level json with bindings`, () => {
+          loggerWithBindings[level]({hello: 'world'});
+          const loggedLines: LogLine[] = readLogsAsObjects(destination);
+          validateLogs(
+            loggedLines,
+            1,
+            [],
+            [{...bindings, hello: 'world'}],
+            logLevels[level]
+          );
+        });
       }
     }
 
     beforeEach(() => {
       destination = new ObjectWritableMock();
-      logger = initLogger(destination) as GCFLogger & {[key: string]: Function};
+      loggerNoBindings = initLogger({destination}) as GCFLogger & {[key: string]: Function};
+      loggerWithBindings = initLogger({bindings, destination}) as GCFLogger & {[key: string]: Function};
     });
 
     testAllLevels();

--- a/packages/gcf-utils/test/gcf-logger.ts
+++ b/packages/gcf-utils/test/gcf-logger.ts
@@ -28,7 +28,7 @@ describe('GCFLogger', () => {
     let destination: ObjectWritableMock;
     let loggerNoBindings: GCFLogger & {[key: string]: Function};
     let loggerWithBindings: GCFLogger & {[key: string]: Function};
-    const bindings = {'foo': 'bar-binding'};
+    const bindings = {foo: 'bar-binding'};
 
     function readLogsAsObjects(writeStream: ObjectWritableMock): LogLine[] {
       try {
@@ -63,7 +63,13 @@ describe('GCFLogger', () => {
         it(`logs ${level} level string with bindings`, () => {
           loggerWithBindings[level]('hello world');
           const loggedLines: LogLine[] = readLogsAsObjects(destination);
-          validateLogs(loggedLines, 1, ['hello world'], [bindings], logLevels[level]);
+          validateLogs(
+            loggedLines,
+            1,
+            ['hello world'],
+            [bindings],
+            logLevels[level]
+          );
         });
 
         it(`logs ${level} level json with bindings`, () => {
@@ -82,8 +88,12 @@ describe('GCFLogger', () => {
 
     beforeEach(() => {
       destination = new ObjectWritableMock();
-      loggerNoBindings = initLogger({destination}) as GCFLogger & {[key: string]: Function};
-      loggerWithBindings = initLogger({bindings, destination}) as GCFLogger & {[key: string]: Function};
+      loggerNoBindings = initLogger({destination}) as GCFLogger & {
+        [key: string]: Function;
+      };
+      loggerWithBindings = loggerNoBindings.child(bindings) as GCFLogger & {
+        [key: string]: Function;
+      };
     });
 
     testAllLevels();

--- a/packages/gcf-utils/test/integration/gcf-logger-integration.ts
+++ b/packages/gcf-utils/test/integration/gcf-logger-integration.ts
@@ -69,7 +69,7 @@ describe('GCFLogger Integration', () => {
 
   beforeEach(() => {
     destination = pino.destination(testStreamPath);
-    logger = initLogger(destination) as GCFLogger & {[key: string]: Function};
+    logger = initLogger({destination: destination}) as GCFLogger & {[key: string]: Function};
   });
 
   testAllLevels();

--- a/packages/gcf-utils/test/integration/gcf-logger-integration.ts
+++ b/packages/gcf-utils/test/integration/gcf-logger-integration.ts
@@ -20,7 +20,9 @@ import SonicBoom from 'sonic-boom';
 import fs from 'fs';
 
 describe('GCFLogger Integration', () => {
-  let logger: GCFLogger & {[key: string]: Function};
+  let loggerNoBindings: GCFLogger & {[key: string]: Function};
+  let loggerWithBindings: GCFLogger & {[key: string]: Function};
+  const bindings = {foo: 'bar-binding'};
   const testStreamPath = './test-stream.txt';
   let destination: SonicBoom;
 
@@ -42,7 +44,7 @@ describe('GCFLogger Integration', () => {
   function testAllLevels() {
     for (const level of Object.keys(logLevels)) {
       it(`logs ${level} level string`, done => {
-        logger[level]('hello world');
+        loggerNoBindings[level]('hello world');
         destination.on('ready', () => {
           const loggedLines: LogLine[] = readLogsAsObjects(destination);
           validateLogs(loggedLines, 1, ['hello world'], [], logLevels[level]);
@@ -51,7 +53,7 @@ describe('GCFLogger Integration', () => {
       });
 
       it(`logs ${level} level json`, done => {
-        logger[level]({hello: 'world'});
+        loggerNoBindings[level]({hello: 'world'});
         destination.on('ready', () => {
           const loggedLines: LogLine[] = readLogsAsObjects(destination);
           validateLogs(
@@ -64,12 +66,41 @@ describe('GCFLogger Integration', () => {
           done();
         });
       });
+
+      it(`logs ${level} level string with bindings`, () => {
+        loggerWithBindings[level]('hello world');
+        const loggedLines: LogLine[] = readLogsAsObjects(destination);
+        validateLogs(
+          loggedLines,
+          1,
+          ['hello world'],
+          [bindings],
+          logLevels[level]
+        );
+      });
+
+      it(`logs ${level} level json with bindings`, () => {
+        loggerWithBindings[level]({hello: 'world'});
+        const loggedLines: LogLine[] = readLogsAsObjects(destination);
+        validateLogs(
+          loggedLines,
+          1,
+          [],
+          [{...bindings, hello: 'world'}],
+          logLevels[level]
+        );
+      });
     }
   }
 
   beforeEach(() => {
     destination = pino.destination(testStreamPath);
-    logger = initLogger({destination: destination}) as GCFLogger & {[key: string]: Function};
+    loggerNoBindings = initLogger({destination: destination}) as GCFLogger & {
+      [key: string]: Function;
+    };
+    loggerWithBindings = loggerNoBindings.child(bindings) as GCFLogger & {
+      [key: string]: Function;
+    };
   });
 
   testAllLevels();

--- a/packages/gcf-utils/test/trigger-info-builder.ts
+++ b/packages/gcf-utils/test/trigger-info-builder.ts
@@ -28,9 +28,9 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
+      message: 'Execution started by Pub/Sub',
       trigger: {
         trigger_type: 'Pub/Sub',
-        message: 'Execution started by Pub/Sub',
       },
     };
     assert.deepEqual(triggerInfo, expectedInfo);
@@ -46,9 +46,9 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
+      message: 'Execution started by Cloud Scheduler',
       trigger: {
         trigger_type: 'Cloud Scheduler',
-        message: 'Execution started by Cloud Scheduler',
       },
     };
     assert.deepEqual(triggerInfo, expectedInfo);
@@ -64,10 +64,10 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
+      message: 'Execution started by Cloud Task',
       trigger: {
         trigger_type: 'Cloud Task',
         github_delivery_guid: '1234',
-        message: 'Execution started by Cloud Task',
       },
     };
     assert.deepEqual(triggerInfo, expectedInfo);
@@ -84,11 +84,11 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
+      message: 'Execution started by GitHub Webhook',
       trigger: {
         trigger_type: 'GitHub Webhook',
         trigger_sender: 'testUser2',
         github_delivery_guid: '1234',
-        message: 'Execution started by GitHub Webhook',
         trigger_source_repo: {
           owner: 'testOwner',
           owner_type: 'User',
@@ -112,9 +112,9 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
+      message: 'Execution started by GitHub Webhook',
       trigger: {
         trigger_type: 'GitHub Webhook',
-        message: 'Execution started by GitHub Webhook',
         trigger_sender: 'UNKNOWN',
         github_delivery_guid: '',
         trigger_source_repo: {

--- a/packages/gcf-utils/test/trigger-info-builder.ts
+++ b/packages/gcf-utils/test/trigger-info-builder.ts
@@ -28,7 +28,6 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
-      message: 'Execution started by Pub/Sub',
       trigger: {
         trigger_type: 'Pub/Sub',
       },
@@ -46,7 +45,6 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
-      message: 'Execution started by Cloud Scheduler',
       trigger: {
         trigger_type: 'Cloud Scheduler',
       },
@@ -64,7 +62,6 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
-      message: 'Execution started by Cloud Task',
       trigger: {
         trigger_type: 'Cloud Task',
         github_delivery_guid: '1234',
@@ -84,7 +81,6 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
-      message: 'Execution started by GitHub Webhook',
       trigger: {
         trigger_type: 'GitHub Webhook',
         trigger_sender: 'testUser2',
@@ -112,7 +108,6 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
-      message: 'Execution started by GitHub Webhook',
       trigger: {
         trigger_type: 'GitHub Webhook',
         trigger_sender: 'UNKNOWN',


### PR DESCRIPTION
* Adds support for initializing GCFLogger with bindings
* Adds support for child loggers (with bindings) to GCFLogger
* Uses above mentioned child logger functionality to bind trigger information to all log statements for an execution

Resulting log statements will look something like this:

```ts
(in gcf-utils.ts)

const triggerInfo  = {
    trigger: {
        trigger_type: 'GITHUB_WEBHOOK',
        trigger_sender: 'some sender',
        payload_hash: '123456',
        trigger_source_repo: {
            owner: 'foo owner',
            owner_type: 'Org',
            repo_name: 'bar name',
            url: 'some url',
        },
    },
};

...

bindTriggerInfoToLogger(triggerInfo);
```

```ts
(in some-bot.ts)

// after gcf-utils has done all the trigger parsing and logged the trigger information the first time

logger.info({ some-property: 'some-value' });
```
```ts
(Cloud Logs Viewer)

{
    insertId: "xyz",
    jsonPayload: {
        some-property: "some-value",                // what the bot logged
        trigger: {                                   // what was automatically attached to logs
            trigger_type: 'GITHUB_WEBHOOK',
            trigger_sender: 'some sender',
            payload_hash: '123456',
            trigger_source_repo: {
                owner: 'foo owner',
                owner_type: 'Org',
                repo_name: 'bar name',
                url: 'some url',
            },
        },
    },
    resource: {
        type: "cloud-function",
        labels: {
            function_name: "some-bot",
            project_id: "repo-automation-bots",
            region: "us-central1"
        },
    },
    timestamp: "12345",
    severity: "INFO",
    labels: {
        execution_id: "abcd"
    }
}
```
Fixes https://github.com/googleapis/repo-automation-bots/issues/777