### PR TITLE
chore(sync-repo-settings): add debug for required status checks

### DIFF
--- a/packages/sync-repo-settings/src/sync-repo-settings.ts
+++ b/packages/sync-repo-settings/src/sync-repo-settings.ts
@@ -168,6 +168,8 @@ async function updateMasterBranchProtection(
   // Combine user settings with a lax set of defaults
   rule = Object.assign({}, branchProtectionDefaults, rule);
 
+  logger.debug(`Required status checks ${rule.requiredStatusCheckContexts}`);
+
   try {
     await context.github.repos.updateBranchProtection({
       branch: rule.pattern,


### PR DESCRIPTION
Somehow we're getting weird overrides for repositories. Adding more debug logging for which required checks are being set.
