### PR TITLE
fix(sync-repo-settings): add google-cloudevents-nodejs to exclude rules

### DIFF
--- a/packages/sync-repo-settings/src/required-checks.json
+++ b/packages/sync-repo-settings/src/required-checks.json
@@ -342,7 +342,8 @@
       "googleapis/google-cloud-node",
       "googleapis/gapic-generator-typescript",
       "googleapis/aip",
-      "googleapis/release-please"
+      "googleapis/release-please",
+      "google-cloudevents-nodejs"
     ]
   },
   "ruby": {


### PR DESCRIPTION
`google-cloudevents-nodejs` contains  auto-generated proto bindings, and has different testing requirements than our standard Node.js repos.
