### PR TITLE
fix(gcf-utils): Revert binding trigger information to logger

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -54,7 +54,7 @@ export interface WrapOptions {
   logging: boolean;
 }
 
-export let logger: GCFLogger = initLogger();
+export const logger: GCFLogger = initLogger();
 
 export interface CronPayload {
   repository: {
@@ -181,19 +181,6 @@ export class GCFBootstrapper {
     return TriggerType.UNKNOWN;
   }
 
-  /**
-   * Binds the given properties to the logger so that every logged statement
-   * includes these properties.
-   *
-   * NOTE: statements logged before this method is called will not include
-   * this information
-   *
-   * @param bindings object containing properties to bind to the logger
-   */
-  private static bindPropertiesToLogger(bindings: {}) {
-    logger = logger.child(bindings);
-  }
-
   gcf(
     appFn: ApplicationFunction,
     wrapOptions?: WrapOptions
@@ -213,9 +200,7 @@ export class GCFBootstrapper {
         taskId
       );
 
-      const triggerInfo = buildTriggerInfo(triggerType, id, request.body);
-      GCFBootstrapper.bindPropertiesToLogger(triggerInfo);
-      logger.metric(`Execution started by ${triggerType}`);
+      logger.metric(buildTriggerInfo(triggerType, id, request.body));
 
       try {
         if (triggerType === TriggerType.UNKNOWN) {

--- a/packages/gcf-utils/src/logging/gcf-logger.ts
+++ b/packages/gcf-utils/src/logging/gcf-logger.ts
@@ -22,86 +22,22 @@ interface LogFn {
   (obj: object, msg?: string, ...args: any[]): void;
 }
 
-interface Bindings {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-}
-
 /**
  * A logger standardized logger for Google Cloud Functions
  */
 export interface GCFLogger {
-  /**
-   * Log at the trace level
-   */
   trace: LogFn;
-
-  /**
-   * Log at the debug level
-   */
   debug: LogFn;
-
-  /**
-   * Log at the info level
-   */
   info: LogFn;
-
-  /**
-   * Log at the warn level
-   */
   warn: LogFn;
-
-  /**
-   * Log at the error level
-   */
   error: LogFn;
-
-  /**
-   * Log at the metric level
-   */
   metric: LogFn;
-
-  /**
-   * Create a child logger
-   * @param bindings static properties that will be included
-   * in all statements logged from the child logger
-   */
-  child: {(bindings: Bindings): GCFLogger};
-
-  /**
-   * Get the bindings associated with this logger
-   */
-  bindings: {(): Bindings};
-
-  /**
-   * Synchronously flush the buffer for this logger.
-   * NOTE: Only supported for SonicBoom destinations
-   */
   flushSync: {(): void};
 }
 
-/**
- * GCFLogger customization options
- */
-export interface GCFLoggerOptions {
-  /**
-   * An alternate destination to write logs.
-   * Default is stdout wrapped in SonicBoom
-   */
-  destination?: NodeJS.WritableStream | SonicBoom;
-
-  /**
-   * static properties that will be included
-   * in all statements logged
-   */
-  bindings?: Bindings;
-}
-
-/**
- * Initialize a GCFLogger instance
- * @param options options for instance initialization
- */
-export function initLogger(options?: GCFLoggerOptions): GCFLogger {
+export function initLogger(
+  dest?: NodeJS.WritableStream | SonicBoom
+): GCFLogger {
   const DEFAULT_LOG_LEVEL = 'trace';
   const defaultOptions: pino.LoggerOptions = {
     formatters: {
@@ -116,58 +52,26 @@ export function initLogger(options?: GCFLoggerOptions): GCFLogger {
     level: DEFAULT_LOG_LEVEL,
   };
 
-  const destination = options?.destination || pino.destination({sync: true});
-  let logger = pino(defaultOptions, destination);
-
-  if (options?.bindings) {
-    logger = logger.child(options.bindings);
-  }
-
-  bindPinoFunctions(logger);
-
-  const flushSync = () => {
-    // flushSync is only available for SonicBoom,
-    // which is the default destination wrapper for GCFLogger
-    if (destination instanceof SonicBoom) {
-      destination.flushSync();
-    }
-  };
-
-  return pinoToGCFLogger(logger, flushSync);
-}
-
-/**
- * Binds the given logger instance to Pino logger functions
- * @param logger instance to bind
- */
-function bindPinoFunctions(logger: pino.Logger): pino.Logger {
+  dest = dest || pino.destination({sync: true});
+  const logger = pino(defaultOptions, dest);
   Object.keys(logger).map(prop => {
     if (logger[prop] instanceof Function) {
       logger[prop] = logger[prop].bind(logger);
     }
   });
-  return logger;
-}
 
-/**
- * Converts a Pino logger instance to a GCFLogger instance
- * @param pinoLogger pino logger to convert
- * @param flushSync the flushSync function to apply to the returned GCFLogger
- */
-function pinoToGCFLogger(
-  pinoLogger: pino.Logger,
-  flushSync: {(): void}
-): GCFLogger {
+  const flushSync = () => {
+    // flushSync is only available for SonicBoom,
+    // which is the default destination wrapper for GCFLogger
+    if (dest instanceof SonicBoom) {
+      dest.flushSync();
+    }
+  };
+
   return {
-    ...pinoLogger,
-    metric: pinoLogger.metric.bind(pinoLogger),
+    ...logger,
+    metric: logger.metric.bind(logger),
     flushSync: flushSync,
-    bindings: pinoLogger.bindings,
-    child: (bindings: Bindings) => {
-      const child = pinoLogger.child(bindings);
-      bindPinoFunctions(child);
-      return pinoToGCFLogger(child, flushSync);
-    },
   };
 }
 

--- a/packages/gcf-utils/src/logging/gcf-logger.ts
+++ b/packages/gcf-utils/src/logging/gcf-logger.ts
@@ -26,12 +26,40 @@ interface LogFn {
  * A logger standardized logger for Google Cloud Functions
  */
 export interface GCFLogger {
+  /**
+   * Log at the trace level
+   */
   trace: LogFn;
+
+  /**
+   * Log at the debug level
+   */
   debug: LogFn;
+
+  /**
+   * Log at the info level
+   */
   info: LogFn;
+
+  /**
+   * Log at the warn level
+   */
   warn: LogFn;
+
+  /**
+   * Log at the error level
+   */
   error: LogFn;
+
+  /**
+   * Log at the metric level
+   */
   metric: LogFn;
+
+  /**
+   * Synchronously flush the buffer for this logger.
+   * NOTE: Only supported for SonicBoom destinations
+   */
   flushSync: {(): void};
 }
 

--- a/packages/gcf-utils/src/logging/trigger-info-builder.ts
+++ b/packages/gcf-utils/src/logging/trigger-info-builder.ts
@@ -19,6 +19,7 @@ import crypto from 'crypto';
  * Information on GCF execution trigger
  */
 interface TriggerInfo {
+  message: string;
   trigger: {
     trigger_type: TriggerType;
     trigger_sender?: string;
@@ -37,7 +38,6 @@ interface TriggerInfo {
       repo_name: string;
       url: string;
     };
-    message: string;
   };
 }
 
@@ -56,9 +56,9 @@ export function buildTriggerInfo(
   const UNKNOWN = 'UNKNOWN';
 
   const triggerInfo: TriggerInfo = {
+    message: `Execution started by ${triggerType}`,
     trigger: {
       trigger_type: triggerType,
-      message: `Execution started by ${triggerType}`,
     },
   };
 

--- a/packages/gcf-utils/src/logging/trigger-info-builder.ts
+++ b/packages/gcf-utils/src/logging/trigger-info-builder.ts
@@ -18,7 +18,7 @@ import crypto from 'crypto';
 /**
  * Information on GCF execution trigger
  */
-export interface TriggerInfo {
+interface TriggerInfo {
   trigger: {
     trigger_type: TriggerType;
     trigger_sender?: string;
@@ -37,6 +37,7 @@ export interface TriggerInfo {
       repo_name: string;
       url: string;
     };
+    message: string;
   };
 }
 
@@ -57,6 +58,7 @@ export function buildTriggerInfo(
   const triggerInfo: TriggerInfo = {
     trigger: {
       trigger_type: triggerType,
+      message: `Execution started by ${triggerType}`,
     },
   };
 

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {GCFBootstrapper, WrapOptions, logger} from '../src/gcf-utils';
+import {GCFBootstrapper, WrapOptions} from '../src/gcf-utils';
 import {describe, beforeEach, afterEach, it} from 'mocha';
 import {GitHubAPI} from 'probot/lib/github';
 import {Options} from 'probot';
@@ -365,28 +365,6 @@ describe('GCFBootstrapper', () => {
       process.env.GCF_SHORT_FUNCTION_NAME = 'bar';
       const latest = bootstrapper.getSecretName();
       assert.strictEqual(latest, 'projects/foo/secrets/bar');
-    });
-  });
-
-  describe('bindPropertiesToLogger', () => {
-    it('binds given properties', () => {
-      const triggerInfoWithoutMessage = {
-        trigger: {
-          trigger_type: 'GITHUB_WEBHOOK',
-          trigger_sender: 'some sender',
-          payload_hash: '123456',
-
-          trigger_source_repo: {
-            owner: 'foo owner',
-            owner_type: 'Org',
-            repo_name: 'bar name',
-            url: 'some url',
-          },
-        },
-      };
-
-      GCFBootstrapper['bindPropertiesToLogger'](triggerInfoWithoutMessage);
-      assert.deepEqual(logger.bindings(), triggerInfoWithoutMessage);
     });
   });
 });

--- a/packages/gcf-utils/test/gcf-logger.ts
+++ b/packages/gcf-utils/test/gcf-logger.ts
@@ -26,9 +26,7 @@ describe('GCFLogger', () => {
   });
   describe('logger instance', () => {
     let destination: ObjectWritableMock;
-    let loggerNoBindings: GCFLogger & {[key: string]: Function};
-    let loggerWithBindings: GCFLogger & {[key: string]: Function};
-    const bindings = {foo: 'bar-binding'};
+    let logger: GCFLogger & {[key: string]: Function};
 
     function readLogsAsObjects(writeStream: ObjectWritableMock): LogLine[] {
       try {
@@ -43,13 +41,13 @@ describe('GCFLogger', () => {
     function testAllLevels() {
       for (const level of Object.keys(logLevels)) {
         it(`logs ${level} level string`, () => {
-          loggerNoBindings[level]('hello world');
+          logger[level]('hello world');
           const loggedLines: LogLine[] = readLogsAsObjects(destination);
           validateLogs(loggedLines, 1, ['hello world'], [], logLevels[level]);
         });
 
         it(`logs ${level} level json`, () => {
-          loggerNoBindings[level]({hello: 'world'});
+          logger[level]({hello: 'world'});
           const loggedLines: LogLine[] = readLogsAsObjects(destination);
           validateLogs(
             loggedLines,
@@ -59,41 +57,12 @@ describe('GCFLogger', () => {
             logLevels[level]
           );
         });
-
-        it(`logs ${level} level string with bindings`, () => {
-          loggerWithBindings[level]('hello world');
-          const loggedLines: LogLine[] = readLogsAsObjects(destination);
-          validateLogs(
-            loggedLines,
-            1,
-            ['hello world'],
-            [bindings],
-            logLevels[level]
-          );
-        });
-
-        it(`logs ${level} level json with bindings`, () => {
-          loggerWithBindings[level]({hello: 'world'});
-          const loggedLines: LogLine[] = readLogsAsObjects(destination);
-          validateLogs(
-            loggedLines,
-            1,
-            [],
-            [{...bindings, hello: 'world'}],
-            logLevels[level]
-          );
-        });
       }
     }
 
     beforeEach(() => {
       destination = new ObjectWritableMock();
-      loggerNoBindings = initLogger({destination}) as GCFLogger & {
-        [key: string]: Function;
-      };
-      loggerWithBindings = loggerNoBindings.child(bindings) as GCFLogger & {
-        [key: string]: Function;
-      };
+      logger = initLogger(destination) as GCFLogger & {[key: string]: Function};
     });
 
     testAllLevels();

--- a/packages/gcf-utils/test/integration/gcf-logger-integration.ts
+++ b/packages/gcf-utils/test/integration/gcf-logger-integration.ts
@@ -20,9 +20,7 @@ import SonicBoom from 'sonic-boom';
 import fs from 'fs';
 
 describe('GCFLogger Integration', () => {
-  let loggerNoBindings: GCFLogger & {[key: string]: Function};
-  let loggerWithBindings: GCFLogger & {[key: string]: Function};
-  const bindings = {foo: 'bar-binding'};
+  let logger: GCFLogger & {[key: string]: Function};
   const testStreamPath = './test-stream.txt';
   let destination: SonicBoom;
 
@@ -44,7 +42,7 @@ describe('GCFLogger Integration', () => {
   function testAllLevels() {
     for (const level of Object.keys(logLevels)) {
       it(`logs ${level} level string`, done => {
-        loggerNoBindings[level]('hello world');
+        logger[level]('hello world');
         destination.on('ready', () => {
           const loggedLines: LogLine[] = readLogsAsObjects(destination);
           validateLogs(loggedLines, 1, ['hello world'], [], logLevels[level]);
@@ -53,7 +51,7 @@ describe('GCFLogger Integration', () => {
       });
 
       it(`logs ${level} level json`, done => {
-        loggerNoBindings[level]({hello: 'world'});
+        logger[level]({hello: 'world'});
         destination.on('ready', () => {
           const loggedLines: LogLine[] = readLogsAsObjects(destination);
           validateLogs(
@@ -66,41 +64,12 @@ describe('GCFLogger Integration', () => {
           done();
         });
       });
-
-      it(`logs ${level} level string with bindings`, () => {
-        loggerWithBindings[level]('hello world');
-        const loggedLines: LogLine[] = readLogsAsObjects(destination);
-        validateLogs(
-          loggedLines,
-          1,
-          ['hello world'],
-          [bindings],
-          logLevels[level]
-        );
-      });
-
-      it(`logs ${level} level json with bindings`, () => {
-        loggerWithBindings[level]({hello: 'world'});
-        const loggedLines: LogLine[] = readLogsAsObjects(destination);
-        validateLogs(
-          loggedLines,
-          1,
-          [],
-          [{...bindings, hello: 'world'}],
-          logLevels[level]
-        );
-      });
     }
   }
 
   beforeEach(() => {
     destination = pino.destination(testStreamPath);
-    loggerNoBindings = initLogger({destination: destination}) as GCFLogger & {
-      [key: string]: Function;
-    };
-    loggerWithBindings = loggerNoBindings.child(bindings) as GCFLogger & {
-      [key: string]: Function;
-    };
+    logger = initLogger(destination) as GCFLogger & {[key: string]: Function};
   });
 
   testAllLevels();

--- a/packages/gcf-utils/test/trigger-info-builder.ts
+++ b/packages/gcf-utils/test/trigger-info-builder.ts
@@ -30,6 +30,7 @@ describe('buildTriggerInfo', () => {
     const expectedInfo = {
       trigger: {
         trigger_type: 'Pub/Sub',
+        message: 'Execution started by Pub/Sub',
       },
     };
     assert.deepEqual(triggerInfo, expectedInfo);
@@ -47,6 +48,7 @@ describe('buildTriggerInfo', () => {
     const expectedInfo = {
       trigger: {
         trigger_type: 'Cloud Scheduler',
+        message: 'Execution started by Cloud Scheduler',
       },
     };
     assert.deepEqual(triggerInfo, expectedInfo);
@@ -65,6 +67,7 @@ describe('buildTriggerInfo', () => {
       trigger: {
         trigger_type: 'Cloud Task',
         github_delivery_guid: '1234',
+        message: 'Execution started by Cloud Task',
       },
     };
     assert.deepEqual(triggerInfo, expectedInfo);
@@ -85,6 +88,7 @@ describe('buildTriggerInfo', () => {
         trigger_type: 'GitHub Webhook',
         trigger_sender: 'testUser2',
         github_delivery_guid: '1234',
+        message: 'Execution started by GitHub Webhook',
         trigger_source_repo: {
           owner: 'testOwner',
           owner_type: 'User',
@@ -110,6 +114,7 @@ describe('buildTriggerInfo', () => {
     const expectedInfo = {
       trigger: {
         trigger_type: 'GitHub Webhook',
+        message: 'Execution started by GitHub Webhook',
         trigger_sender: 'UNKNOWN',
         github_delivery_guid: '',
         trigger_source_repo: {

--- a/packages/gcf-utils/test/trigger-info-builder.ts
+++ b/packages/gcf-utils/test/trigger-info-builder.ts
@@ -28,9 +28,9 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
+      message: 'Execution started by Pub/Sub',
       trigger: {
         trigger_type: 'Pub/Sub',
-        message: 'Execution started by Pub/Sub',
       },
     };
     assert.deepEqual(triggerInfo, expectedInfo);
@@ -46,9 +46,9 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
+      message: 'Execution started by Cloud Scheduler',
       trigger: {
         trigger_type: 'Cloud Scheduler',
-        message: 'Execution started by Cloud Scheduler',
       },
     };
     assert.deepEqual(triggerInfo, expectedInfo);
@@ -64,10 +64,10 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
+      message: 'Execution started by Cloud Task',
       trigger: {
         trigger_type: 'Cloud Task',
         github_delivery_guid: '1234',
-        message: 'Execution started by Cloud Task',
       },
     };
     assert.deepEqual(triggerInfo, expectedInfo);
@@ -84,11 +84,11 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
+      message: 'Execution started by GitHub Webhook',
       trigger: {
         trigger_type: 'GitHub Webhook',
         trigger_sender: 'testUser2',
         github_delivery_guid: '1234',
-        message: 'Execution started by GitHub Webhook',
         trigger_source_repo: {
           owner: 'testOwner',
           owner_type: 'User',
@@ -112,9 +112,9 @@ describe('buildTriggerInfo', () => {
       requestBody
     );
     const expectedInfo = {
+      message: 'Execution started by GitHub Webhook',
       trigger: {
         trigger_type: 'GitHub Webhook',
-        message: 'Execution started by GitHub Webhook',
         trigger_sender: 'UNKNOWN',
         github_delivery_guid: '',
         trigger_source_repo: {


### PR DESCRIPTION
This reverts the changes in this commit https://github.com/googleapis/repo-automation-bots/commit/157c768e6de8e3067e24a6dd17be152ae98c25d8 (but keeps some of the JSDocs and message changes).

This is a quick fix for the issue described in https://github.com/googleapis/repo-automation-bots/issues/808 until we can figure out the root cause.