### PR TITLE
chore: disable strict status checks for python-bigtable

### DIFF
--- a/packages/sync-repo-settings/src/required-checks.json
+++ b/packages/sync-repo-settings/src/required-checks.json
@@ -304,6 +304,18 @@
             ]
           }
         ]
+      },
+      {
+        "repo": "googleapis/python-bigtable",
+        "branchProtectionRules": [
+          {
+            "requiresStrictStatusChecks": false,
+            "requiredStatusCheckContexts": [
+              "Kokoro",
+              "cla/google"
+            ]
+          }
+        ]
       }
     ],
     "ignoredRepos": [


### PR DESCRIPTION
Is `requiresStrictStatusChecks` ==  "require branches to be up to date before merging."?

cc @tseaver