### PR TITLE
chore(snippet-bot): remove problematic deps

### DIFF
--- a/packages/snippet-bot/package.json
+++ b/packages/snippet-bot/package.json
@@ -29,9 +29,8 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "@octokit/rest": "^18.0.0",
-    "gcf-utils": "^5.5.1",
-    "probot": "^9.11.3"
+    "@octokit/rest": "^16.0.0",
+    "gcf-utils": "^5.5.1"
   },
   "devDependencies": {
     "@types/body-parser": "^1.17.0",

--- a/packages/snippet-bot/src/snippet-bot.ts
+++ b/packages/snippet-bot/src/snippet-bot.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint-disable node/no-extraneous-import */
+
 import {Application, Octokit} from 'probot';
 import {parseRegionTags} from './region-tag-parser';
 import {logger} from 'gcf-utils';

--- a/packages/snippet-bot/test/snippet-bot.ts
+++ b/packages/snippet-bot/test/snippet-bot.ts
@@ -14,6 +14,7 @@
 //
 
 /* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable node/no-extraneous-import */
 
 import myProbotApp from '../src/snippet-bot';
 


### PR DESCRIPTION
also pin octokit version

Somehow the previous combination of the dependencies caused problems on Cloud Function environment. I'm still not 100% sure it's going to fix the problem, but I don't have local repro anyways, I think I need to try.