### PR TITLE
feat(release-please): allow changelog path to be configured

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -4996,9 +4996,9 @@
       }
     },
     "release-please": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-5.7.2.tgz",
-      "integrity": "sha512-RsACuPCCFcU7/pUKNMpnGrrJEABHfYRWMhj6yZt/PaFaHf2/2M0IWPkoAK15r7LFsAtoiAtMtPi3ziDQHcvVMw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-5.8.0.tgz",
+      "integrity": "sha512-GuKIK4my/nIVAFP4hs7AUAhKNsKFymKSZdd88W8eBKBMtyZObx1+uRxB8TuM8TkvT0k2g8enKJWrC/y576fR8g==",
       "requires": {
         "@octokit/graphql": "^4.3.1",
         "@octokit/request": "^5.3.4",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -31,7 +31,7 @@
     "@octokit/rest": "^18.0.0",
     "@octokit/webhooks": "7.1.1",
     "gcf-utils": "^5.5.1",
-    "release-please": "^5.7.0"
+    "release-please": "^5.8.0"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -37,6 +37,7 @@ interface ConfigurationOptions {
   handleGHRelease?: boolean;
   bumpMinorPreMajor?: boolean;
   path?: string;
+  changelogPath?: string;
 }
 
 const DEFAULT_API_URL = 'https://api.github.com';
@@ -94,7 +95,7 @@ async function createReleasePR(
     },
     bumpMinorPreMajor,
     snapshot,
-    path,
+    path
   };
   if (releaseLabels) {
     buildOptions.label = releaseLabels.join(',');
@@ -108,7 +109,8 @@ async function createGitHubRelease(
   packageName: string,
   repoUrl: string,
   github: GitHubAPI,
-  path?: string
+  path?: string,
+  changelogPath?: string
 ) {
   const releaseOptions: GitHubReleaseOptions = {
     label: 'autorelease: pending',
@@ -122,6 +124,7 @@ async function createGitHubRelease(
       request: github.request,
     },
     path,
+    changelogPath
   };
   const ghr = new GitHubRelease(releaseOptions);
   await Runner.releaser(ghr);
@@ -177,11 +180,12 @@ export = (app: Application) => {
     // this for our repos that have autorelease enabled.
     if (configuration.handleGHRelease) {
       logger.info(`handling GitHub release for (${repoUrl})`);
-      createGitHubRelease(
-        configuration.packageName || repoName,
+      await createGitHubRelease(
+        configuration.packageName ?? repoName,
         repoUrl,
         context.github,
-        configuration.path
+        configuration.path,
+        configuration.changelogPath ?? 'CHANGELOG.md'
       );
     }
   });

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -95,7 +95,7 @@ async function createReleasePR(
     },
     bumpMinorPreMajor,
     snapshot,
-    path
+    path,
   };
   if (releaseLabels) {
     buildOptions.label = releaseLabels.join(',');
@@ -124,7 +124,7 @@ async function createGitHubRelease(
       request: github.request,
     },
     path,
-    changelogPath
+    changelogPath,
   };
   const ghr = new GitHubRelease(releaseOptions);
   await Runner.releaser(ghr);


### PR DESCRIPTION
go's CHANGELOG has a different name.