### PR TITLE
feat(auto-label): auto-detect from Conventional Commit scopes

### DIFF
--- a/packages/auto-label/src/auto-label.ts
+++ b/packages/auto-label/src/auto-label.ts
@@ -62,7 +62,13 @@ export function autoDetectLabel(
   if (!jsonArray || !title) {
     return undefined;
   }
-  let firstPart = title.split(':')[0]; // Before the colon, if there is one.
+  // Regex to match the scope of a Conventional Commit message.
+  const conv = /[^(]+\(([^)]+)\):/;
+  const match = title.match(conv);
+
+  let firstPart = match ? match[1] : title;
+
+  firstPart = firstPart.split(':')[0]; // Before the colon, if there is one.
   firstPart = firstPart.split('/')[0]; // Before the slash, if there is one.
   firstPart = firstPart.split('.')[0]; // Before the period, if there is one.
   firstPart = firstPart.toLowerCase(); // Convert to lower case.
@@ -70,7 +76,7 @@ export function autoDetectLabel(
 
   const wantLabel = `api: ${firstPart}`;
   // Some APIs have "cloud" before the name (e.g. cloudkms and cloudiot).
-  // If needed, we could replace common firstParts to known API names.
+  // If needed, we could replace common firstPart values with known API names.
   const wantLabelCloud = `api: cloud${firstPart}`;
   // Assume jsonArray contains all api: labels. Avoids an extra API call to list
   // the labels on a repo.

--- a/packages/auto-label/test/auto-label.ts
+++ b/packages/auto-label/test/auto-label.ts
@@ -499,9 +499,13 @@ describe('auto-label', () => {
         {title: 'spanner.ignored', want: 'api: spanner'},
         {title: 'SPANNER.IGNORED', want: 'api: spanner'},
         {title: 'SPAN ner: ignored', want: 'api: spanner'},
+        {title: 'feat(spanner): ignored', want: 'api: spanner'},
+        {title: 'fix(spanner/helper): ignored', want: 'api: spanner'},
         {title: 'iot: ignored', want: 'api: cloudiot'},
         {title: 'unknown: ignored', want: undefined},
         {title: 'spanner with no separator', want: undefined},
+        {title: 'fix(unknown): ignored', want: undefined},
+        {title: 'feat(): ignored', want: undefined},
       ];
       for (const test of tests) {
         assert.strictEqual(autoDetectLabel(driftRepos, test.title), test.want);


### PR DESCRIPTION
Issues don't always follow Conventional Commits. But, more and more languages are following Conventional Commits for PR titles. This PR adds support for the auto-label bot to detect labels from the scope of a Conventional Commit.

This is closely related to https://github.com/googleapis/repo-automation-bots/pull/871, which starts auto-labeling PRs.