### PR TITLE
fix(snippet-bot): fix deployment for nodejs12 runtime

### DIFF
--- a/packages/snippet-bot/package.json
+++ b/packages/snippet-bot/package.json
@@ -21,7 +21,6 @@
     "compile": "tsc -p .",
     "start": "probot run ./build/src/snippet-bot.js",
     "start:local": "node ./build/src/local.js",
-    "prepare": "npm run compile",
     "pretest": "npm run compile",
     "test": "cross-env LOG_LEVEL=fatal c8 mocha --exit build/test",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test",


### PR DESCRIPTION
We don't need `prepare` script for our bots. It also causes deployment failure on nodejs12 runtime.