### PR TITLE
fix(trusted-contribution): don't use Cloud Tasks

### DIFF
--- a/packages/trusted-contribution/src/app.ts
+++ b/packages/trusted-contribution/src/app.ts
@@ -17,6 +17,6 @@ import appFn from './trusted-contribution';
 
 const bootstrap = new GCFBootstrapper();
 module.exports.trusted_contribution = bootstrap.gcf(appFn, {
-  background: true,
+  background: false,
   logging: true,
 });


### PR DESCRIPTION
Some of the tasks are running over the Cloud Tasks size limit.

Fixes #920.