### PR TITLE
feat(metrics): add context aware commits to dashboard

### DIFF
--- a/metrics/dashboards.sql
+++ b/metrics/dashboards.sql
@@ -184,7 +184,7 @@ ORDER BY month_start ASC)
 UNION ALL
 
 /*
-Measure autosynth PRs with full context. We ran a survey wiht the Yoshi team,
+Measure autosynth PRs with full context. We ran a survey with the Yoshi team,
 which indicated each of these PRs saves 3.5 minutes:
 
 We look for PRs that have a "context: full" label and were merged.

--- a/metrics/dashboards.sql
+++ b/metrics/dashboards.sql
@@ -194,7 +194,7 @@ SELECT * FROM (SELECT COUNT(id) as prs, month_start, 3.5 as minutes, 'context-aw
   SELECT DATE_TRUNC(DATE(created_at), MONTH) as month_start, id, JSON_EXTRACT(payload, '$.pull_request.merged_at') as merged
   FROM `githubarchive.day.20*`
   WHERE
-  _TABLE_SUFFIX BETWEEN '200701' AND '210101' AND
+  _TABLE_SUFFIX BETWEEN '190101' AND '210101' AND
   (
   repo.name LIKE 'googleapis/%' OR
   repo.name LIKE 'GoogleCloudPlatform/%'


### PR DESCRIPTION
Adds context aware commits to our dashboard, using the 3.5 minute estimate we were given by teammates on survey:

<img width="705" alt="Screen Shot 2020-08-28 at 1 07 20 PM" src="https://user-images.githubusercontent.com/194609/91611129-6d04fe80-e92f-11ea-8a69-c053dd55ea62.png">
