### PR TITLE
feat(auto-label): auto-detect before underscores

### DIFF
--- a/packages/auto-label/README.md
+++ b/packages/auto-label/README.md
@@ -13,6 +13,7 @@ Issue title | Label
 `spanner/ignored` | `api: spanner`
 `spanner.ignored` | `api: spanner`
 `SPANNER.IGNORED` | `api: spanner`
+`spanner_ignored` | `api: spanner`
 `SPAN ner: ignored` | `api: spanner`
 `ignored(spanner): ignored` | `api: spanner`
 `ignored(spanner/ignored): ignored` | `api: spanner`

--- a/packages/auto-label/src/auto-label.ts
+++ b/packages/auto-label/src/auto-label.ts
@@ -81,6 +81,7 @@ export function autoDetectLabel(
   firstPart = firstPart.split(':')[0]; // Before the colon, if there is one.
   firstPart = firstPart.split('/')[0]; // Before the slash, if there is one.
   firstPart = firstPart.split('.')[0]; // Before the period, if there is one.
+  firstPart = firstPart.split('_')[0]; // Before the underscore, if there is one.
   firstPart = firstPart.toLowerCase(); // Convert to lower case.
   firstPart = firstPart.replace(/\s/, ''); // Remove spaces.
 

--- a/packages/auto-label/test/auto-label.ts
+++ b/packages/auto-label/test/auto-label.ts
@@ -499,6 +499,7 @@ describe('auto-label', () => {
         {title: 'spanner.ignored', want: 'api: spanner'},
         {title: 'SPANNER.IGNORED', want: 'api: spanner'},
         {title: 'SPAN ner: ignored', want: 'api: spanner'},
+        {title: 'spanner_ignored: ignored', want: 'api: spanner'},
         {title: 'feat(spanner): ignored', want: 'api: spanner'},
         {title: 'fix(spanner/helper): ignored', want: 'api: spanner'},
         {title: 'fix(/spanner/helper): ignored', want: 'api: spanner'},


### PR DESCRIPTION
Support for issues like https://github.com/GoogleCloudPlatform/python-docs-samples/issues/4543.