### PR TITLE
fix(sync-repo-settings): maintain and triage not available yet

### DIFF
--- a/packages/sync-repo-settings/README.md
+++ b/packages/sync-repo-settings/README.md
@@ -43,7 +43,7 @@ branchProtectionRules:
 permissionRules:
     # Team slug to add to repository permissions
   - team: team1
-    # Access level required, one of push|pull|admin|maintain|triage
+    # Access level required, one of push|pull|admin
     permission: push
 ```
 

--- a/packages/sync-repo-settings/src/schema.json
+++ b/packages/sync-repo-settings/src/schema.json
@@ -85,9 +85,9 @@
             "type": "string"
           },
           "permission": {
-            "description": "Permission to provide the team.  Can be one of (pull|push|admin|maintain|triage)",
+            "description": "Permission to provide the team.  Can be one of (pull|push|admin)",
             "type": "string",
-            "enum": ["pull", "push", "admin", "maintain", "triage"]
+            "enum": ["pull", "push", "admin"]
           }
         },
         "required": ["team", "permission"]

--- a/packages/sync-repo-settings/src/sync-repo-settings.ts
+++ b/packages/sync-repo-settings/src/sync-repo-settings.ts
@@ -296,19 +296,18 @@ async function updateMasterBranchProtection(
         accept: 'application/vnd.github.luke-cage-preview+json',
       },
     });
+    logger.info(`Success updating master branch protection for ${repo}`);
   } catch (err) {
     if (err.status === 401) {
       logger.warn(
         `updateMasterBranchProtection: warning received ${err.status} updating ${owner}/${name}`
       );
     } else {
-      logger.error(
-        `updateMasterBranchProtection: error received ${err.status} updating ${owner}/${name}`
-      );
-      throw err;
+      err.message = `updateMasterBranchProtection: error received ${err.status} updating ${owner}/${name}\n\n${err.message}`;
+      logger.error(err);
+      return;
     }
   }
-  logger.info(`Success updating master branch protection for ${repo}`);
 }
 
 /**
@@ -335,6 +334,7 @@ async function updateRepoTeams(
         });
       })
     );
+    logger.info(`Success updating repo in org for ${repo}`);
   } catch (err) {
     const knownErrors = [
       401, // bot does not have permission to access this repository.
@@ -345,13 +345,11 @@ async function updateRepoTeams(
         `updateRepoTeams: warning received ${err.status} updating ${owner}/${name}`
       );
     } else {
-      logger.error(
-        `updateRepoTeams: error received ${err.status} updating ${owner}/${name}`
-      );
-      throw err;
+      err.message = `updateRepoTeams: error received ${err.status} updating ${owner}/${name}\n\n${err.message}`;
+      logger.error(err);
+      return;
     }
   }
-  logger.info(`Success updating repo in org for ${repo}`);
 }
 
 /**
@@ -380,6 +378,7 @@ async function updateRepoOptions(
       allow_rebase_merge: config.rebaseMergeAllowed,
       allow_squash_merge: config.squashMergeAllowed,
     });
+    logger.info(`Success updating repo options for ${repo}`);
   } catch (err) {
     const knownErrors = [
       401, // bot does not have permission to access this repository.
@@ -390,11 +389,9 @@ async function updateRepoOptions(
         `updateRepoOptions: warning received ${err.status} updating ${owner}/${name}`
       );
     } else {
-      logger.error(
-        `updateRepoOptions: error received ${err.status} updating ${owner}/${name}`
-      );
-      throw err;
+      err.message = `updateRepoOptions: error received ${err.status} updating ${owner}/${name}\n\n${err.message}`;
+      logger.error(err);
+      return;
     }
   }
-  logger.info(`Success updating repo options for ${repo}`);
 }

--- a/packages/sync-repo-settings/src/types.ts
+++ b/packages/sync-repo-settings/src/types.ts
@@ -35,7 +35,7 @@ export interface RepoConfig {
   permissionRules?: PermissionRule[];
 }
 
-export type Permission = 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
+export type Permission = 'pull' | 'push' | 'admin';
 
 export interface PermissionRule {
   /**


### PR DESCRIPTION
Fixes two issues appearing in the logs.  
1. The `maintain` and `triage` permissions are not actually available in the GitHub API yet 🙄  Backed that out of the config.
2. When there's an exception updating permissions or other settings, don't crash.  Just log the error and move on. 