### PR TITLE
fix(logger): allow log methods to be used in isolation

### DIFF
--- a/packages/gcf-utils/src/logging/gcf-logger.ts
+++ b/packages/gcf-utils/src/logging/gcf-logger.ts
@@ -26,6 +26,12 @@ export class GCFLogger {
 
   constructor(customDestination?: Destination) {
     this.initPinoLogger(customDestination);
+    this.trace = this.trace.bind(this);
+    this.debug = this.debug.bind(this);
+    this.info = this.info.bind(this);
+    this.warn = this.warn.bind(this);
+    this.metric = this.metric.bind(this);
+    this.error = this.error.bind(this);
   }
 
   /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/gcf-utils/test/gcf-logger.ts
+++ b/packages/gcf-utils/test/gcf-logger.ts
@@ -57,6 +57,13 @@ describe('GCFLogger', () => {
             logLevels[level]
           );
         });
+
+        it(`allows ${level} log to be passed as argument`, (done) => {
+          setTimeout(logger[level], 1);
+          setTimeout(() => {
+            return done();
+          })
+        });
       }
     }
 

--- a/packages/gcf-utils/test/gcf-logger.ts
+++ b/packages/gcf-utils/test/gcf-logger.ts
@@ -58,11 +58,11 @@ describe('GCFLogger', () => {
           );
         });
 
-        it(`allows ${level} log to be passed as argument`, (done) => {
+        it(`allows ${level} log to be passed as argument`, done => {
           setTimeout(logger[level], 1);
           setTimeout(() => {
             return done();
-          })
+          });
         });
       }
     }


### PR DESCRIPTION
We are seeing quite a few errors in auto-label, I believe due to code like this:

```js
        await context.github.issues
          .addLabels({
            owner,
            repo,
            issue_number: issueNumber,
            labels: [githubLabel],
          })
          .catch(logger.error);
```

When a method is passed by reference like this, it will lose reference to its `this`, making it throw, see:

```js
class Logger {
  error(msg) {this.log(msg)}
  log(msg) {console.info(msg)}
}
const logger = new Logger()
setTimeout(logger.error, 10) <-- if you do this in JavaScript this goes away.
```