### PR TITLE
feat(failure-checker): autorelease: tagged is not considered failure for some languages

### DIFF
--- a/packages/failurechecker/test/failurechecker.ts
+++ b/packages/failurechecker/test/failurechecker.ts
@@ -47,6 +47,15 @@ describe('failurechecker', () => {
 
   it('opens an issue on GitHub if there exists a pending label > threshold', async () => {
     const requests = nock('https://api.github.com')
+      .get('/repos/bcoe/nodejs-foo/contents/.github%2Frelease-please.yml')
+      .reply(
+        200,
+        Buffer.from(
+          JSON.stringify({
+            releaseType: 'node',
+          })
+        )
+      )
       .get(
         '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20pending&state=closed&sort=updated&direction=desc&per_page=16'
       )
@@ -86,6 +95,9 @@ describe('failurechecker', () => {
       payload: {
         repository: {
           name: 'nodejs-foo',
+          owner: {
+            login: 'bcoe',
+          },
         },
         organization: {
           login: 'googleapis',
@@ -98,6 +110,15 @@ describe('failurechecker', () => {
 
   it('opens an issue on GitHub if there exists a tagged label > threshold', async () => {
     const requests = nock('https://api.github.com')
+      .get('/repos/bcoe/nodejs-foo/contents/.github%2Frelease-please.yml')
+      .reply(
+        200,
+        Buffer.from(
+          JSON.stringify({
+            releaseType: 'node',
+          })
+        )
+      )
       .get(
         '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20pending&state=closed&sort=updated&direction=desc&per_page=16'
       )
@@ -105,16 +126,16 @@ describe('failurechecker', () => {
       .get(
         '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20tagged&state=closed&sort=updated&direction=desc&per_page=16'
       )
-      .reply(200, [])
-      .get(
-        '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20failed&state=closed&sort=updated&direction=desc&per_page=16'
-      )
       .reply(200, [
         {
           number: 33,
           updated_at: '2020-01-30T13:33:48Z',
         },
       ])
+      .get(
+        '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20failed&state=closed&sort=updated&direction=desc&per_page=16'
+      )
+      .reply(200, [])
       .get('/repos/googleapis/nodejs-foo/pulls/33')
       .reply(200, {
         number: 33,
@@ -137,6 +158,47 @@ describe('failurechecker', () => {
       payload: {
         repository: {
           name: 'nodejs-foo',
+          owner: {
+            login: 'bcoe',
+          },
+        },
+        organization: {
+          login: 'googleapis',
+        },
+      },
+      id: 'abc123',
+    });
+    requests.done();
+  });
+
+  it('does not open issue for tagged label, when upstream repository of type "go-yoshi"', async () => {
+    const requests = nock('https://api.github.com')
+      .get('/repos/bcoe/nodejs-foo/contents/.github%2Frelease-please.yml')
+      .reply(
+        200,
+        Buffer.from(
+          JSON.stringify({
+            releaseType: 'go-yoshi',
+          })
+        )
+      )
+      .get(
+        '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20pending&state=closed&sort=updated&direction=desc&per_page=16'
+      )
+      .reply(200, [])
+      .get(
+        '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20failed&state=closed&sort=updated&direction=desc&per_page=16'
+      )
+      .reply(200, []);
+
+    await probot.receive({
+      name: 'schedule.repository' as any,
+      payload: {
+        repository: {
+          name: 'nodejs-foo',
+          owner: {
+            login: 'bcoe',
+          },
         },
         organization: {
           login: 'googleapis',
@@ -150,6 +212,15 @@ describe('failurechecker', () => {
   it('does not open an issue if merged_at is < threshold', async () => {
     const date = new Date().toISOString();
     const requests = nock('https://api.github.com')
+      .get('/repos/bcoe/nodejs-foo/contents/.github%2Frelease-please.yml')
+      .reply(
+        200,
+        Buffer.from(
+          JSON.stringify({
+            releaseType: 'node',
+          })
+        )
+      )
       .get(
         '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20pending&state=closed&sort=updated&direction=desc&per_page=16'
       )
@@ -173,6 +244,9 @@ describe('failurechecker', () => {
       payload: {
         repository: {
           name: 'nodejs-foo',
+          owner: {
+            login: 'bcoe',
+          },
         },
         organization: {
           login: 'googleapis',
@@ -185,6 +259,15 @@ describe('failurechecker', () => {
 
   it('does not open an issue if merged_at is over the max threshold', async () => {
     const requests = nock('https://api.github.com')
+      .get('/repos/bcoe/nodejs-foo/contents/.github%2Frelease-please.yml')
+      .reply(
+        200,
+        Buffer.from(
+          JSON.stringify({
+            releaseType: 'node',
+          })
+        )
+      )
       .get(
         '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20pending&state=closed&sort=updated&direction=desc&per_page=16'
       )
@@ -208,6 +291,9 @@ describe('failurechecker', () => {
       payload: {
         repository: {
           name: 'nodejs-foo',
+          owner: {
+            login: 'bcoe',
+          },
         },
         organization: {
           login: 'googleapis',
@@ -220,6 +306,15 @@ describe('failurechecker', () => {
 
   it('does not open an issue if a prior warning issue is still open', async () => {
     const requests = nock('https://api.github.com')
+      .get('/repos/bcoe/nodejs-foo/contents/.github%2Frelease-please.yml')
+      .reply(
+        200,
+        Buffer.from(
+          JSON.stringify({
+            releaseType: 'node',
+          })
+        )
+      )
       .get(
         '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20pending&state=closed&sort=updated&direction=desc&per_page=16'
       )
@@ -258,6 +353,9 @@ describe('failurechecker', () => {
       payload: {
         repository: {
           name: 'nodejs-foo',
+          owner: {
+            login: 'bcoe',
+          },
         },
         organization: {
           login: 'googleapis',


### PR DESCRIPTION
Reads `release-please.yml`, and for some language flavors doesn't treat an old `autorelease: tagged` label as a failure.