### PR TITLE
chore(python): make python-samples-owners writers

### DIFF
--- a/packages/sync-repo-settings/src/required-checks.json
+++ b/packages/sync-repo-settings/src/required-checks.json
@@ -60,7 +60,7 @@
       {
         "team": "yoshi-python",
         "permission": "push"
-      }
+      },
       {
         "team": "python-samples-owners",
         "permission": "push"

--- a/packages/sync-repo-settings/src/required-checks.json
+++ b/packages/sync-repo-settings/src/required-checks.json
@@ -61,6 +61,10 @@
         "team": "yoshi-python",
         "permission": "push"
       }
+      {
+        "team": "python-samples-owners",
+        "permission": "push"
+      }
     ],
     "repoOverrides": [
       {


### PR DESCRIPTION
@python-samples-owners is currently a child team of @yoshi-python.
This results in more notification spam to samples reviewers

