### PR TITLE
feat(blunderbuss): support assign_prs_by config

### DIFF
--- a/packages/blunderbuss/.eslintignore
+++ b/packages/blunderbuss/.eslintignore
@@ -1,2 +1,3 @@
 **/node_modules
 build/
+__snapshots__/

--- a/packages/blunderbuss/__snapshots__/blunderbuss.js
+++ b/packages/blunderbuss/__snapshots__/blunderbuss.js
@@ -1,59 +1,65 @@
 exports['Blunderbuss issue tests assigns opened issues with no assignees 1'] = {
-  'assignees': [
-    'issues1'
+  "assignees": [
+    "issues1"
   ]
 }
 
 exports['Blunderbuss issue tests assigns issue when correct label 1'] = {
-  'assignees': [
-    'issues1'
+  "assignees": [
+    "issues1"
   ]
 }
 
 exports['Blunderbuss pr tests assigns user to a PR when opened with no assignee 1'] = {
-  'assignees': [
-    'prs1'
+  "assignees": [
+    "prs1"
   ]
 }
 
 exports['Blunderbuss pr tests assigns issue when correct label 1'] = {
-  'assignees': [
-    'prs1'
+  "assignees": [
+    "prs1"
   ]
 }
 
 exports['Blunderbuss issue tests assigns blunderbuss labeled issue by label 1'] = {
-  'assignees': [
-    'bar_baz_user'
+  "assignees": [
+    "bar_baz_user"
   ]
 }
 
 exports['Blunderbuss issue tests assigns opened issue by label 1'] = {
-  'assignees': [
-    'foo_user'
+  "assignees": [
+    "foo_user"
   ]
 }
 
 exports['Blunderbuss issue tests assigns labeled issue by label 1'] = {
-  'assignees': [
-    'bar_baz_user'
+  "assignees": [
+    "bar_baz_user"
   ]
 }
 
 exports['Blunderbuss pr tests assigns user to a PR when opened with no assignee, ignoring assign_issues_by 1'] = {
-  'assignees': [
-    'prs1'
+  "assignees": [
+    "prs1"
   ]
 }
 
 exports['Blunderbuss issue tests expands teams for an issue 1'] = {
-  'assignees': [
-    'user123'
+  "assignees": [
+    "user123"
   ]
 }
 
 exports['Blunderbuss pr tests expands teams for a PR 1'] = {
-  'assignees': [
-    'user123'
+  "assignees": [
+    "user123"
+  ]
+}
+
+exports['Blunderbuss pr tests assigns pr by label 1'] = {
+  "assignees": [
+    "java-samples-reviewers"
   ]
 }

--- a/packages/blunderbuss/src/blunderbuss.ts
+++ b/packages/blunderbuss/src/blunderbuss.ts
@@ -79,6 +79,7 @@ export function blunderbuss(app: Application) {
       } catch (err) {
         err.message = `Error reading configuration: ${err.message}`;
         logger.error(err);
+        return;
       }
       config = config || {};
 
@@ -97,11 +98,13 @@ export function blunderbuss(app: Application) {
         (context.payload.issue &&
           !config.assign_issues &&
           !config.assign_issues_by) ||
-        (context.payload.pull_request && !config.assign_prs)
+        (context.payload.pull_request &&
+          !config.assign_prs &&
+          !config.assign_prs_by)
       ) {
         const paramName = context.payload.issue
           ? '"assign_issues" and "assign_issues_by"'
-          : '"assign_prs"';
+          : '"assign_prs" and "assign_prs_by"';
         context.log.info(
           util.format(
             '[%s] #%s ignored: %s not in config',

--- a/packages/blunderbuss/src/blunderbuss.ts
+++ b/packages/blunderbuss/src/blunderbuss.ts
@@ -29,6 +29,7 @@ interface Configuration {
   assign_issues?: string[];
   assign_issues_by?: ByConfig[];
   assign_prs?: string[];
+  assign_prs_by?: ByConfig[];
 }
 
 interface Issue {
@@ -118,7 +119,7 @@ export function blunderbuss(app: Application) {
         : config.assign_prs!;
       const byConfig = context.payload.issue
         ? config.assign_issues_by
-        : undefined;
+        : config.assign_prs_by;
       const issuePayload =
         context.payload.issue || context.payload.pull_request;
 

--- a/packages/blunderbuss/test/fixtures/config/pr_on_label.yml
+++ b/packages/blunderbuss/test/fixtures/config/pr_on_label.yml
@@ -1,0 +1,7 @@
+assign_prs_by:
+- labels:
+  - 'samples'
+  to:
+  - java-samples-reviewers
+assign_prs:
+- prs1


### PR DESCRIPTION
Allows blunderbuss to use the same configuration structure for issues by labels for assigning PRs.