### PR TITLE
build: also copy the package-lock.json during deployment

### DIFF
--- a/scripts/build-function.sh
+++ b/scripts/build-function.sh
@@ -38,5 +38,6 @@ npm install
 npm run compile
 cp -r build "${targetDir}"
 cp package.json "${targetDir}/package.json"
+cp package-lock.json "${targetDir}/package-lock.json"
 
 popd


### PR DESCRIPTION
For repeatable builds, we should be running the latest version that was tested.

Note that this may actually downgrade dependencies that are currently running in production. The runtime was ignoring our package-lock.json, but our tests and compilation was respecting it. By providing the package-lock.json to the GCF runtime, this will likely snap some dependencies back to the last versions that were tested.

I believe this behavior was the intention of #130 