### PR TITLE
feat(release-please): support go monorepo release process

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -2010,9 +2010,9 @@
           "integrity": "sha512-fbDukFPnJBdn2eZ3RR+5mK2slHLFd6gYHY7jna1KWWy4Yr4XysHuCdXRzy+RiG/HwG4WJat00vdC2UHky5eKiQ=="
         },
         "yargs-parser": {
-          "version": "20.2.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
-          "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww=="
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
         }
       }
     },
@@ -2128,9 +2128,9 @@
           "integrity": "sha512-fbDukFPnJBdn2eZ3RR+5mK2slHLFd6gYHY7jna1KWWy4Yr4XysHuCdXRzy+RiG/HwG4WJat00vdC2UHky5eKiQ=="
         },
         "yargs-parser": {
-          "version": "20.2.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
-          "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww=="
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
         }
       }
     },
@@ -5683,9 +5683,9 @@
       }
     },
     "release-please": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-6.7.0.tgz",
-      "integrity": "sha512-MugP1gM0U8hqxupqxpYoeemy3nTj5ZYcHKfG7DxSl46E2Scr6jmFRSa+ki/goqUqxPJgWhBe0c6PaT3u3IZKcQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-6.8.0.tgz",
+      "integrity": "sha512-OwfmXIEXcqd6SvVRXapVHG4GMXr7Ue5vlAfmdyhb26svgwFJFzaV0LS6eL/efZUyD0DL+T3fUEBMr21QBRtrow==",
       "requires": {
         "@octokit/graphql": "^4.3.1",
         "@octokit/request": "^5.3.4",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@octokit/webhooks": "7.11.4",
     "gcf-utils": "^6.1.0",
-    "release-please": "^6.7.0"
+    "release-please": "^6.8.0"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -113,7 +113,7 @@ async function createReleasePR(
     bumpMinorPreMajor,
     snapshot,
     path,
-    monorepoTags
+    monorepoTags,
   };
   if (releaseLabels) {
     buildOptions.label = releaseLabels.join(',');
@@ -144,7 +144,7 @@ async function createGitHubRelease(
     },
     path,
     changelogPath,
-    monorepoTags
+    monorepoTags,
   };
   const ghr = new GitHubRelease(releaseOptions);
   await Runner.releaser(ghr);

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -47,6 +47,7 @@ interface GitHubAPI {
 interface ConfigurationOptions {
   primaryBranch: string;
   releaseLabels?: string[];
+  monorepoTags?: boolean;
   releaseType?: string;
   packageName?: string;
   handleGHRelease?: boolean;
@@ -96,7 +97,8 @@ async function createReleasePR(
   releaseLabels?: string[],
   bumpMinorPreMajor?: boolean,
   snapshot?: boolean,
-  path?: string
+  path?: string,
+  monorepoTags?: boolean
 ) {
   const buildOptions: BuildOptions = {
     packageName,
@@ -111,6 +113,7 @@ async function createReleasePR(
     bumpMinorPreMajor,
     snapshot,
     path,
+    monorepoTags
   };
   if (releaseLabels) {
     buildOptions.label = releaseLabels.join(',');
@@ -125,7 +128,8 @@ async function createGitHubRelease(
   repoUrl: string,
   github: GitHubAPI,
   path?: string,
-  changelogPath?: string
+  changelogPath?: string,
+  monorepoTags?: boolean
 ) {
   const releaseOptions: GitHubReleaseOptions = {
     label: 'autorelease: pending',
@@ -140,6 +144,7 @@ async function createGitHubRelease(
     },
     path,
     changelogPath,
+    monorepoTags
   };
   const ghr = new GitHubRelease(releaseOptions);
   await Runner.releaser(ghr);
@@ -188,7 +193,8 @@ export = (app: Application) => {
       configuration.releaseLabels,
       configuration.bumpMinorPreMajor,
       false,
-      configuration.path
+      configuration.path,
+      configuration.monorepoTags
     );
 
     // release-please can handle creating a release on GitHub, we opt not to do
@@ -200,7 +206,8 @@ export = (app: Application) => {
         repoUrl,
         context.github as GitHubAPI,
         configuration.path,
-        configuration.changelogPath ?? 'CHANGELOG.md'
+        configuration.changelogPath ?? 'CHANGELOG.md',
+        configuration.monorepoTags
       );
     }
   });
@@ -241,7 +248,8 @@ export = (app: Application) => {
       configuration.releaseLabels,
       configuration.bumpMinorPreMajor,
       true,
-      configuration.path
+      configuration.path,
+      configuration.monorepoTags
     );
   });
 
@@ -306,7 +314,8 @@ export = (app: Application) => {
       configuration.releaseLabels,
       configuration.bumpMinorPreMajor,
       false,
-      configuration.path
+      configuration.path,
+      configuration.monorepoTags
     );
   });
 };


### PR DESCRIPTION
Pass the additional flag `monorepoTags` through, for the benefit of the `go` monorepo release process.