### PR TITLE
fix(snippet-bot): use products.json for region_tag_prefix

### DIFF
--- a/packages/snippet-bot/README.md
+++ b/packages/snippet-bot/README.md
@@ -76,6 +76,11 @@ ignoreFiles:
 
 `npm run test:snap`
 
+## Environment variables for local development
+
+- `DEVREL_SETTINGS_BUCKET`: specify the bucket name for external json
+  files, defaults to `devrel-prod-settings`.
+
 ## Contributing
 
 If you have suggestions for how snippet-bot could be improved, or want to report a bug, open an issue! We'd love all and any contributions.

--- a/packages/snippet-bot/src/api-labels.ts
+++ b/packages/snippet-bot/src/api-labels.ts
@@ -13,24 +13,27 @@
 // limitations under the License.
 
 import {Storage} from '@google-cloud/storage';
+import {logger} from 'gcf-utils';
 
 const storage = new Storage();
 
 export interface ApiLabel {
-  display_name: string; // Access Approval
-  github_label: string; // api: accessapproval
-  api_shortname: string; // accessapproval
+  api_shortname: string; // run
+  region_tag_prefix: string; // cloudrun
+  title: string; // Cloud Run
+  github_label: string; // api: run
 }
 
 export interface ApiLabels {
-  apis: Array<ApiLabel>;
+  products: Array<ApiLabel>;
 }
 
-export const getApiLabels = async (): Promise<ApiLabels> => {
+export const getApiLabels = async (dataBucket: string): Promise<ApiLabels> => {
   const apis = await storage
-    .bucket('devrel-prod-settings')
-    .file('apis.json')
+    .bucket(dataBucket)
+    .file('products.json')
     .download();
   const parsedResponse = JSON.parse(apis[0].toString()) as ApiLabels;
+  logger.debug({apiLabels: parsedResponse});
   return parsedResponse;
 };

--- a/packages/snippet-bot/src/violations.ts
+++ b/packages/snippet-bot/src/violations.ts
@@ -24,18 +24,24 @@ export interface Violation {
   violationType: violationTypes;
 }
 
+let dataBucket: string | undefined = process.env['DEVREL_SETTINGS_BUCKET'];
+if (dataBucket === undefined) {
+  // Default prod bucket
+  dataBucket = 'devrel-prod-settings';
+}
+
 export const checkProductPrefixViolations = async (
   changes: ChangesInPullRequest
 ): Promise<Array<Violation>> => {
   const ret: Violation[] = [];
-  const apiLabels = await getApiLabels();
+  const apiLabels = await getApiLabels(dataBucket as string);
   for (const change of changes.changes) {
     if (change.type !== 'add') {
       continue;
     }
     if (
-      !apiLabels.apis.some((label: ApiLabel) => {
-        return change.regionTag.startsWith(label.api_shortname);
+      !apiLabels.products.some((label: ApiLabel) => {
+        return change.regionTag.startsWith(label.region_tag_prefix);
       })
     ) {
       ret.push({

--- a/packages/snippet-bot/src/violations.ts
+++ b/packages/snippet-bot/src/violations.ts
@@ -24,11 +24,7 @@ export interface Violation {
   violationType: violationTypes;
 }
 
-let dataBucket: string | undefined = process.env['DEVREL_SETTINGS_BUCKET'];
-if (dataBucket === undefined) {
-  // Default prod bucket
-  dataBucket = 'devrel-prod-settings';
-}
+const dataBucket = process.env.DEVREL_SETTINGS_BUCKET || 'devrel-prod-settings';
 
 export const checkProductPrefixViolations = async (
   changes: ChangesInPullRequest

--- a/packages/snippet-bot/test/snippet-bot.ts
+++ b/packages/snippet-bot/test/snippet-bot.ts
@@ -50,7 +50,7 @@ describe('snippet-bot', () => {
 
   const sandbox = sinon.createSandbox();
 
-  let getApiLabelsStub: sinon.SinonStub<[], Promise<{}>>;
+  let getApiLabelsStub: sinon.SinonStub<[string], Promise<{}>>;
   beforeEach(() => {
     probot = createProbot({
       githubToken: 'abc123',
@@ -74,11 +74,12 @@ describe('snippet-bot', () => {
     beforeEach(() => {
       getApiLabelsStub = sandbox.stub(apiLabelsModule, 'getApiLabels');
       getApiLabelsStub.resolves({
-        apis: [
+        products: [
           {
             display_name: 'Datastore',
             github_label: 'api: datastore',
             api_shortname: 'datastore',
+            region_tag_prefix: 'datastore',
           },
         ],
       });


### PR DESCRIPTION
fixes #1101

Locally it works fine with using the dev bucket. Currently the new `products.json` file is not yet deployed to the prod bucket, so we can not merge this yet.