### PR TITLE
fix(snippet-bot): ignore 403 error as well

### DIFF
--- a/packages/snippet-bot/src/snippet-bot.ts
+++ b/packages/snippet-bot/src/snippet-bot.ts
@@ -350,10 +350,10 @@ ${bodyDetail}`
             tagsFound = true;
           }
         } catch (err) {
-          // Ignoring 404 errors.
-          if (err.status === 404) {
+          // Ignoring 403/404 errors.
+          if (err.status === 403 || err.status === 404) {
             logger.info(
-              `ignoring 404 errors upon fetching ${file}: ${err.message}`
+              `ignoring 403/404 errors upon fetching ${file}: ${err.message}`
             );
           }
           throw err;

--- a/packages/snippet-bot/src/snippet-bot.ts
+++ b/packages/snippet-bot/src/snippet-bot.ts
@@ -355,8 +355,9 @@ ${bodyDetail}`
             logger.info(
               `ignoring 403/404 errors upon fetching ${file}: ${err.message}`
             );
+          } else {
+            throw err;
           }
-          throw err;
         }
       }
 


### PR DESCRIPTION
fixes #1108 
fixes #1110

At least, this will avoid the bot from dying.
