### PR TITLE
chore: update Go genproto later in day on Monday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
     },
     {
       "packageNames": ["google.golang.org/genproto"],
-      "schedule": "after 9am on monday"
+      "schedule": "after 2pm on monday"
     }
   ],
   "ignoreDeps": ["typescript"]


### PR DESCRIPTION
The Go genproto repo updates every day after a human reviews and merges
a PR. However, this can lead to two Renovate PRs on Monday, which is
annoying. So, I updated the Renovate config to update genproto later in
the day, hopefully _after_ the Monday genproto generation is merged.