### PR TITLE
feat(gcf-utils): export a function for the comment mark

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -97,6 +97,13 @@ export enum TriggerType {
   UNKNOWN = 'Unknown',
 }
 
+/**
+ * It creates a comment string used for `addOrUpdateissuecomment`.
+ */
+export const getCommentMark = (installationId: number): string => {
+  return `<!-- probot comment [${installationId}]-->`;
+};
+
 export const addOrUpdateIssueComment = async (
   github: ProbotOctokitType,
   owner: string,
@@ -105,7 +112,7 @@ export const addOrUpdateIssueComment = async (
   installationId: number,
   commentBody: string
 ) => {
-  const commentMark = `<!-- probot comment [${installationId}]-->`;
+  const commentMark = getCommentMark(installationId);
   const listCommentsResponse = await github.issues.listComments({
     owner: owner,
     repo: repo,


### PR DESCRIPTION
fixes #1160

Now a bot can utilize the following two functions for adding an issue
comment and providing a checkbox for refreshing the comment.

- addOrUpdateIssueComment
- getCommentMark

snippet-bot has an example implementation.
