### PR TITLE
fix(build): builds failing due to format

### DIFF
--- a/packages/release-please/README.md
+++ b/packages/release-please/README.md
@@ -33,9 +33,9 @@ options:
 ## Testing
 
 This bot uses [nock](https://www.npmjs.com/package/nock) for mocking requests
-to GitHub, and [snap-shot-it](https://www.npmjs.com/package/snap-shot-it) for capturing
-responses; This allows updates to the API surface to be treated as a visual diff,
-rather than tediously asserting against each field.
+to GitHub, and [snap-shot-it](https://www.npmjs.com/package/snap-shot-it) for
+capturing responses; This allows updates to the API surface to be treated as a
+visual diff, rather than tediously asserting against each field.
 
 Running tests:
 

--- a/scripts/publish-function.sh
+++ b/scripts/publish-function.sh
@@ -60,5 +60,5 @@ fi
 gcloud tasks queues ${verb} "${queueName}" \
   --max-concurrent-dispatches="2048" \
   --max-attempts="100" \
-  --max-retry-duration="21600"
+  --max-retry-duration="43200s"
   --max-dispatches-per-second="500"


### PR DESCRIPTION
Deployment was yelling about there being no `s` on `max-retry-duration` (for the second format).

I also pulled us out to 12 hours, to give us more time to log a bug when alerts are going off.