### PR TITLE
build: also need to escape newline

### DIFF
--- a/packages/release-please/README.md
+++ b/packages/release-please/README.md
@@ -51,7 +51,8 @@ npm run test:snap
 
 ## Contributing
 
-If you have suggestions for how release-please could be improved, or want to report a bug, open an issue! We'd love all and any contributions.
+If you have suggestions for how release-please could be improved, or want to
+report a bug, open an issue! We'd love all and any contributions.
 
 For more, check out the [Contributing Guide](CONTRIBUTING.md).
 

--- a/scripts/publish-function.sh
+++ b/scripts/publish-function.sh
@@ -60,5 +60,5 @@ fi
 gcloud tasks queues ${verb} "${queueName}" \
   --max-concurrent-dispatches="2048" \
   --max-attempts="100" \
-  --max-retry-duration="43200s"
+  --max-retry-duration="43200s" \
   --max-dispatches-per-second="500"


### PR DESCRIPTION
we were also missing a newline, grumble.