### PR TITLE
fix(sync-repo-settings): ensure cloud dpes are always added

### DIFF
--- a/packages/sync-repo-settings/src/sync-repo-settings.ts
+++ b/packages/sync-repo-settings/src/sync-repo-settings.ts
@@ -224,7 +224,6 @@ export function handler(app: Application) {
       config = extend(true, {}, languageConfig)[language];
       if (!config) {
         logger.info(`no config for language ${language}`);
-        return;
       }
 
       // Check for repositories we're specifically configured to skip
@@ -245,13 +244,10 @@ export function handler(app: Application) {
     }
 
     const jobs: Promise<void>[] = [];
-    if (config!.permissionRules) {
-      jobs.push(updateRepoTeams(repo, context, config.permissionRules));
-    }
-    if (!ignored) {
+    jobs.push(updateRepoTeams(repo, context, config?.permissionRules || []));
+    if (!ignored && config) {
       jobs.push(updateRepoOptions(repo, context, config));
       if (config.branchProtectionRules) {
-        //console.log(JSON.stringify(config.branchProtectionRules))
         jobs.push(
           updateMasterBranchProtection(
             repo,

--- a/packages/sync-repo-settings/test/test.ts
+++ b/packages/sync-repo-settings/test/test.ts
@@ -147,11 +147,15 @@ describe('Sync repo settings', () => {
   });
 
   it('should ignore repos not represented in required-checks.json', async () => {
+    const org = 'Codertocat';
+    const repo = 'Hello-World';
     const scopes = [
-      nockConfig404('Codertocat', 'Hello-World'),
-      nockLanguagesList('Codertocat', 'Hello-World', {kotlin: 1}),
+      nockConfig404(org, repo),
+      nockLanguagesList(org, repo, {kotlin: 1}),
+      nockUpdateTeamMembership('cloud-dpe', org, repo),
+      nockUpdateTeamMembership('cloud-devrel-pgm', org, repo),
     ];
-    await receive('Codertocat', 'Hello-World');
+    await receive(org, repo);
     scopes.forEach(s => s.done());
   });
 


### PR DESCRIPTION
Previously, if a language wasn't listed in the global config of `required-checks.json`, no changes would be made to settings.  With this change, the `cloud-dpe` and `cloud-devrel-pgm` groups now are *always* added to every repository with write access where this GitHub app is installed.  