### PR TITLE
feat(failurechecker): track multiple failures and autoclose after success

### DIFF
--- a/packages/failurechecker/__snapshots__/failurechecker.js
+++ b/packages/failurechecker/__snapshots__/failurechecker.js
@@ -14,6 +14,18 @@ exports['failurechecker opens an issue on GitHub if there exists a tagged label 
   ]
 }
 
-exports['failurechecker does not open an issue if a prior warning issue is still open 1'] = {
-  "body": "The following release PRs may have failed:\n\n* #33"
+exports['failurechecker ignores a PR both failed and published 1'] = {
+  "state": "closed"
+}
+
+exports['failurechecker updates an issue with new failures 1'] = {
+  "body": "The following release PRs may have failed:\n\n* #33\n* #34"
+}
+
+exports['failurechecker opens an issue with multiple failures 1'] = {
+  "title": "Warning: a recent release failed",
+  "body": "The following release PRs may have failed:\n\n* #33\n* #34",
+  "labels": [
+    "type: process"
+  ]
 }

--- a/packages/failurechecker/__snapshots__/failurechecker.js
+++ b/packages/failurechecker/__snapshots__/failurechecker.js
@@ -1,6 +1,6 @@
 exports['failurechecker opens an issue on GitHub if there exists a pending label > threshold 1'] = {
   "title": "Warning: a recent release failed",
-  "body": "The release PR #33 is still in a pending state after several hours",
+  "body": "The following release PRs may have failed:\n\n* #33",
   "labels": [
     "type: process"
   ]
@@ -8,8 +8,12 @@ exports['failurechecker opens an issue on GitHub if there exists a pending label
 
 exports['failurechecker opens an issue on GitHub if there exists a tagged label > threshold 1'] = {
   "title": "Warning: a recent release failed",
-  "body": "The release PR #33 is still in a pending state after several hours",
+  "body": "The following release PRs may have failed:\n\n* #33",
   "labels": [
     "type: process"
   ]
+}
+
+exports['failurechecker does not open an issue if a prior warning issue is still open 1'] = {
+  "body": "The following release PRs may have failed:\n\n* #33"
 }

--- a/packages/failurechecker/__snapshots__/failurechecker.js
+++ b/packages/failurechecker/__snapshots__/failurechecker.js
@@ -14,10 +14,6 @@ exports['failurechecker opens an issue on GitHub if there exists a tagged label 
   ]
 }
 
-exports['failurechecker ignores a PR both failed and published 1'] = {
-  "state": "closed"
-}
-
 exports['failurechecker updates an issue with new failures 1'] = {
   "body": "The following release PRs may have failed:\n\n* #33\n* #34"
 }
@@ -28,4 +24,8 @@ exports['failurechecker opens an issue with multiple failures 1'] = {
   "labels": [
     "type: process"
   ]
+}
+
+exports['failurechecker closes a PR once failing releases are handled 1'] = {
+  "state": "closed"
 }

--- a/packages/failurechecker/package.json
+++ b/packages/failurechecker/package.json
@@ -22,7 +22,7 @@
     "start": "probot run ./build/src/failurechecker.js",
     "start:local": "node ./build/src/local.js",
     "pretest": "npm run compile",
-    "test": "cross-env LOG_LEVEL=fatal c8 mocha --exit build/test",
+    "test": "cross-env LOG_LEVEL=fatal c8 mocha build/test",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test",
     "fix": "gts fix",
     "lint": "gts check"

--- a/packages/failurechecker/package.json
+++ b/packages/failurechecker/package.json
@@ -22,7 +22,7 @@
     "start": "probot run ./build/src/failurechecker.js",
     "start:local": "node ./build/src/local.js",
     "pretest": "npm run compile",
-    "test": "cross-env LOG_LEVEL=fatal c8 mocha --exit build/test --timeout 50000",
+    "test": "cross-env LOG_LEVEL=fatal c8 mocha --exit build/test",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test",
     "fix": "gts fix",
     "lint": "gts check"

--- a/packages/failurechecker/package.json
+++ b/packages/failurechecker/package.json
@@ -22,7 +22,7 @@
     "start": "probot run ./build/src/failurechecker.js",
     "start:local": "node ./build/src/local.js",
     "pretest": "npm run compile",
-    "test": "cross-env LOG_LEVEL=fatal c8 mocha build/test",
+    "test": "cross-env LOG_LEVEL=fatal c8 mocha --exit build/test --timeout 50000",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test",
     "fix": "gts fix",
     "lint": "gts check"

--- a/packages/failurechecker/src/failurechecker.ts
+++ b/packages/failurechecker/src/failurechecker.ts
@@ -25,6 +25,7 @@ type OctokitType = InstanceType<typeof ProbotOctokit>;
 // labels indicative of the fact that a release has not completed yet.
 const RELEASE_LABELS = ['autorelease: pending', 'autorelease: failed'];
 const RELEASE_TYPE_NO_PUBLISH = ['go-yoshi'];
+const SUCCESSFUL_PUBLISH_LABEL = 'autorelease: published';
 
 // We open an issue that a release has failed if it's been longer than 3
 // hours and we're within normal working hours.
@@ -100,7 +101,10 @@ export function failureChecker(app: Application) {
               pull_number: issue.number,
             })
           ).data;
-          if (pr.merged_at) {
+          if (
+            pr.merged_at &&
+            !pr.labels.some(l => l.name === SUCCESSFUL_PUBLISH_LABEL)
+          ) {
             failed.push(pr.number);
           }
         }
@@ -112,7 +116,7 @@ export function failureChecker(app: Application) {
   });
 
   function buildIssueBody(prNumbers: number[]): string {
-    const list = prNumbers.map((prNumber) => `* #${prNumber}`).join("\n")
+    const list = prNumbers.map(prNumber => `* #${prNumber}`).join('\n');
     return `The following release PRs may have failed:\n\n${list}`;
   }
 
@@ -146,7 +150,7 @@ export function failureChecker(app: Application) {
         issue_number: warningIssue.number,
         state: 'closed',
       });
-      return
+      return;
     }
 
     const body = buildIssueBody(prNumbers);

--- a/packages/failurechecker/src/failurechecker.ts
+++ b/packages/failurechecker/src/failurechecker.ts
@@ -143,13 +143,15 @@ export function failureChecker(app: Application) {
     logger.info((await github.rateLimit.get()).data);
 
     // existing issue and no failures - close the existing issue
-    if (warningIssue && prNumbers.length === 0) {
-      await github.issues.update({
-        owner,
-        repo,
-        issue_number: warningIssue.number,
-        state: 'closed',
-      });
+    if (prNumbers.length === 0) {
+      if (warningIssue) {
+        await github.issues.update({
+          owner,
+          repo,
+          issue_number: warningIssue.number,
+          state: 'closed',
+        });
+      }
       return;
     }
 
@@ -163,7 +165,7 @@ export function failureChecker(app: Application) {
       }
 
       // Update the existing issue
-      github.issues.update({
+      await github.issues.update({
         owner,
         repo,
         issue_number: warningIssue.number,
@@ -172,7 +174,7 @@ export function failureChecker(app: Application) {
       return;
     }
     app.log(`opening warning issue on ${repo} for PR #${prNumbers}`);
-    return github.issues.create({
+    await github.issues.create({
       owner,
       repo,
       title: ISSUE_TITLE,

--- a/packages/failurechecker/test/failurechecker.ts
+++ b/packages/failurechecker/test/failurechecker.ts
@@ -192,7 +192,9 @@ describe('failurechecker', () => {
       .reply(200, [])
       .get('/rate_limit')
       .reply(200, {})
-      .get('/repos/googleapis/nodejs-foo/issues?labels=type%3A%20process&per_page=32')
+      .get(
+        '/repos/googleapis/nodejs-foo/issues?labels=type%3A%20process&per_page=32'
+      )
       .reply(200, []);
 
     await probot.receive({
@@ -244,7 +246,9 @@ describe('failurechecker', () => {
       ])
       .get('/rate_limit')
       .reply(200, [])
-      .get('/repos/googleapis/nodejs-foo/issues?labels=type%3A%20process&per_page=32')
+      .get(
+        '/repos/googleapis/nodejs-foo/issues?labels=type%3A%20process&per_page=32'
+      )
       .reply(200, []);
 
     await probot.receive({
@@ -295,7 +299,9 @@ describe('failurechecker', () => {
       ])
       .get('/rate_limit')
       .reply(200, {})
-      .get('/repos/googleapis/nodejs-foo/issues?labels=type%3A%20process&per_page=32')
+      .get(
+        '/repos/googleapis/nodejs-foo/issues?labels=type%3A%20process&per_page=32'
+      )
       .reply(200, []);
 
     await probot.receive({
@@ -357,7 +363,7 @@ describe('failurechecker', () => {
         {
           title: 'Warning: a recent release failed',
           number: 44,
-          body: "The following release PRs may have failed:\n\n* #33",
+          body: 'The following release PRs may have failed:\n\n* #33',
         },
       ])
       .get('/rate_limit')
@@ -424,7 +430,10 @@ describe('failurechecker', () => {
       .reply(200, {
         number: 33,
         merged_at: '2020-01-30T13:33:48Z',
-        labels: [{name: 'autorelease: failed'}, {name: 'autorelease: published'}],
+        labels: [
+          {name: 'autorelease: failed'},
+          {name: 'autorelease: published'},
+        ],
       })
       .get(
         '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20tagged&state=closed&sort=updated&direction=desc&per_page=16'
@@ -493,7 +502,10 @@ describe('failurechecker', () => {
       .reply(200, {
         number: 33,
         merged_at: '2020-01-30T13:33:48Z',
-        labels: [{name: 'autorelease: failed'}, {name: 'autorelease: published'}],
+        labels: [
+          {name: 'autorelease: failed'},
+          {name: 'autorelease: published'},
+        ],
       })
       .get(
         '/repos/googleapis/nodejs-foo/issues?labels=autorelease%3A%20tagged&state=closed&sort=updated&direction=desc&per_page=16'
@@ -579,7 +591,7 @@ describe('failurechecker', () => {
         {
           title: 'Warning: a recent release failed',
           number: 44,
-          body: "The following release PRs may have failed:\n\n* #33",
+          body: 'The following release PRs may have failed:\n\n* #33',
         },
       ])
       .get('/rate_limit')

--- a/packages/failurechecker/test/failurechecker.ts
+++ b/packages/failurechecker/test/failurechecker.ts
@@ -406,7 +406,7 @@ describe('failurechecker', () => {
     });
   });
 
-  it('ignores a PR both failed and published', async () => {
+  it('closes a PR once failing releases are handled', async () => {
     const requests = nock('https://api.github.com')
       .get('/repos/bcoe/nodejs-foo/contents/.github%2Frelease-please.yml')
       .reply(
@@ -478,7 +478,7 @@ describe('failurechecker', () => {
     requests.done();
   });
 
-  it('closes a PR once failing releases are handled', async () => {
+  it('ignores a PR both failed and published', async () => {
     const requests = nock('https://api.github.com')
       .get('/repos/bcoe/nodejs-foo/contents/.github%2Frelease-please.yml')
       .reply(


### PR DESCRIPTION
This PR does a few things:

* track multiple release PR failures (shown as a list)
* updates the issue body when a new release fails
* ignores release PRs that are marked as both `autorelease: failed` and `autorelease: published` (in case you retry and it succeeds)
* closes the open issue when release failures are resolved
