### PR TITLE
build: auto assign issues and pull requests by bot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,21 @@
 
 
 *     @googleapis/github-automation
+
+packages/auto-label/*                 @googleapis/github-automation @nicoleczhu @sofisl
+packages/blunderbuss/*                @googleapis/github-automation @kurtisvg
+packages/buildcop/*                   @googleapis/github-automation @tbp
+packages/conventional-commit-lint/*   @googleapis/github-automation @bcoe
+packages/do-not-merge/*               @googleapis/github-automation @tbp
+packages/failurechecker/*             @googleapis/github-automation @bcoe
+packages/generated-files-bot/*        @googleapis/github-automation @chingor13
+packages/header-checker-lint/*        @googleapis/github-automation @chingor13
+packages/label-sync/*                 @googleapis/github-automation @JustinBeckwith
+packages/merge-on-green/*             @googleapis/github-automation @sofisl
+packages/monitoring-system/*          @googleapis/github-automation @chingor13
+packages/publish/*                    @googleapis/github-automation @bcoe
+packages/release-please/*             @googleapis/github-automation @bcoe @chingor13
+packages/slo-stat-bot/*               @googleapis/github-automation @orthros
+packages/snippet-bot/*                @googleapis/github-automation @tmatsuo
+packages/sync-repo-settings/*         @googleapis/github-automation @JustinBeckwith
+packages/trusted-contribution/*       @googleapis/github-automation @crwilcox

--- a/.github/auto-label.yml
+++ b/.github/auto-label.yml
@@ -1,0 +1,27 @@
+# See https://github.com/googleapis/repo-automation-bots/tree/master/packages/auto-label
+
+# Turn of product-based auto-labelling
+product: false
+
+# Label bots by code path
+path:
+  pullrequest: true
+  labelprefix: 'bot: '
+  packages:
+    auto-label: 'auto-label'
+    blunderbuss: 'blunderbuss'
+    buildcop: 'buildcop'
+    conventional-commit-lint: 'conventional-commit-lint'
+    do-not-merge: 'do-not-merge'
+    failurechecker: 'failurechecker'
+    generated-files-bot: 'generated-files-bot'
+    header-checker-lint: 'header-checker-lint'
+    label-sync: 'label-sync'
+    merge-on-green: 'merge-on-green'
+    publish: 'publish'
+    release-please: 'release-please'
+    slo-stat-bot: 'slo-stat-bot'
+    snippet-bot: 'snippet-bot'
+    sync-repo-settings: 'sync-repo-settings'
+    trusted-contribution: 'trusted-contribution'
+

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,0 +1,109 @@
+# See https://github.com/googleapis/repo-automation-bots/tree/master/packages/blunderbuss
+
+assign_issues_by:
+  - labels:
+    - 'bot: auto-label'
+    to:
+    - nicoleczhu
+    - sofisl
+  - labels:
+    - 'bot: blunderbuss'
+    to:
+    - kvg
+  - labels:
+    - 'bot: buildcop'
+    - 'bot: do-not-merge'
+    to:
+    - tbp
+  - labels:
+    - 'bot: conventional-commit-lint'
+    - 'bot: failurechecker'
+    - 'bot: publish'
+    to:
+    - bcoe
+  - labels:
+    - 'bot: generated-files-bot'
+    - 'bot: header-checker-lint'
+    - 'bot: monitoring-system'
+    to:
+    - chingor13
+  - labels:
+    - 'bot: label-sync'
+    - 'bot: sync-repo-settings'
+    to:
+    - JustinBeckwith
+  - labels:
+    - 'bot: merge-on-green'
+    to:
+    - sofisl
+  - labels:
+    - 'bot: release-please'
+    to:
+    - bcoe
+    - chingor13
+  - labels:
+    - 'bot: slo-stat-bot'
+    to:
+    - orthros
+  - labels:
+    - 'bot: snippet-bot'
+    to:
+    - tmatsuo
+  - labels:
+    - 'bot: trusted-contribution'
+    to:
+    - crwilcox
+
+assign_prs_by:
+  - labels:
+    - 'bot: auto-label'
+    to:
+    - nicoleczhu
+    - sofisl
+  - labels:
+    - 'bot: blunderbuss'
+    to:
+    - kvg
+  - labels:
+    - 'bot: buildcop'
+    - 'bot: do-not-merge'
+    to:
+    - tbp
+  - labels:
+    - 'bot: conventional-commit-lint'
+    - 'bot: failurechecker'
+    - 'bot: publish'
+    to:
+    - bcoe
+  - labels:
+    - 'bot: generated-files-bot'
+    - 'bot: header-checker-lint'
+    - 'bot: monitoring-system'
+    to:
+    - chingor13
+  - labels:
+    - 'bot: label-sync'
+    - 'bot: sync-repo-settings'
+    to:
+    - JustinBeckwith
+  - labels:
+    - 'bot: merge-on-green'
+    to:
+    - sofisl
+  - labels:
+    - 'bot: release-please'
+    to:
+    - bcoe
+    - chingor13
+  - labels:
+    - 'bot: slo-stat-bot'
+    to:
+    - orthros
+  - labels:
+    - 'bot: snippet-bot'
+    to:
+    - tmatsuo
+  - labels:
+    - 'bot: trusted-contribution'
+    to:
+    - crwilcox


### PR DESCRIPTION
* adds users as CODEOWNERS to bots they authored (note we keep the github-automation team as an owner to prevent blocking and in case a solo author/owner submits a PR)
* enables auto-label for PRs by code path
* enables blunderbuss auto assignment by bot label
