### PR TITLE
fix: avoid unpredictable repo state

### DIFF
--- a/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
+++ b/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
@@ -130,7 +130,6 @@ for (( idx=${#ungenerated_shas[@]}-1 ; idx>=0 ; idx-- )) ; do
         # Commit changes and push them.
         git -C "$GOOGLEAPIS_GEN" commit -F "$(realpath commit-msg.txt)"
         git -C "$GOOGLEAPIS_GEN" tag "googleapis-$sha"
-        git -C "$GOOGLEAPIS_GEN" pull
         git -C "$GOOGLEAPIS_GEN" push origin
         git -C "$GOOGLEAPIS_GEN" push origin "googleapis-$sha"
     fi


### PR DESCRIPTION
The "git pull" was designed to make the following "git push" more likely to succeed in the face of a race condition.  However, if the push fails for any reason, I think it's safer to fail and retry later.
