### PR TITLE
build(owl-bot): update gcf-utils with probot 11

### DIFF
--- a/packages/owl-bot/package-lock.json
+++ b/packages/owl-bot/package-lock.json
@@ -395,9 +395,9 @@
       }
     },
     "@octokit/plugin-request-log": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
-      "integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
+      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "4.4.1",
@@ -452,14 +452,39 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.0.12",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.12.tgz",
-      "integrity": "sha512-hNRCZfKPpeaIjOVuNJzkEL6zacfZlBPV8vw8ReNeyUkVvbuCvvrrx8K8Gw2eyHHsmd4dPlAxIXIZ9oHhJfkJpw==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.1.0.tgz",
+      "integrity": "sha512-YQfpTzWV3jdzDPyXQVO54f5I2t1zxk/S53Vbe+Aa5vQj6MdTx6sNEWzmUzUO8lSVowbGOnjcQHzW1A8ATr+/7g==",
       "requires": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "4.4.1"
+        "@octokit/plugin-rest-endpoint-methods": "4.10.1"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.1.tgz",
+          "integrity": "sha512-k2hRcfcLRyPJjtYfJLzg404n7HZ6sUpAWAR/uNI8tf96NgatWOpw1ocdF+WFfx/trO1ivBh7ckynO1rn+xAw/Q=="
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.10.1.tgz",
+          "integrity": "sha512-YGMiEidTORzgUmYZu0eH4q2k8kgQSHQMuBOBYiKxUYs/nXea4q/Ze6tDzjcRAPmHNJYXrENs1bEMlcdGKT+8ug==",
+          "requires": {
+            "@octokit/types": "^6.8.2",
+            "deprecation": "^2.3.1"
+          }
+        },
+        "@octokit/types": {
+          "version": "6.8.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.2.tgz",
+          "integrity": "sha512-RpG0NJd7OKSkWptiFhy1xCLkThs5YoDIKM21lEtDmUvSpbaIEfrxzckWLUGDFfF8RydSyngo44gDv8m2hHruUg==",
+          "requires": {
+            "@octokit/openapi-types": "^4.0.0",
+            "@types/node": ">= 8"
+          }
+        }
       }
     },
     "@octokit/types": {

--- a/packages/owl-bot/package-lock.json
+++ b/packages/owl-bot/package-lock.json
@@ -190,22 +190,23 @@
       "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
     },
     "@google-cloud/secret-manager": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.3.0.tgz",
-      "integrity": "sha512-v4N4Kj+TpSboHxHyOuqk28wTAx79Nj5rUlvU+ySzE5+cgkAILMbM0e+QkjkvXWzwP41q7rAUM1cccQ2z9qtolg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.4.0.tgz",
+      "integrity": "sha512-GH1YUeELu310TVY/Mmler8ND2ZG10wBo6nr5cOwr+vgA+uEKbw/6v4ns5ETO4lLfFRWHQxWxvBEtuwTmubYTmQ==",
       "requires": {
         "google-gax": "^2.9.2"
       }
     },
     "@google-cloud/storage": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.7.2.tgz",
-      "integrity": "sha512-LEKGOe+GnD1yV5YnpAmRJFAReOYHthyC2CAdQs0wv7OJAplvJCEPHchUNC7nk0QEc23mz9cYHEnT76MP+YmBhQ==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.7.4.tgz",
+      "integrity": "sha512-fynB3kDT+lhx71laML+LtUs/w9Ezcf+SVAsaP0fhAyPQzOc0kp43uYTymYCvF9GffYR7jcy6yqYifeMSU9VEVA==",
       "requires": {
         "@google-cloud/common": "^3.5.0",
         "@google-cloud/paginator": "^3.0.0",
         "@google-cloud/promisify": "^2.0.0",
         "arrify": "^2.0.0",
+        "async-retry": "^1.3.1",
         "compressible": "^2.0.12",
         "date-and-time": "^0.14.2",
         "duplexify": "^4.0.0",
@@ -232,9 +233,9 @@
       }
     },
     "@google-cloud/tasks": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-2.2.0.tgz",
-      "integrity": "sha512-VsliFnP3H5DIU4RcptdJGtzYhOZbvVItiuWcO3VB3UdqojO0MJcGGDA1Gb1MgVuMMP2OLVP/vA38sCdhE1DsWg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-2.3.0.tgz",
+      "integrity": "sha512-09Ah1wWe2oueTxUUvPzgtiN7/sfM0Q9pWclKmeEhdu5i7AGaxTHDtZ07pVMoiV8I7dCVRe/LpKMH5T1B3KQbzA==",
       "requires": {
         "google-gax": "^2.9.2"
       }
@@ -308,9 +309,9 @@
       }
     },
     "@octokit/auth-app": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-2.10.5.tgz",
-      "integrity": "sha512-6yXyjtcBWpuPYSdZN8z8IIjGSqkPmiJzdmCdod8at41ANB1FtaKbUIDL5+IkG+svv68NIYs+XORbhBRFXYB3bw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-2.11.0.tgz",
+      "integrity": "sha512-tC0BjqyTEjReIBHogOjLjF3rc2n4xwjZcpOaUUhybDnqkrp7Gxj5n91aGUcIFgJ3MDYf+f3XZehQd2B4ijG+4w==",
       "requires": {
         "@octokit/request": "^5.4.11",
         "@octokit/request-error": "^2.0.0",
@@ -331,9 +332,9 @@
       }
     },
     "@octokit/auth-unauthenticated": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-2.0.3.tgz",
-      "integrity": "sha512-8w7hq3FUSsCtbta/VuxVwoAXpHo1jVfTQopUfSj8nhMBkah9wGEfz3lh9JDmH7NlOvVRhfhg2dsP4JR0Yt6viw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-2.0.4.tgz",
+      "integrity": "sha512-jZMwIz2PfQuLcOQRRELY6zb/jIyWQKlPxVV1oEG4sxJNmnANz3Skvnz4kVNvfs1r2jhgKAx9Pb6f+3vXeyh7yg==",
       "requires": {
         "@octokit/request-error": "^2.0.2",
         "@octokit/types": "^6.0.3"
@@ -409,18 +410,18 @@
       }
     },
     "@octokit/plugin-retry": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.6.tgz",
-      "integrity": "sha512-2ht+F85yN5pVw6rhFfJhrpujI8ch2lQUEEsK/Pkx3elFgh9lW4sbZXisH+uDD15+kZU5NX4zQ4ycUDofGLmhXg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.7.tgz",
+      "integrity": "sha512-n08BPfVeKj5wnyH7IaOWnuKbx+e9rSJkhDHMJWXLPv61625uWjsN8G7sAW3zWm9n9vnS4friE7LL/XLcyGeG8Q==",
       "requires": {
         "@octokit/types": "^6.0.3",
         "bottleneck": "^2.15.3"
       }
     },
     "@octokit/plugin-throttling": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.3.4.tgz",
-      "integrity": "sha512-cjMoonVhe2wb6iLRZltDzLF2X6udZPam+Rgr9SbvENda1GO5d38qrqByZcrDZXVzFPWOUmY8icofM4Puae/F5g==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.4.1.tgz",
+      "integrity": "sha512-qCQ+Z4AnL9OrXvV59EH3GzPxsB+WyqufoCjiCJXJxTbnt3W+leXbXw5vHrMp4NG9ltw00McFWIxIxNQAzLNoTA==",
       "requires": {
         "@octokit/types": "^6.0.1",
         "bottleneck": "^2.15.3"
@@ -522,21 +523,6 @@
       "requires": {
         "@types/js-yaml": "^4.0.0",
         "js-yaml": "^4.0.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "js-yaml": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
       }
     },
     "@probot/pino": {
@@ -606,47 +592,47 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@sentry/core": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.0.0.tgz",
-      "integrity": "sha512-afAiOachs/WfGWc9LsJBFnJMhqQVENyzfSMnf7sLRvxPAw8n7IrXY0R09MKmG0SlAnTKN2pWoQFzFF+J3NuHBA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.0.4.tgz",
+      "integrity": "sha512-5+Xnk3jb0nkKYvgBV/kKWUqrNsNeM38r98ZRqfHrl69WoSrv+ynTsj8gn0tZO+VvhxUDRLOYvDha+QZgkYZt/w==",
       "requires": {
-        "@sentry/hub": "6.0.0",
-        "@sentry/minimal": "6.0.0",
-        "@sentry/types": "6.0.0",
-        "@sentry/utils": "6.0.0",
+        "@sentry/hub": "6.0.4",
+        "@sentry/minimal": "6.0.4",
+        "@sentry/types": "6.0.4",
+        "@sentry/utils": "6.0.4",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.0.0.tgz",
-      "integrity": "sha512-s8IsW6LvEH7ACnniQcxxb/9uEyjmoQ/TAoryTJN2qyPzzrHTw8NCyMuJvK+8ivUvRViz5AvtuOFf8AJlh9lzeA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.0.4.tgz",
+      "integrity": "sha512-gutuxH8M3CdElSbwqNq9G29MiNuGsPESB22w4k4wx+pc632bi6w0v53+BLjGO6wh2EMfHVWptgAYmojEk5yKQg==",
       "requires": {
-        "@sentry/types": "6.0.0",
-        "@sentry/utils": "6.0.0",
+        "@sentry/types": "6.0.4",
+        "@sentry/utils": "6.0.4",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.0.0.tgz",
-      "integrity": "sha512-daYdEzTr+ERMwViu6RpWHOfk0oZrSNqdx+7bejTqmFHqO4pt+9ZrMiw3vinL+MWQcKXwD95uXBz6O/ryrVdPtg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.0.4.tgz",
+      "integrity": "sha512-COL0tjznrCaatOPH2eGgT1Y9vUUKJw+W0srCn5V1dHgRu3t00rGFXrcyOXQmHfEWmBaagt9lXEJCFaN7yMucVQ==",
       "requires": {
-        "@sentry/hub": "6.0.0",
-        "@sentry/types": "6.0.0",
+        "@sentry/hub": "6.0.4",
+        "@sentry/types": "6.0.4",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.0.0.tgz",
-      "integrity": "sha512-YPCHZtJeh7rougAg173pwp9vL1v3J4uOBJ+QCscqHoNbGl5XNO1ZO32T+il74Ra6qVWc9pCyqozUjvW5GL+rNQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.0.4.tgz",
+      "integrity": "sha512-ce3hybOOPRx93rG2V1ac8baNFMlGF+n0Ddbc2mGNl4nV20djI7dyACjUsmERqBzRrz3ozKfS379AkIa2dP2lcA==",
       "requires": {
-        "@sentry/core": "6.0.0",
-        "@sentry/hub": "6.0.0",
-        "@sentry/tracing": "6.0.0",
-        "@sentry/types": "6.0.0",
-        "@sentry/utils": "6.0.0",
+        "@sentry/core": "6.0.4",
+        "@sentry/hub": "6.0.4",
+        "@sentry/tracing": "6.0.4",
+        "@sentry/types": "6.0.4",
+        "@sentry/utils": "6.0.4",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -661,28 +647,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.0.0.tgz",
-      "integrity": "sha512-7Qes5godGCuvcEBxynFuRT5iiFR5aOfBdvdPmWnx29XbZKQvhjvBsDtdoVSQUmv/nCLtpH6UWeLwddFvXh3A2w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.0.4.tgz",
+      "integrity": "sha512-/da81kbkpiA17kAVjW8ZdpASwgsdYUXZg3jdOfbV07HK/6aFkfOF8/sHKMjVG2Iy4oaRel/F7l6/wf+XlKbBMw==",
       "requires": {
-        "@sentry/hub": "6.0.0",
-        "@sentry/minimal": "6.0.0",
-        "@sentry/types": "6.0.0",
-        "@sentry/utils": "6.0.0",
+        "@sentry/hub": "6.0.4",
+        "@sentry/minimal": "6.0.4",
+        "@sentry/types": "6.0.4",
+        "@sentry/utils": "6.0.4",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.0.0.tgz",
-      "integrity": "sha512-yueRSRGPCahuju/UMdtOt8LIIncbpwLINQd9Q8E4OXtoPpMHR6Oun8sMKCPd+Wq3piI5yRDzKkGCl+sH7mHVrA=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.0.4.tgz",
+      "integrity": "sha512-VqmnhJPpPmsu4gMzSZw8UHgYlP1QSikMZ5X6E3q6zwmbWu+2oniQHD6xGB6PXv6uTo5zg2NseQEiWnEjJRUYWw=="
     },
     "@sentry/utils": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.0.0.tgz",
-      "integrity": "sha512-dMMWOT69bQ4CF1R33dOnXIOyiHRWsUAON3nFVljV1JNNTDA69YwaF9f5FIT0DKpO4qhgTlElsm8WgHI9prAVEQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.0.4.tgz",
+      "integrity": "sha512-UOAz5p5IIntmIcmX04Cjk7l7+EwnuBn2S/rhNN92I1vDCaL010OmUZOHGHJExoXBE75zVh/LDssAPQTKXo0F+g==",
       "requires": {
-        "@sentry/types": "6.0.0",
+        "@sentry/types": "6.0.4",
         "tslib": "^1.9.3"
       }
     },
@@ -815,9 +801,9 @@
       }
     },
     "@types/ioredis": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.19.1.tgz",
-      "integrity": "sha512-+q10eLAgjbYJMY/fAM7+zmNBegCAk3FZwcvgjdsPy5xK4MzFcVXB6yxa69bTB5Ouz24WqJiub6lPzasLE5BYZQ==",
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.19.3.tgz",
+      "integrity": "sha512-r9rXLYeZVmvTf0nKDmFYrpBeVzK5B6jgE2ncfkzPOAuRM5RTzKnYdW2wVn+ZONMnFxV6H4R3NrCdRdC3CL4nFA==",
       "requires": {
         "@types/node": "*"
       }
@@ -907,9 +893,9 @@
       }
     },
     "@types/pino-http": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/pino-http/-/pino-http-5.0.6.tgz",
-      "integrity": "sha512-JAIADDYjq621p451z9L6zD+m4nlzZ3Fz/LLTqZNJtS06YFUthf9bfFRKPwuBw42nqMwUhI5fIHgfK7IrXS9GaQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@types/pino-http/-/pino-http-5.4.0.tgz",
+      "integrity": "sha512-d2OqdD3BWZA7JupHHkWHl/9aqzpGOI2jwD9FGcoWqbg/1f/HaXENI8T4gqzCHZg3ELkhrTaPjrLWbAfD8bGJ3g==",
       "requires": {
         "@types/pino": "*"
       }
@@ -1344,6 +1330,14 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
+    },
+    "async-retry": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
+      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
+      "requires": {
+        "retry": "0.12.0"
+      }
     },
     "atomic-sleep": {
       "version": "1.0.0",
@@ -2577,9 +2571,9 @@
       }
     },
     "gcf-utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-7.0.0.tgz",
-      "integrity": "sha512-sgObcF3+oQgEiAogNhEoCwtg5tQ3Q1s28Ml5eT6Lbtvt55tOeB8fOmK4EZXklPN9ADjx9i0JD0TyqnNbLc/sdg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-7.1.0.tgz",
+      "integrity": "sha512-2cc8o8TWIk0MDAnaFgn7qwWF6f0YcWoDWmSzfafrrrt6ebkknGabtBTK+rNDHKgrBSIgq63gaVdhKvBpmWHASw==",
       "requires": {
         "@google-cloud/kms": "^2.0.0",
         "@google-cloud/secret-manager": "^3.0.0",
@@ -2601,8 +2595,9 @@
         "gaxios": "^4.0.0",
         "get-stream": "^6.0.0",
         "into-stream": "^6.0.0",
+        "octokit-auth-probot": "^1.2.2",
         "pino": "^6.3.2",
-        "probot": "11.0.4",
+        "probot": "^11.0.5",
         "tmp": "^0.2.0",
         "uuid": "^8.3.0",
         "yargs": "^16.0.0"
@@ -4264,9 +4259,9 @@
       }
     },
     "pino-http": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.3.0.tgz",
-      "integrity": "sha512-aV4e7L8ez2MCa1qsuuliKYX5CDJug3LjW8oht+r4H4+fcf7ZvxPOppTs7P9dNHccF8k8oqhOcU/myiP4GvzJiA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.4.0.tgz",
+      "integrity": "sha512-CxJtTq65jmihTVzkFexlvkUl1naGU6j/8+hV2WwUJ+zb842O6Ff0Q9WdqdmR2GeVT3Uu+NZAC8tHyA2Cgile7A==",
       "requires": {
         "fast-url-parser": "^1.1.3",
         "pino": "^6.0.0",
@@ -4281,9 +4276,9 @@
       }
     },
     "pino-pretty": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.3.0.tgz",
-      "integrity": "sha512-uEc9SUCCGVEs0goZvyznKXBHtI1PNjGgqHviJHxOCEFEWZN6Z/IQKv5pO9gSdm/b+WfX+/dfheWhtZUyScqjlQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.5.0.tgz",
+      "integrity": "sha512-TtIzAq3JrPT4cYMZcXHypAXYV+MTE7ncAPUFoaz/1enVD2Loj+hV6RZsypYo85dm7SbBolW6fcIydOF28iGjsg==",
       "requires": {
         "@hapi/bourne": "^2.0.0",
         "args": "^5.0.1",
@@ -4379,9 +4374,9 @@
       }
     },
     "probot": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/probot/-/probot-11.0.4.tgz",
-      "integrity": "sha512-I43Ak928G8e8Rz6/vfZ0qDjm+LDzdVRLT9rQjbSncFZSmLqIRkwMed+l3aFK8n34zvfIYtiq88LOeDP4r8ODeQ==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-11.0.5.tgz",
+      "integrity": "sha512-o8euQLHiJobgbKwbJb/1fg+ghC5Rf1gzSAk1qFH55tUhBkmTIxgVp1P21mkuFbyyTVlw9MZ0AwaVmdJJc6tpxQ==",
       "requires": {
         "@octokit/core": "^3.2.4",
         "@octokit/plugin-enterprise-compatibility": "^1.2.8",
@@ -4800,6 +4795,11 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "retry-request": {
       "version": "4.1.3",
@@ -5319,9 +5319,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.12.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.5.tgz",
-      "integrity": "sha512-SgpgScL4T7Hj/w/GexjnBHi3Ien9WS1Rpfg5y91WXMj9SY997ZCQU76mH4TpLwwfmMvoOU8wiaRkIf6NaH3mtg==",
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.6.tgz",
+      "integrity": "sha512-aqWHe3DfQmZUDGWBbabZ2eQnJlQd1fKlMUu7gV+MiTuDzdgDw31bI3wA2jLLsV/hNcDP26IfyEgSVoft5+0SVw==",
       "optional": true
     },
     "unique-string": {

--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@google-cloud/cloudbuild": "^2.0.6",
-    "@octokit/rest": "^18.0.12",
+    "@octokit/rest": "^18.1.0",
     "gaxios": "^4.1.0",
     "gcf-utils": "^7.0.0",
     "js-yaml": "^4.0.0",

--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -54,7 +54,7 @@
     "@google-cloud/cloudbuild": "^2.0.6",
     "@octokit/rest": "^18.1.0",
     "gaxios": "^4.1.0",
-    "gcf-utils": "^7.0.0",
+    "gcf-utils": "^7.1.0",
     "js-yaml": "^4.0.0",
     "jsonwebtoken": "^8.5.1",
     "yargs": "^16.2.0"


### PR DESCRIPTION
This gets us upgraded to the latest and greatest version of gcf-utils, with support for probot 11.

Note, `@octokit/webhooks@7.21.0` has been pinned for the time being due to https://github.com/octokit/webhooks.js/issues/436.