### PR TITLE
build(owl-bot): no prepare

### DIFF
--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -16,7 +16,6 @@
     "compile": "tsc -p .",
     "fix": "gts fix",
     "lint": "gts check",
-    "prepare": "npm run compile",
     "test": "c8 mocha build/test",
     "pretest": "npm run compile",
     "precompile": "gts clean"


### PR DESCRIPTION
We can't have a prepare that requires dev dependencies, as these are not installed during Cloud Build deploy.