### PR TITLE
fix: confirm that bazel can fetch remote build dependencies

### DIFF
--- a/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
+++ b/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
@@ -78,6 +78,15 @@ for (( idx=${#ungenerated_shas[@]}-1 ; idx>=0 ; idx-- )) ; do
     fi
     # Clean out all the source packages from the previous build.
     rm -f $(find -L "$GOOGLEAPIS/bazel-bin" -name "*.tar.gz")
+    # Confirm that bazel can fetch remote build dependencies before building
+    # with -k.  Otherwise, we can't distinguish a build failure due to a bad proto
+    # vs. a build failure due to transient network issue.
+    if [[ -z "$FETCH_TARGETS" ]] ; then
+        fetch_targets="$targets"
+    else
+        fetch_targets="$FETCH_TARGETS"
+    fi
+    (cd "$GOOGLEAPIS" && bazel fetch $BAZEL_FLAGS $fetch_targets)
     # Some API always fails to build.  One failing API should not prevent all other
     # APIs from being updated.
     set +e

--- a/packages/bazel-bot/test-generate-googleapis-gen.sh
+++ b/packages/bazel-bot/test-generate-googleapis-gen.sh
@@ -67,6 +67,7 @@ git -C googleapis-gen checkout -b other
 export GOOGLEAPIS_GEN=`realpath googleapis-gen-clone`
 export INSTALL_CREDENTIALS="echo 'Pretending to install credentials...''"
 export BUILD_TARGETS="//google/cloud/vision/v1:vision-v1-nodejs.tar.gz //google/bogus:api.tar.gz"
+export FETCH_TARGETS="//google/cloud/vision/v1:vision-v1-nodejs.tar.gz"
 bash -x "$generate_googleapis_gen"
 
 # Display the state of googleapis-gen


### PR DESCRIPTION
before building with -k.  Otherwise, we can't distinguish a build failure due to a bad proto
from a build failure due to transient network issue.
