### PR TITLE
chore: restore CODEOWNERS and synth ignore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,21 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-# The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/github-automation
+*     @googleapis/github-automation
+
+packages/auto-label/*                 @googleapis/github-automation @nicoleczhu @sofisl
+packages/blunderbuss/*                @googleapis/github-automation @kurtisvg
+packages/flakybot/*                   @googleapis/github-automation @tbp
+packages/conventional-commit-lint/*   @googleapis/github-automation @bcoe
+packages/do-not-merge/*               @googleapis/github-automation @tbp
+packages/failurechecker/*             @googleapis/github-automation @bcoe
+packages/generated-files-bot/*        @googleapis/github-automation @chingor13
+packages/header-checker-lint/*        @googleapis/github-automation @chingor13
+packages/label-sync/*                 @googleapis/github-automation @JustinBeckwith
+packages/merge-on-green/*             @googleapis/github-automation @sofisl
+packages/monitoring-system/*          @googleapis/github-automation @chingor13
+packages/release-please/*             @googleapis/github-automation @bcoe @chingor13
+packages/slo-stat-bot/*               @googleapis/github-automation @orthros
+packages/snippet-bot/*                @googleapis/github-automation @tmatsuo
+packages/sync-repo-settings/*         @googleapis/github-automation @JustinBeckwith
+packages/trusted-contribution/*       @googleapis/github-automation @crwilcox

--- a/synth.py
+++ b/synth.py
@@ -10,6 +10,7 @@ templates = common_templates.node_library()
 s.copy(templates, excludes=[
   '.eslintignore',
   '.eslintrc.json',
+  '.github/CODEOWNERS',
   '.github/release-please.yml',
   '.github/workflows/',
   '.github/publish.yml',


### PR DESCRIPTION
I messed this up in the recent CODEOWNERS rollout to the other regular repos