### PR TITLE
build: update environment variables rather than replacing

### DIFF
--- a/scripts/publish-function.sh
+++ b/scripts/publish-function.sh
@@ -48,7 +48,7 @@ gcloud functions deploy "${functionName}" \
   --trigger-http \
   --runtime "${functionRuntime}" \
   --region "${functionRegion}" \
-  --set-env-vars DRIFT_PRO_BUCKET="${bucket}",KEY_LOCATION="${keyLocation}",KEY_RING="${keyRing}",GCF_SHORT_FUNCTION_NAME="${functionName}",PROJECT_ID="${project}",GCF_LOCATION="${functionRegion}",PUPPETEER_SKIP_CHROMIUM_DOWNLOAD='1',WEBHOOK_TMP=tmp-webhook-payloads
+  --update-env-vars DRIFT_PRO_BUCKET="${bucket}",KEY_LOCATION="${keyLocation}",KEY_RING="${keyRing}",GCF_SHORT_FUNCTION_NAME="${functionName}",PROJECT_ID="${project}",GCF_LOCATION="${functionRegion}",PUPPETEER_SKIP_CHROMIUM_DOWNLOAD='1',WEBHOOK_TMP=tmp-webhook-payloads
 
 echo "Deploying Queue ${queueName}"
 


### PR DESCRIPTION
This change moves us towards updating environment variables, rather than replacing all environment variables.

The reason for this is that owl-bot has a couple special variables it sets:

* `APP_ID`: the ID of the GitHub app.
*  `TRIGGER`: the cloud build trigger.