### PR TITLE
fix: escape all the special characters in firestore ids

### DIFF
--- a/packages/owl-bot/src/database.ts
+++ b/packages/owl-bot/src/database.ts
@@ -27,7 +27,7 @@ interface UpdateLockPr {
  * strings into keys.  And use a format that can be decoded by decodeURIComponent().
  */
 export function encodeId(s: string): string {
-  return s.replace('%', '%25').replace('/', '%2F').replace('+', '%2B');
+  return s.replace(/%/g, '%25').replace(/\//g, '%2F').replace(/\+/g, '%2B');
 }
 
 export function decodeId(s: string): string {

--- a/packages/owl-bot/test/database.ts
+++ b/packages/owl-bot/test/database.ts
@@ -155,4 +155,11 @@ describe('encodeId', () => {
     assert.strictEqual(encoded, chars);
     assert.strictEqual(decodeId(encoded), chars);
   });
+
+  it('encodes repeated special chars', () => {
+    const chars = '/%+/%+/%+';
+    const encoded = encodeId(chars);
+    assert.strictEqual(encoded, '%2F%25%2B%2F%25%2B%2F%25%2B');
+    assert.strictEqual(decodeId(encoded), chars);
+  });
 });


### PR DESCRIPTION
the code was just escaping just the first instance of each special character