### PR TITLE
fix(owl-bot): fix two timing related bugs

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -151,7 +151,7 @@ export class GCFBootstrapper {
       this.probot = createProbot({overrides: cfg});
     }
 
-    this.probot.load(appFn);
+    await this.probot.load(appFn);
 
     return this.probot;
   }

--- a/packages/owl-bot/src/handlers.ts
+++ b/packages/owl-bot/src/handlers.ts
@@ -66,7 +66,7 @@ export async function onPostProcessorPublished(
         installation: configs.installationId,
       });
       // TODO(bcoe): switch updatedAt to date from PubSub payload:
-      createOnePullRequestForUpdatingLock(configsStore, octokit, repo, lock);
+      await createOnePullRequestForUpdatingLock(configsStore, octokit, repo, lock);
     }
   }
 }

--- a/packages/owl-bot/src/handlers.ts
+++ b/packages/owl-bot/src/handlers.ts
@@ -66,7 +66,12 @@ export async function onPostProcessorPublished(
         installation: configs.installationId,
       });
       // TODO(bcoe): switch updatedAt to date from PubSub payload:
-      await createOnePullRequestForUpdatingLock(configsStore, octokit, repo, lock);
+      await createOnePullRequestForUpdatingLock(
+        configsStore,
+        octokit,
+        repo,
+        lock
+      );
     }
   }
 }


### PR DESCRIPTION
There was no await during loading in gcf-utils, this meant that our async
load step would not have loaded routes yet, before requests are handled.

I also found a missing await in handlers, which could have lead to perf
issues
