### PR TITLE
chore(.github): upgrade CI to Go 1.16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.14'
+        go-version: '^1.16'
     - name: Install goimports
       run: go get golang.org/x/tools/cmd/goimports
     - name: Checkout code


### PR DESCRIPTION
Updates #1475.