### PR TITLE
fix(flakybot): use os.WalkDir to hopefully avoid lstat error

### DIFF
--- a/packages/flakybot/go.mod
+++ b/packages/flakybot/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/repo-automation-bots/packages/flakybot
 
-go 1.14
+go 1.16
 
 require (
 	cloud.google.com/go/pubsub v1.3.1


### PR DESCRIPTION
I'm hoping the optimization in Go 1.16 to call `lstat` less often will avoid the error in #1475. But, I'm not 100% as that was caused by a filesystem race condition.

I also added a test by faking out PubSub publishing.

Fixes #1475.