### PR TITLE
fix(owl-bot): set email/username and add to trusted contributors

### DIFF
--- a/packages/owl-bot/cloud-build/update-pr.yaml
+++ b/packages/owl-bot/cloud-build/update-pr.yaml
@@ -4,6 +4,19 @@ steps:
     args:
       - clone
       - https://github.com/${_PR_OWNER}/${_REPOSITORY}.git
+  # Populate global username, email for git:
+  - name: 'gcr.io/cloud-builders/git'
+    args:
+      - config
+      - --global
+      - user.email
+      - 'gcf-owl-bot[bot]@users.noreply.github.com'
+  - name: 'gcr.io/cloud-builders/git'
+    args:
+      - config
+      - --global
+      - user.name
+      - 'Owl Bot'
   - name: 'gcr.io/cloud-builders/git'
     args:
       - checkout
@@ -19,19 +32,7 @@ steps:
   # Run container listed in OwlBot.yaml:
   - name: ${_CONTAINER}
     dir: '${_REPOSITORY}'
-  # Populate global username, email, and credentials for git:
-  - name: 'gcr.io/cloud-builders/git'
-    args:
-      - config
-      - --global
-      - user.email
-      - 'gcf-owl-bot[bot]@users.noreply.github.com'
-  - name: 'gcr.io/cloud-builders/git'
-    args:
-      - config
-      - --global
-      - user.name
-      - 'Owl Bot'
+  # Populate credentials for push to GitHub:
   - name: 'bash'
     args:
       - '-eEuo'

--- a/packages/trusted-contribution/src/trusted-contribution.ts
+++ b/packages/trusted-contribution/src/trusted-contribution.ts
@@ -27,7 +27,6 @@ const DEFAULT_TRUSTED_CONTRIBUTORS = [
   'release-please[bot]',
   'gcf-merge-on-green[bot]',
   'yoshi-code-bot',
-  'gcf-owl-bot',
   'gcf-owl-bot[bot]',
 ];
 

--- a/packages/trusted-contribution/src/trusted-contribution.ts
+++ b/packages/trusted-contribution/src/trusted-contribution.ts
@@ -27,6 +27,8 @@ const DEFAULT_TRUSTED_CONTRIBUTORS = [
   'release-please[bot]',
   'gcf-merge-on-green[bot]',
   'yoshi-code-bot',
+  'gcf-owl-bot',
+  'gcf-owl-bot[bot]',
 ];
 
 function isTrustedContribution(


### PR DESCRIPTION
PRs made by OwlBot were erroring with:

```bash
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"
```

This moves username/email configuration earlier.

---

This PR also adds `gcf-owl-bot[bot]` to trusted contributors so that tests kick off.