### PR TITLE
fix: owl-bot doesn't currently have permission to search

### DIFF
--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -316,19 +316,6 @@ export async function copyExists(
   sourceCommitHash: string,
   logger = console
 ): Promise<boolean> {
-  const q = `repo:${destRepo}+${sourceCommitHash}`;
-  const foundCommits = await octokit.search.commits({q});
-  if (foundCommits.data.total_count > 0) {
-    logger.info(`Commit with ${sourceCommitHash} exists in ${destRepo}.`);
-    return true;
-  }
-  const found = await octokit.search.issuesAndPullRequests({q});
-  for (const item of found.data.items) {
-    logger.info(
-      `Issue or pull request ${item.number} with ${sourceCommitHash} exists in ${destRepo}.`
-    );
-    return true;
-  }
   // I observed octokit.search.issuesAndPullRequests() not finding recent, open
   // pull requests.  So enumerate them.
   const owner = destRepo.owner;


### PR DESCRIPTION
That's fine.  We enumerate the list of pull requests and issues and will still find the hash if it's there.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/repo-automation-bots/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
