### PR TITLE
fix(auto-label): never auto-detect label for docs or build

### DIFF
--- a/packages/auto-label/src/helper.ts
+++ b/packages/auto-label/src/helper.ts
@@ -81,12 +81,6 @@ export function autoDetectLabel(
     return undefined;
   }
 
-  // The Conventional Commits "docs:" and "build:" prefixes are far more common
-  // than the APIs. So, never label those with "api: docs" or "api: build".
-  if (title.startsWith('docs:') || title.startsWith('build:')) {
-    return undefined;
-  }
-
   // Regex to match the scope of a Conventional Commit message.
   const conv = /[^(]+\(([^)]+)\):/;
   const match = title.match(conv);
@@ -109,6 +103,12 @@ export function autoDetectLabel(
   firstPart = firstPart.split('_')[0]; // Before the underscore, if there is one.
   firstPart = firstPart.toLowerCase(); // Convert to lower case.
   firstPart = firstPart.replace(/\s/, ''); // Remove spaces.
+
+  // The Conventional Commits "docs" and "build" prefixes are far more common
+  // than the APIs. So, never label those with "api: docs" or "api: build".
+  if (firstPart === 'docs' || firstPart === 'build') {
+    return undefined;
+  }
 
   // Replace some known firstPart values with their API name.
   const commonConversions = new Map();

--- a/packages/auto-label/test/auto-label.ts
+++ b/packages/auto-label/test/auto-label.ts
@@ -427,25 +427,35 @@ describe('auto-label', () => {
         fixturesPath,
         './events/issue_opened_spanner'
       ));
-      payload['issue']['title'] = 'docs: they are awesome';
 
-      const ghRequests = nock('https://api.github.com')
-        .get(
-          '/repos/GoogleCloudPlatform/golang-samples/contents/.github%2Fauto-label.yaml'
-        )
-        .reply(200, config)
-        .get('/repos/GoogleCloudPlatform/golang-samples/issues/5/labels')
-        .reply(200, [
-          {
-            name: 'samples',
-          },
-        ]);
-      await probot.receive({
-        name: 'issues',
-        payload,
-        id: 'abc123',
-      });
-      ghRequests.done();
+      const titles = [
+        'docs: they are awesome',
+        'fix(docs): still awesome',
+        'build(foo): still never flake',
+        'ci(build): never flake',
+      ];
+
+      for (const title of titles) {
+        payload['issue']['title'] = title;
+
+        const ghRequests = nock('https://api.github.com')
+          .get(
+            '/repos/GoogleCloudPlatform/golang-samples/contents/.github%2Fauto-label.yaml'
+          )
+          .reply(200, config)
+          .get('/repos/GoogleCloudPlatform/golang-samples/issues/5/labels')
+          .reply(200, [
+            {
+              name: 'samples',
+            },
+          ]);
+        await probot.receive({
+          name: 'issues',
+          payload,
+          id: 'abc123',
+        });
+        ghRequests.done();
+      }
     });
   });
 


### PR DESCRIPTION
I tried to do this in #1062, but that missed some title formats.

Related to #1483, but fixes one reason people might need to disable the bot.