### PR TITLE
fix: bad Source-Link path in pull requests

### DIFF
--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -53,9 +53,11 @@ export function newCmd(logger = console): Cmd {
   return cmd;
 }
 
-// Composes a link to the source commit that triggered the copy.
-function sourceLinkFrom(sourceRepo: string, sourceCommitHash: string): string {
-  return `https://github.com/${sourceRepo}/commit/${sourceCommitHash}`;
+/**
+ * Composes a link to the source commit that triggered the copy.
+ */
+function sourceLinkFrom(sourceCommitHash: string): string {
+  return `https://github.com/googleapis/googleapis-gen/commit/${sourceCommitHash}`;
 }
 
 /**
@@ -92,7 +94,7 @@ export async function copyCodeAndCreatePullRequest(
   } catch (err) {
     logger.error(err);
     // Create a github issue.
-    const sourceLink = sourceLinkFrom(sourceRepo, sourceRepoCommitHash);
+    const sourceLink = sourceLinkFrom(sourceRepoCommitHash);
     const octokit = await octokitFactory.getShortLivedOctokit();
     const issue = await octokit.issues.create({
       owner,
@@ -230,7 +232,7 @@ export async function copyCode(
   let commitMsg = cmd('git log -1 --format=%s%n%n%b', {
     cwd: sourceDir,
   }).toString('utf8');
-  const sourceLink = sourceLinkFrom(sourceRepo, sourceCommitHash);
+  const sourceLink = sourceLinkFrom(sourceCommitHash);
   commitMsg += `Source-Link: ${sourceLink}\n`;
   fs.writeFileSync(commitMsgPath, commitMsg);
   cmd('git add -A', {cwd: destDir});

--- a/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
@@ -225,7 +225,7 @@ describe('scanGoogleapisGenAndCreatePullRequests', () => {
     assert.strictEqual(pull.base, 'main');
     assert.strictEqual(
       pull.body,
-      `Source-Link: https://github.com/${abcRepo}/commit/${abcCommits[1]}`
+      `Source-Link: https://github.com/googleapis/googleapis-gen/commit/${abcCommits[1]}`
     );
 
     // Confirm the pull request branch contains the new file.


### PR DESCRIPTION
Even though we clone googleapis/googleapis-gen to a local directory,
we always want the source linke to point to
 https://github.com/googleapis/googleapis-gen.

Fixes https://github.com/googleapis/repo-automation-bots/issues/1502
