### PR TITLE
fix(owlbot): address rate limit issues

### DIFF
--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -156,7 +156,7 @@ async function waitForBuild(
   id: string,
   client: CloudBuildClient
 ) {
-  for (let i = 0; i < 120; i++) {
+  for (let i = 0; i < 60; i++) {
     const [build] = await client.getBuild({projectId, id});
     if (build.status !== 'WORKING' && build.status !== 'QUEUED') {
       return build;
@@ -165,10 +165,10 @@ async function waitForBuild(
     await new Promise(resolve => {
       setTimeout(() => {
         return resolve(undefined);
-      }, 5000);
+      }, 10000);
     });
   }
-  throw Error(`timed out waiting for buuild ${id}`);
+  throw Error(`timed out waiting for build ${id}`);
 }
 
 export async function getHeadCommit(

--- a/packages/owl-bot/src/handlers.ts
+++ b/packages/owl-bot/src/handlers.ts
@@ -86,6 +86,11 @@ export async function onPostProcessorPublished(
         lock,
         configs
       );
+      // We were hitting GitHub's abuse detection algorithm,
+      // add a short sleep between creating PRs to help circumvent:
+      await new Promise((resolve) => {
+        setTimeout(resolve, 500);
+      });
     }
   }
 }

--- a/packages/owl-bot/src/handlers.ts
+++ b/packages/owl-bot/src/handlers.ts
@@ -88,7 +88,7 @@ export async function onPostProcessorPublished(
       );
       // We were hitting GitHub's abuse detection algorithm,
       // add a short sleep between creating PRs to help circumvent:
-      await new Promise((resolve) => {
+      await new Promise(resolve => {
         setTimeout(resolve, 500);
       });
     }

--- a/scripts/publish-function.sh
+++ b/scripts/publish-function.sh
@@ -61,4 +61,5 @@ gcloud tasks queues ${verb} "${queueName}" \
   --max-concurrent-dispatches="2048" \
   --max-attempts="100" \
   --max-retry-duration="43200s" \
-  --max-dispatches-per-second="500"
+  --max-dispatches-per-second="500" \
+  --min-backoff="5"


### PR DESCRIPTION
We bumped into a few rate limit issues when we bootstrapped OwlBot across dozens of repos the first time:

1. GitHub's abuse detection algorithm was triggered when opening PRs for updating all docker containers in sequence (I've added a delay to hopefully make this less likely).
2. We were hitting the Concurrent Get requests on Cloud Build (I've increased our polling interval to hopefully reduce this issue).
3. we were retrying almost immediately upon receiving an exception in Cloud Tasks, this lead to odd behavior where multiple jobs attempted to concurrently create the same PR, let's wait 5s making it less likely that this thundering herd happens.

---

Unsolved Problem:

* we're very close to the limit on Cloud Build for creating a maximum number of concurrent builds (we're allowed to queue 60 in a minute).
* perhaps less of an issue, we're hitting the 10 job concurrent job limit -- as I understand it the fact that jobs queue will protect us from this.