### PR TITLE
feat(sync-repo-settings): apply config after pushing to default branch

### DIFF
--- a/packages/sync-repo-settings/README.md
+++ b/packages/sync-repo-settings/README.md
@@ -49,4 +49,5 @@ permissionRules:
     permission: push
 ```
 
+Settings will be immediately applied after committing the config to the default branch.
 The bot is currently configured to run on a cron job, and updates settings 1am PST.

--- a/packages/sync-repo-settings/src/bot.ts
+++ b/packages/sync-repo-settings/src/bot.ts
@@ -99,17 +99,16 @@ export function handler(app: Probot) {
           head_sha: context.payload.pull_request.head.sha,
           conclusion: 'success' as Conclusion,
           output: {
-            title: 'Successful sync-repo-settings.yaml check',
-            summary: 'sync-repo-settings.yaml matches the required schema',
+            title: `Successful ${configFileName} check`,
+            summary: `${configFileName} matches the required schema`,
             text: 'Success',
           },
         });
         if (!isValid) {
           (checkParams.conclusion = 'failure'),
             (checkParams.output = {
-              title: 'Invalid sync-repo-settings.yaml schema 😱',
-              summary:
-                'sync-repo-settings.yaml does not match the required schema 😱',
+              title: `Invalid ${configFileName} schema 😱`,
+              summary: `${configFileName} does not match the required schema 😱`,
               text: errorText,
             });
         }
@@ -142,7 +141,7 @@ export function handler(app: Probot) {
         for (const list of fileChangedLists) {
           if (commit[list]) {
             for (const file of commit[list]) {
-              if (file?.includes('sync-repo-settings.yaml')) {
+              if (file?.includes(configFileName)) {
                 return true;
               }
             }
@@ -193,7 +192,7 @@ export function handler(app: Probot) {
 async function getConfig(context: Context) {
   let config!: RepoConfig | null;
   try {
-    config = await context.config<RepoConfig>('sync-repo-settings.yaml');
+    config = await context.config<RepoConfig>(configFileName);
   } catch (err) {
     err.message = `Error reading configuration: ${err.message}`;
     logger.error(err);

--- a/packages/sync-repo-settings/test/test.bot.ts
+++ b/packages/sync-repo-settings/test/test.bot.ts
@@ -17,7 +17,7 @@ import nock from 'nock';
 // eslint-disable-next-line node/no-extraneous-import
 import {Probot, createProbot, ProbotOctokit} from 'probot';
 import {promises as fs} from 'fs';
-import {handler} from '../src/bot';
+import {handler, configFileName} from '../src/bot';
 import assert from 'assert';
 import * as sinon from 'sinon';
 import {logger} from 'gcf-utils';
@@ -41,9 +41,9 @@ function nockUpdateTeamMembership(team: string, org: string, repo: string) {
 
 function nockConfig404(org = 'googleapis', repo = 'api-common-java') {
   return nock('https://api.github.com')
-    .get(`/repos/${org}/${repo}/contents/.github%2Fsync-repo-settings.yaml`)
+    .get(`/repos/${org}/${repo}/contents/.github%2F${configFileName}`)
     .reply(404)
-    .get(`/repos/${org}/.github/contents/.github%2Fsync-repo-settings.yaml`)
+    .get(`/repos/${org}/.github/contents/.github%2F${configFileName}`)
     .reply(404);
 }
 
@@ -231,7 +231,7 @@ describe('Sync repo settings', () => {
     const content = await fs.readFile('./test/fixtures/localConfig.yaml');
     const scopes = [
       nock('https://api.github.com')
-        .get(`/repos/${org}/${repo}/contents/.github%2Fsync-repo-settings.yaml`)
+        .get(`/repos/${org}/${repo}/contents/.github%2F${configFileName}`)
         .reply(200, content),
       nockUpdateRepoSettings(repo, false, true),
       nockUpdateBranchProtection(repo, ['check1', 'check2'], false, true),
@@ -251,7 +251,7 @@ describe('Sync repo settings', () => {
     );
     const scopes = [
       nock('https://api.github.com')
-        .get(`/repos/${org}/${repo}/contents/.github%2Fsync-repo-settings.yaml`)
+        .get(`/repos/${org}/${repo}/contents/.github%2F${configFileName}`)
         .reply(200, content),
       nockUpdateRepoSettings(repo, false, true),
       nockUpdateTeamMembership('team1', org, repo),
@@ -277,7 +277,7 @@ describe('Sync repo settings', () => {
         .reply(200, [
           {
             sha: fileSha,
-            filename: '.github/sync-repo-settings.yaml',
+            filename: `.github/${configFileName}`,
             status: 'added',
           },
         ]),
@@ -331,7 +331,7 @@ describe('Sync repo settings', () => {
         .reply(200, [
           {
             sha: fileSha,
-            filename: '.github/sync-repo-settings.yaml',
+            filename: `.github/${configFileName}`,
             status: 'added',
           },
         ]),
@@ -386,7 +386,7 @@ describe('Sync repo settings', () => {
         .reply(200, [
           {
             sha: fileSha,
-            filename: '.github/sync-repo-settings.yaml',
+            filename: `.github/${configFileName}`,
             status: 'added',
           },
         ]),
@@ -496,7 +496,7 @@ describe('Sync repo settings', () => {
         },
         commits: [
           {
-            added: ['.github/sync-repo-settings.yaml'],
+            added: [`.github/${configFileName}`],
           },
         ],
       },


### PR DESCRIPTION
Fixes #1517.  This uses the `push` event webhook, looks at the commits in the push, and then runs the sync if the settings file was among the list of changed files. 