### PR TITLE
fix(release-brancher): fix build configuration and set private to false

### DIFF
--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -11,7 +11,7 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "nodejs-secret-manager/.kokoro/trampoline_v2.sh"
+build_file: "repo-automation-bots/.kokoro/trampoline_v2.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -20,5 +20,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/nodejs-secret-manager/.kokoro/test.sh"
+    value: "github/repo-automation-bots/.kokoro/test.sh"
 }

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -11,7 +11,7 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "repo-automation-bots/.kokoro/trampoline.sh"
+build_file: "nodejs-secret-manager/.kokoro/trampoline_v2.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -20,5 +20,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/repo-automation-bots/.kokoro/test.sh"
+    value: "github/nodejs-secret-manager/.kokoro/test.sh"
 }

--- a/.kokoro/publish.sh
+++ b/.kokoro/publish.sh
@@ -30,7 +30,7 @@ python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /
 
 cd $(dirname $0)/..
 
-NPM_TOKEN=$(cat "${KOKORO_KEYSTORE_DIR}/secret_manager/repo_automation_bots_npm_publish_token")
+NPM_TOKEN=$(cat "${KOKORO_GFILE_DIR}/secret_manager/repo_automation_bots_npm_publish_token")
 printf "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}\nregistry=https://wombat-dressing-room.appspot.com" > ~/.npmrc
 
 npx mono-repo-publish --pr-url="${AUTORELEASE_PR}"

--- a/.kokoro/publish.sh
+++ b/.kokoro/publish.sh
@@ -33,4 +33,4 @@ cd $(dirname $0)/..
 NPM_TOKEN=$(cat "${KOKORO_GFILE_DIR}/secret_manager/repo_automation_bots_npm_publish_token")
 printf "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}\nregistry=https://wombat-dressing-room.appspot.com" > ~/.npmrc
 
-npx mono-repo-publish --pr-url="${AUTORELEASE_PR}"
+npx @google-cloud/mono-repo-publish --pr-url="${AUTORELEASE_PR}"

--- a/.kokoro/release/publish.cfg
+++ b/.kokoro/release/publish.cfg
@@ -53,7 +53,7 @@ env_vars: {
 }
 
 # Use the trampoline script to run in docker.
-build_file: "repo-automation-bots/.kokoro/trampoline.sh"
+build_file: "nodejs-secret-manager/.kokoro/trampoline_v2.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {

--- a/.kokoro/release/publish.cfg
+++ b/.kokoro/release/publish.cfg
@@ -47,15 +47,6 @@ before_action {
   }
 }
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "repo-automation-bots-npm-token"
-    }
-  }
-}
-
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "repo_automation_bots_npm_publish_token,releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"

--- a/.kokoro/release/publish.cfg
+++ b/.kokoro/release/publish.cfg
@@ -53,7 +53,7 @@ env_vars: {
 }
 
 # Use the trampoline script to run in docker.
-build_file: "nodejs-secret-manager/.kokoro/trampoline_v2.sh"
+build_file: "repo-automation-bots/.kokoro/trampoline_v2.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {

--- a/packages/release-brancher/package.json
+++ b/packages/release-brancher/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "Cut release branches",
   "bin": "./build/src/bin/release-brancher.js",
-  "private": true,
   "author": "Google LLC.",
   "license": "Apache-2.0",
   "repository": "https://github.com/googleapis/repo-automation-bots.git",


### PR DESCRIPTION
This token was causing a build failure, and does not appear to be used.