### PR TITLE
build: fix trigger branch pattern to be more restrictive

### DIFF
--- a/scripts/sync-triggers.sh
+++ b/scripts/sync-triggers.sh
@@ -64,7 +64,7 @@ do
     --description="Deploy ${botName}" \
     --included-files="${directory}/**" \
     --name="${triggerName}" \
-    --branch-pattern="${branch}" \
+    --branch-pattern="^${branch}$" \
     --build-config="${config}" \
     --substitutions="${substitutions},_DIRECTORY=${directory}"
 


### PR DESCRIPTION
Will need to delete the existing deploy triggers and let them be recreated.

Fixes #1556
