### PR TITLE
fix(policy): exit gracefully if autofix fails

### DIFF
--- a/packages/policy/src/bot.ts
+++ b/packages/policy/src/bot.ts
@@ -42,6 +42,14 @@ export function policyBot(app: Probot) {
     }
     const result = await policy.checkRepoPolicy(repoMetadata);
     await exportToBigQuery(result);
-    await submitFixes(result, context.octokit);
+
+    // specifically wrap this in a try/catch to avoid retries if the fix
+    // causes any errors.  Otherwise, the entire function is retried, and the
+    // result is recorded twice.
+    try {
+      await submitFixes(result, context.octokit);
+    } catch (e) {
+      logger.error(e);
+    }
   });
 }


### PR DESCRIPTION
If the call to `submitFixes` failed, it threw for the whole loop, and put the task back into the retry queue.   This led to records getting written into BigQuery every time it retried, and muddied up the logs something fierce.  This will now log the error, and move on if autofix fails.