### PR TITLE
fix(policy): use uuid for branch names

### DIFF
--- a/packages/policy/package-lock.json
+++ b/packages/policy/package-lock.json
@@ -470,7 +470,17 @@
     "@octokit/types": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.12.2.tgz",
-      "integrity": "sha512-kCkiN8scbCmSq+gwdJV0iLgHc0O/GTPY1/cffo9kECu1MvatLPh9E+qFhfRIktKfHEA6ZYvv6S1B4Wnv3bi3pA=="
+      "integrity": "sha512-kCkiN8scbCmSq+gwdJV0iLgHc0O/GTPY1/cffo9kECu1MvatLPh9E+qFhfRIktKfHEA6ZYvv6S1B4Wnv3bi3pA==",
+      "requires": {
+        "@octokit/openapi-types": "^5.3.2"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-5.3.2.tgz",
+          "integrity": "sha512-NxF1yfYOUO92rCx3dwvA2onF30Vdlg7YUkMVXkeptqpzA3tRLplThhFleV/UKWFgh7rpKu1yYRbvNDUtzSopKA=="
+        }
+      }
     },
     "@octokit/webhooks": {
       "version": "7.21.0",

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -33,13 +33,15 @@
     "@octokit/rest": "^18.3.5",
     "code-suggester": "^1.9.2",
     "gaxios": "^4.2.0",
-    "gcf-utils": "^7.0.0"
+    "gcf-utils": "^7.0.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@octokit/openapi-types": "^6.0.0",
     "@types/mocha": "^8.0.0",
     "@types/node": "^12.6.1",
     "@types/sinon": "^9.0.11",
+    "@types/uuid": "^8.3.0",
     "c8": "^7.3.5",
     "cross-env": "^7.0.0",
     "gts": "^3.0.0",

--- a/packages/policy/src/changer.ts
+++ b/packages/policy/src/changer.ts
@@ -15,6 +15,7 @@
 import {Octokit} from '@octokit/rest';
 import {createPullRequest, Changes} from 'code-suggester';
 import {request} from 'gaxios';
+import {v4 as uuid} from 'uuid';
 import {PolicyResult} from './policy';
 
 export const cocUrl =
@@ -77,6 +78,7 @@ export async function addCodeOfConduct(
     upstreamOwner: owner,
     upstreamRepo: repo,
     fork: false,
+    branch: `policy-bot-${uuid()}`,
   });
 }
 


### PR DESCRIPTION
Otherwise we keep stomping on the same branch, and ideally we will use this code for other PRs as well.  Also, it was causing failures in the case that the branch name already existed, but was behind the default branch 