### PR TITLE
fix: don't demand a source-repo-commit-hash argument

### DIFF
--- a/packages/owl-bot/src/bin/commands/copy-code.ts
+++ b/packages/owl-bot/src/bin/commands/copy-code.ts
@@ -39,6 +39,7 @@ export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
         describe:
           'The commit hash of the source repo from which to copy files.',
         type: 'string',
+        demand: false,
         default: '',
       })
       .option('dest', {


### PR DESCRIPTION
I thought giving it a default would be sufficient to avoid demanding it on the command line.  I was wrong.
