### PR TITLE
fix(failurechecker): check that PR returned has labels

### DIFF
--- a/packages/failurechecker/src/failurechecker.ts
+++ b/packages/failurechecker/src/failurechecker.ts
@@ -19,6 +19,7 @@
 // eslint-disable-next-line node/no-extraneous-import
 import {Probot, ProbotOctokit} from 'probot';
 import {logger} from 'gcf-utils';
+import { SlowBuffer } from 'node:buffer';
 
 type OctokitType = InstanceType<typeof ProbotOctokit>;
 
@@ -103,8 +104,14 @@ export function failureChecker(app: Probot) {
           ).data;
           if (
             pr.merged_at &&
+            pr.labels.some(l => labels.includes(l.name!)) &&
             !pr.labels.some(l => l.name === SUCCESSFUL_PUBLISH_LABEL)
           ) {
+            logger.info(
+              `found failure for ${owner}/${repo} pr = ${
+                pr.number
+              } labels = ${labels.join(',')}`
+            );
             failed.push(pr.number);
           }
         }

--- a/packages/failurechecker/src/failurechecker.ts
+++ b/packages/failurechecker/src/failurechecker.ts
@@ -19,7 +19,6 @@
 // eslint-disable-next-line node/no-extraneous-import
 import {Probot, ProbotOctokit} from 'probot';
 import {logger} from 'gcf-utils';
-import { SlowBuffer } from 'node:buffer';
 
 type OctokitType = InstanceType<typeof ProbotOctokit>;
 


### PR DESCRIPTION
I'm not 100% how this could be possible, but I'm hoping this protects against behavior seen here:

https://github.com/googleapis/google-api-go-client/issues/958