### PR TITLE
build(mono-repo-publish): update manifest to reflect currently published version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "packages/gcf-utils": "7.1.4",
-  "packages/release-brancher": "1.0.3"
+  "packages/release-brancher": "1.0.3",
+  "packages/mono-repo-publish": "1.0.1"
 }


### PR DESCRIPTION
Add the current release to the manifest for mono-repo-publish.