### PR TITLE
fix(mono-repo-publish): links should point to repo-automation-bots

### DIFF
--- a/packages/mono-repo-publish/package.json
+++ b/packages/mono-repo-publish/package.json
@@ -14,13 +14,11 @@
     "src",
     "bin"
   ],
-  "repository": "sofisl/mono-repo-publish",
+  "repository": "https://github.com/googleapis/repo-automation-bots.git",
+  "homepage": "https://github.com/googleapis/repo-automation-bots",
+  "bugs": "https://github.com/googleapis/repo-automation-bots/issues",
   "author": "Google LLC",
   "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/sofisl/mono-repo-publish/issues"
-  },
-  "homepage": "https://github.com/sofisl/mono-repo-publish#readme",
   "devDependencies": {
     "c8": "^7.4.0",
     "mocha": "^8.2.1",


### PR DESCRIPTION
Missed migrating links over, which caused a publication error:

```
npm ERR!   bcoe cannot push repo https://github.com/sofisl/mono-repo-publish. push permission required to publish.
```