### PR TITLE
fix: do not trigger on the missing releases for 'simple' release type

### DIFF
--- a/packages/failurechecker/src/failurechecker.ts
+++ b/packages/failurechecker/src/failurechecker.ts
@@ -24,7 +24,7 @@ type OctokitType = InstanceType<typeof ProbotOctokit>;
 
 // labels indicative of the fact that a release has not completed yet.
 const RELEASE_LABELS = ['autorelease: pending', 'autorelease: failed'];
-const RELEASE_TYPE_NO_PUBLISH = ['go-yoshi'];
+const RELEASE_TYPE_NO_PUBLISH = ['go-yoshi', 'simple'];
 const SUCCESSFUL_PUBLISH_LABEL = 'autorelease: published';
 
 // We open an issue that a release has failed if it's been longer than 3


### PR DESCRIPTION
`simple` release type only updates `version.txt` and does not do anything else. Skip the check for this type.
