### PR TITLE
feat(owlbot): link to cloud build job from post processor

### DIFF
--- a/packages/owl-bot/src/bin/commands/trigger-build.ts
+++ b/packages/owl-bot/src/bin/commands/trigger-build.ts
@@ -111,6 +111,7 @@ export const triggerBuildCommand: yargs.CommandModule<{}, Args> = {
         text: buildStatus.text,
         summary: buildStatus.summary,
         conclusion: buildStatus.conclusion,
+        detailsURL: buildStatus.detailsURL,
         title: `🦉 OwlBot - ${buildStatus.summary}`,
       },
       octokit

--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -142,7 +142,7 @@ export async function triggerPostProcessBuild(
       conclusion,
       summary,
       text,
-      detailsURL: detailsUrl(buildId, project)
+      detailsURL: detailsUrl(buildId, project),
     };
   } catch (err) {
     logger.error(err);

--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -115,12 +115,12 @@ export async function triggerPostProcessBuild(
       },
     },
   });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const buildId: string = (resp as any).metadata.build.id;
   try {
     // TODO(bcoe): work with fenster@ to figure out why awaiting a long
     // running operation does not behave as expected:
     // const [build] = await resp.promise();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const build = await waitForBuild(project, buildId, cb);
     if (!build.steps) throw Error('trigger contained no steps');
     const successMessage = `successfully ran ${build.steps.length} steps 🎉!`;

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -138,6 +138,7 @@ export = (privateKey: string | undefined, app: Probot, db?: Db) => {
           summary: buildStatus.summary,
           conclusion: buildStatus.conclusion,
           title: `🦉 OwlBot - ${buildStatus.summary}`,
+          detailsURL: buildStatus.detailsURL,
         },
         context.octokit
       );

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -122,6 +122,7 @@ describe('owlBot', () => {
           text: 'the text for check',
           summary: 'summary for check',
           conclusion: 'success',
+          detailsURL: 'http://www.example.com',
         });
       const hasOwlBotLoopStub = sandbox
         .stub(core, 'hasOwlBotLoop')
@@ -214,6 +215,7 @@ describe('owlBot', () => {
           text: 'the text for check',
           summary: 'summary for check',
           conclusion: 'success',
+          detailsURL: 'http://www.example.com',
         });
       const hasOwlBotLoopStub = sandbox
         .stub(core, 'hasOwlBotLoop')


### PR DESCRIPTION
Include a details URL that links to the Cloud Build job, so that it's easier for folks in DPE to debug their builds.