### PR TITLE
feat(sync-repo-settings): support multiple branch protection rules

### DIFF
--- a/packages/sync-repo-settings/src/sync-repo-settings.ts
+++ b/packages/sync-repo-settings/src/sync-repo-settings.ts
@@ -138,28 +138,24 @@ export class SyncRepoSettings {
     if (!ignored && config) {
       jobs.push(this.updateRepoOptions(repo, config));
       if (config.branchProtectionRules) {
-        jobs.push(
-          this.updateMasterBranchProtection(repo, config.branchProtectionRules)
-        );
+        config.branchProtectionRules.forEach(rule => {
+          jobs.push(this.updateBranchProtection(repo, rule));
+        });
       }
     }
     await Promise.all(jobs);
   }
 
   /**
-   * Enable master branch protection, and required status checks
-   * @param repos List of repos to iterate.
+   * Enable branch protection, and required status checks
+   * @param repo Owner/Repo to update
+   * @param rule The branch protection rules
    */
-  async updateMasterBranchProtection(
-    repo: string,
-    rules: BranchProtectionRule[]
-  ) {
+  async updateBranchProtection(repo: string, rule: BranchProtectionRule) {
     const logger = this.logger;
     logger.info(`Updating master branch protection for ${repo}`);
     const [owner, name] = repo.split('/');
 
-    // TODO: add support for mutiple rules
-    let rule = rules[0];
     logger.debug('Rules before applying defaults:');
     logger.debug(rule);
 
@@ -191,14 +187,14 @@ export class SyncRepoSettings {
           accept: 'application/vnd.github.luke-cage-preview+json',
         },
       });
-      logger.info(`Success updating master branch protection for ${repo}`);
+      logger.info(`Success updating branch protection for ${repo}:${rule.pattern}`);
     } catch (err) {
       if (err.status === 401) {
         logger.warn(
-          `updateMasterBranchProtection: warning received ${err.status} updating ${owner}/${name}`
+          `updateBranchProtection: warning received ${err.status} updating ${owner}/${name}`
         );
       } else {
-        err.message = `updateMasterBranchProtection: error received ${err.status} updating ${owner}/${name}\n\n${err.message}`;
+        err.message = `updateBranchProtection: error received ${err.status} updating ${owner}/${name}\n\n${err.message}`;
         logger.error(err);
         return;
       }

--- a/packages/sync-repo-settings/test/fixtures/multipleBranches.yaml
+++ b/packages/sync-repo-settings/test/fixtures/multipleBranches.yaml
@@ -1,0 +1,14 @@
+rebaseMergeAllowed: false
+branchProtectionRules:
+- requiresCodeOwnerReviews: true
+  requiredStatusCheckContexts:
+    - check1
+    - check2
+- pattern: feature-branch
+  requiresCodeOwnerReviews: true
+  requiredStatusCheckContexts:
+    - check1
+    - check2
+permissionRules:
+  - team: team1
+    permission: push

--- a/packages/sync-repo-settings/test/sync-repo-settings.ts
+++ b/packages/sync-repo-settings/test/sync-repo-settings.ts
@@ -1,0 +1,95 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, beforeEach, afterEach} from 'mocha';
+import nock from 'nock';
+import * as sinon from 'sinon';
+import {SyncRepoSettings} from '../src/sync-repo-settings';
+import {Octokit} from '@octokit/rest';
+import {logger} from 'gcf-utils';
+import {RepoConfig} from '../src/types';
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import * as yaml from 'js-yaml';
+import assert from 'assert';
+
+nock.disableNetConnect();
+
+const sandbox = sinon.createSandbox();
+
+function loadConfig(fixture: string): RepoConfig {
+  const content = readFileSync(resolve('./test/fixtures', fixture), 'utf8');
+  return yaml.load(content) as RepoConfig;
+}
+
+describe('SyncRepoSettings', () => {
+  let runner: SyncRepoSettings;
+  let octokit: Octokit;
+
+  beforeEach(() => {
+    octokit = new Octokit({
+      auth: 'faketoken',
+    });
+    sandbox.stub(logger, 'error').throwsArg(0);
+    sandbox.stub(logger, 'info');
+    sandbox.stub(logger, 'debug');
+    runner = new SyncRepoSettings(octokit, logger);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    nock.cleanAll();
+  });
+
+  it('should fill in default values', async () => {
+    const updateRepo = sandbox.stub(octokit.repos, 'update');
+    const updateBranch = sandbox.stub(octokit.repos, 'updateBranchProtection');
+    const updateTeams = sandbox.stub(
+      octokit.teams,
+      'addOrUpdateRepoPermissionsInOrg'
+    );
+    const config = loadConfig('localConfig.yaml');
+    await runner.syncRepoSettings({
+      repo: 'test-owner/test-repo',
+      config: config,
+    });
+    sinon.assert.calledOnce(updateRepo);
+    sinon.assert.calledOnce(updateBranch);
+    sinon.assert.calledThrice(updateTeams);
+
+    // grab first arg of first call
+    const branchProtection = updateBranch.args[0][0];
+
+    // ensure we set a default value not set in the yaml
+    assert.equal(branchProtection?.branch, 'master');
+    assert.ok(branchProtection?.enforce_admins);
+  });
+
+  it('should handle multiple branches', async () => {
+    const updateRepo = sandbox.stub(octokit.repos, 'update');
+    const updateBranch = sandbox.stub(octokit.repos, 'updateBranchProtection');
+    const updateTeams = sandbox.stub(
+      octokit.teams,
+      'addOrUpdateRepoPermissionsInOrg'
+    );
+    const config = loadConfig('multipleBranches.yaml');
+    await runner.syncRepoSettings({
+      repo: 'test-owner/test-repo',
+      config: config,
+    });
+    sinon.assert.calledOnce(updateRepo);
+    sinon.assert.calledTwice(updateBranch);
+    sinon.assert.calledThrice(updateTeams);
+  });
+});


### PR DESCRIPTION
Ran into this while testing multiple release branches using the release-brancher script (sync-repo-settings was not updating rules for other branches).
