### PR TITLE
feat(label-sync): added label for end of life

### DIFF
--- a/packages/label-sync/src/labels.json
+++ b/packages/label-sync/src/labels.json
@@ -6,6 +6,11 @@
       "color": "00ff00"
     },
     {
+      "name": "eol",
+      "description": "End of life. Deprecating support for a previous version.",
+      "color": "c9abb2"
+    },
+    {
       "name": "status: blocked",
       "description": "Resolving the issue is dependent on other work.",
       "color": "f9d0c4"


### PR DESCRIPTION
In the short term, to be applied to PRs opened by renovate-bot in which dependencies require Node 12. 