### PR TITLE
feat: update bazel query to include rules instead of tar.gz output files

### DIFF
--- a/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
+++ b/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
@@ -22,7 +22,7 @@
 # Optional arguments.
 #
 # BUILD_TARGETS: Build targets to rebuild.  Example: 
-#   //google/cloud/vision/v1:vision-v1-nodejs.tar.gz
+#   //google/cloud/vision/v1:vision-v1-nodejs
 #
 # BAZEL_FLAGS: additional flags to pass to 'bazel query' and 'bazel build'.
 # Useful for setting a remote cache, coping with different versions of bazel, etc.
@@ -71,8 +71,8 @@ for (( idx=${#ungenerated_shas[@]}-1 ; idx>=0 ; idx-- )) ; do
     # Choose build targets.
     if [[ -z "$BUILD_TARGETS" ]] ; then
         targets=$(cd "$GOOGLEAPIS" \
-        && bazel query $BAZEL_FLAGS 'filter("-(go|csharp|java|php|ruby|nodejs|py)\.tar\.gz$", kind("generated file", //...:*))' \
-        | grep -v -E ":(proto|grpc|gapic)-.*-java\.tar\.gz$")
+        && bazel query $BAZEL_FLAGS  'filter("-(go|csharp|java|php|ruby|nodejs|py)$", kind("rule", //...:*))' \
+        | grep -v -E ":(proto|grpc|gapic)-.*-java$")
     else
         targets="$BUILD_TARGETS"
     fi
@@ -102,7 +102,7 @@ for (( idx=${#ungenerated_shas[@]}-1 ; idx>=0 ; idx-- )) ; do
     failed_targets=()
     for target in $targets ; do
         let target_count++
-        tar_gz=$(echo "${target:2}" | tr ":" "/")
+        tar_gz=$(echo "${target:2}.tar.gz" | tr ":" "/")
         # Create the parent directory if it doesn't already exist.
         parent_dir=$(dirname $tar_gz)
         target_dir="$GOOGLEAPIS_GEN/$parent_dir"

--- a/packages/bazel-bot/test-generate-googleapis-gen.sh
+++ b/packages/bazel-bot/test-generate-googleapis-gen.sh
@@ -66,8 +66,8 @@ git -C googleapis-gen checkout -b other
 # Test!
 export GOOGLEAPIS_GEN=`realpath googleapis-gen-clone`
 export INSTALL_CREDENTIALS="echo 'Pretending to install credentials...''"
-export BUILD_TARGETS="//google/cloud/vision/v1:google-cloud-vision-v1-csharp //google/bogus:api"
-export FETCH_TARGETS="//google/cloud/vision/v1:google-cloud-vision-v1-csharp"
+export BUILD_TARGETS="//google/cloud/vision/v1:vision-v1-nodejs //google/bogus:api"
+export FETCH_TARGETS="//google/cloud/vision/v1:vision-v1-nodejs"
 bash -x "$generate_googleapis_gen"
 
 # Display the state of googleapis-gen

--- a/packages/bazel-bot/test-generate-googleapis-gen.sh
+++ b/packages/bazel-bot/test-generate-googleapis-gen.sh
@@ -66,8 +66,8 @@ git -C googleapis-gen checkout -b other
 # Test!
 export GOOGLEAPIS_GEN=`realpath googleapis-gen-clone`
 export INSTALL_CREDENTIALS="echo 'Pretending to install credentials...''"
-export BUILD_TARGETS="//google/cloud/vision/v1:vision-v1-nodejs.tar.gz //google/bogus:api.tar.gz"
-export FETCH_TARGETS="//google/cloud/vision/v1:vision-v1-nodejs.tar.gz"
+export BUILD_TARGETS="//google/cloud/vision/v1:google-cloud-vision-v1-csharp //google/bogus:api"
+export FETCH_TARGETS="//google/cloud/vision/v1:google-cloud-vision-v1-csharp"
 bash -x "$generate_googleapis_gen"
 
 # Display the state of googleapis-gen


### PR DESCRIPTION
- updates bazel query that creates the list of the build targets to include rules instead of tar.gz output files
- updates script docs
- updates test with new targets

see https://github.com/googleapis/repo-automation-bots/issues/1338