### PR TITLE
fix(merge-on-green): ignore 404 when removing a label

### DIFF
--- a/packages/merge-on-green/src/merge-on-green.ts
+++ b/packages/merge-on-green/src/merge-on-green.ts
@@ -150,12 +150,19 @@ handler.cleanUpPullRequest = async function cleanUpPullRequest(
   reactionId: number,
   github: GitHubType
 ) {
-  await github.issues.removeLabel({
-    owner,
-    repo,
-    issue_number: prNumber,
-    name: label,
-  });
+  try {
+    await github.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: prNumber,
+      name: label,
+    });
+  } catch (err) {
+    // Ignoring 404 errors.
+    if (err.status !== 404) {
+      throw err;
+    }
+  }
   await github.reactions.deleteForIssue({
     owner,
     repo,


### PR DESCRIPTION
fixes #1638
