### PR TITLE
feat(auto-label): support dashes and more prefixes

### DIFF
--- a/packages/auto-label/src/helper.ts
+++ b/packages/auto-label/src/helper.ts
@@ -91,7 +91,12 @@ export function autoDetectLabel(
   // Remove common prefixes. For example,
   // https://github.com/GoogleCloudPlatform/java-docs-samples/issues/3578 and
   // https://github.com/GoogleCloudPlatform/python-docs-samples/issues/5657.
-  const trimPrefixes = ['com.example.', 'com.google.', 'snippets.', 'data-science-onramp.'];
+  const trimPrefixes = [
+    'com.example.',
+    'com.google.',
+    'snippets.',
+    'data-science-onramp.',
+  ];
   for (const prefix of trimPrefixes) {
     if (firstPart.startsWith(prefix)) {
       firstPart = firstPart.slice(prefix.length);

--- a/packages/auto-label/src/helper.ts
+++ b/packages/auto-label/src/helper.ts
@@ -89,8 +89,9 @@ export function autoDetectLabel(
   let firstPart = match ? match[1] : title;
 
   // Remove common prefixes. For example,
-  // https://github.com/GoogleCloudPlatform/java-docs-samples/issues/3578.
-  const trimPrefixes = ['com.example.', 'com.google.', 'snippets.'];
+  // https://github.com/GoogleCloudPlatform/java-docs-samples/issues/3578 and
+  // https://github.com/GoogleCloudPlatform/python-docs-samples/issues/5657.
+  const trimPrefixes = ['com.example.', 'com.google.', 'snippets.', 'data-science-onramp.'];
   for (const prefix of trimPrefixes) {
     if (firstPart.startsWith(prefix)) {
       firstPart = firstPart.slice(prefix.length);
@@ -104,6 +105,7 @@ export function autoDetectLabel(
   firstPart = firstPart.split('_')[0]; // Before the underscore, if there is one.
   firstPart = firstPart.toLowerCase(); // Convert to lower case.
   firstPart = firstPart.replace(/\s/, ''); // Remove spaces.
+  firstPart = firstPart.replace('-', ''); // Remove dashes.
 
   // The Conventional Commits "docs" and "build" prefixes are far more common
   // than the APIs. So, never label those with "api: docs" or "api: build".

--- a/packages/auto-label/test/auto-label.ts
+++ b/packages/auto-label/test/auto-label.ts
@@ -841,6 +841,7 @@ describe('auto-label', () => {
         {title: 'com.google.spanner.helper: ignored', want: 'api: spanner'},
         {title: 'fix(snippets.spanner.helper): ignored', want: 'api: spanner'},
         {title: 'snippets.video: ignored', want: 'api: videointelligence'},
+        {title: 'data-science-onramp.video-intelligence.ignored: ignored', want: 'api: videointelligence'},
         {title: 'unknown: ignored', want: undefined},
         {title: 'spanner with no separator', want: undefined},
         {title: 'fix(unknown): ignored', want: undefined},

--- a/packages/auto-label/test/auto-label.ts
+++ b/packages/auto-label/test/auto-label.ts
@@ -841,7 +841,10 @@ describe('auto-label', () => {
         {title: 'com.google.spanner.helper: ignored', want: 'api: spanner'},
         {title: 'fix(snippets.spanner.helper): ignored', want: 'api: spanner'},
         {title: 'snippets.video: ignored', want: 'api: videointelligence'},
-        {title: 'data-science-onramp.video-intelligence.ignored: ignored', want: 'api: videointelligence'},
+        {
+          title: 'data-science-onramp.video-intelligence.ignored: ignored',
+          want: 'api: videointelligence',
+        },
         {title: 'unknown: ignored', want: undefined},
         {title: 'spanner with no separator', want: undefined},
         {title: 'fix(unknown): ignored', want: undefined},


### PR DESCRIPTION
This removes another known prefix from titles (see https://github.com/GoogleCloudPlatform/python-docs-samples/issues/5657). Alternatively, we could build fancy auto-detect logic, but that would be much more complex. So, I kept it simple for now.

Fixes #1649.