### PR TITLE
fix(sync-repo-settings): remove local ignore and override configs

### DIFF
--- a/packages/sync-repo-settings/src/required-checks.json
+++ b/packages/sync-repo-settings/src/required-checks.json
@@ -65,26 +65,6 @@
         "team": "python-samples-owners",
         "permission": "push"
       }
-    ],
-    "repoOverrides": [
-      {
-        "repo": "googleapis/python-bigtable",
-        "branchProtectionRules": [
-          {
-            "requiresStrictStatusChecks": false,
-            "requiredStatusCheckContexts": [
-              "Kokoro",
-              "cla/google"
-            ]
-          }
-        ]
-      }
-    ],
-    "ignoredRepos": [
-      "GoogleCloudPlatform/python-docs-samples",
-      "GoogleCloudPlatform/getting-started-python",
-      "googleapis/sample-tester",
-      "googleapis/google-cloud-python"
     ]
   },
   "nodejs": {
@@ -119,54 +99,6 @@
         "team": "yoshi-nodejs",
         "permission": "push"
       }
-    ],
-    "ignoredRepos": [
-      "GoogleCloudPlatform/nodejs-docs-samples",
-      "GoogleCloudPlatform/nodejs-getting-started",
-      "googleapis/google-cloud-node",
-      "googleapis/gapic-generator-typescript",
-      "googleapis/aip",
-      "googleapis/release-please",
-      "google-cloudevents-nodejs"
-    ]
-  },
-  "ruby": {
-    "branchProtectionRules": [
-      {
-        "requiresStrictStatusChecks": true,
-        "requiredStatusCheckContexts": [
-          "OSx",
-          "Ubuntu",
-          "Windows",
-          "cla/google"
-        ]
-      }
-    ],
-    "permissionRules": [
-      {
-        "team": "yoshi-admins",
-        "permission": "admin"
-      },
-      {
-        "team": "yoshi-ruby-admins",
-        "permission": "admin"
-      },
-      {
-        "team": "yoshi-ruby",
-        "permission": "push"
-      }
-    ],
-    "ignoredRepos": [
-      "googleapis/discovery-artifact-manager",
-      "googleapis/gax-ruby",
-      "googleapis/google-api-ruby-client",
-      "googleapis/google-auth-library-ruby",
-      "googleapis/google-cloud-ruby",
-      "googleapis/ruby-style",
-      "googleapis/signet",
-      "googleapis/gapic-generator-ruby",
-      "GoogleCloudPlatform/ruby-docs-samples",
-      "GoogleCloudPlatform/getting-started-ruby"
     ]
   }
 }

--- a/packages/sync-repo-settings/src/sync-repo-settings.ts
+++ b/packages/sync-repo-settings/src/sync-repo-settings.ts
@@ -78,7 +78,6 @@ export class SyncRepoSettings {
     const logger = this.logger;
     const repo = options.repo;
     const [owner, name] = repo.split('/');
-    let ignored = false;
     if (!config) {
       logger.info(`no local config found for ${repo}, checking global config`);
       // Fetch the list of languages used in this repository
@@ -115,27 +114,11 @@ export class SyncRepoSettings {
       if (!config) {
         logger.info(`no config for language ${language}`);
       }
-
-      // Check for repositories we're specifically configured to skip
-      ignored = !!languageConfig[language]?.ignoredRepos?.find(x => x === repo);
-      if (ignored) {
-        logger.info(`ignoring repo ${repo}`);
-      }
-
-      if (languageConfig[language]?.repoOverrides) {
-        const customConfig = languageConfig[language].repoOverrides!.find(
-          x => x.repo === repo
-        );
-        if (customConfig) {
-          logger.info(`Discovered override config for ${repo}`);
-          config.branchProtectionRules = customConfig.branchProtectionRules;
-        }
-      }
     }
 
     const jobs: Promise<void>[] = [];
     jobs.push(this.updateRepoTeams(repo, config?.permissionRules || []));
-    if (!ignored && config) {
+    if (config) {
       jobs.push(this.updateRepoOptions(repo, config));
       if (config.branchProtectionRules) {
         config.branchProtectionRules.forEach(rule => {

--- a/packages/sync-repo-settings/test/test.bot.ts
+++ b/packages/sync-repo-settings/test/test.bot.ts
@@ -129,21 +129,6 @@ describe('Sync repo settings', () => {
     nock.cleanAll();
   });
 
-  it('should ignore repos in ignored repos in required-checks.json', async () => {
-    const repo = 'gax-ruby';
-    const scopes = [
-      nockConfig404(org, repo),
-      nockLanguagesList(org, repo, {ruby: 1}),
-      nockUpdateTeamMembership('yoshi-admins', org, repo),
-      nockUpdateTeamMembership('yoshi-ruby-admins', org, repo),
-      nockUpdateTeamMembership('yoshi-ruby', org, repo),
-      nockUpdateTeamMembership('cloud-dpe', org, repo),
-      nockUpdateTeamMembership('cloud-devrel-pgm', org, repo),
-    ];
-    await receive(org, repo);
-    scopes.forEach(x => x.done());
-  });
-
   it('should skip for the wrong context', async () => {
     await receive('googleapis', 'api-common-java', 'GoogleCloudPlatform');
   });
@@ -154,24 +139,6 @@ describe('Sync repo settings', () => {
     const scopes = [
       nockConfig404(org, repo),
       nockLanguagesList(org, repo, {kotlin: 1}),
-      nockUpdateTeamMembership('cloud-dpe', org, repo),
-      nockUpdateTeamMembership('cloud-devrel-pgm', org, repo),
-    ];
-    await receive(org, repo);
-    scopes.forEach(s => s.done());
-  });
-
-  it('should override master branch protection if the repo is overridden', async () => {
-    const repo = 'python-bigtable';
-    const scopes = [
-      nockConfig404(org, repo),
-      nockLanguagesList(org, repo, {python: 1}),
-      nockUpdateRepoSettings(repo, true, true),
-      nockUpdateBranchProtection(repo, ['Kokoro', 'cla/google'], false, false),
-      nockUpdateTeamMembership('yoshi-admins', org, repo),
-      nockUpdateTeamMembership('yoshi-python-admins', org, repo),
-      nockUpdateTeamMembership('yoshi-python', org, repo),
-      nockUpdateTeamMembership('python-samples-owners', org, repo),
       nockUpdateTeamMembership('cloud-dpe', org, repo),
       nockUpdateTeamMembership('cloud-devrel-pgm', org, repo),
     ];


### PR DESCRIPTION
This is the start of a broader config refactoring.  I want to push repo specific config away from the bot, and eventually multiple configs to `googleapis/.github` centralized config.  

It does a few things:
- removes the ability to have centralized ignored repos
- removes the ability to have centralized repo overrides
- drops the centralized ruby configs, since they had nothing in common

Blocked by:
- [x] https://github.com/googleapis/google-cloud-python/pull/10544
- [x] https://github.com/googleapis/google-cloud-node/pull/3090
- [x] https://github.com/googleapis/gapic-generator-typescript/pull/856
- [x] https://github.com/googleapis/release-please/pull/875
- [x] https://github.com/googleapis/google-auth-library-ruby/pull/314
- [x] https://github.com/googleapis/gapic-generator-ruby/pull/576
- [x] https://github.com/googleapis/ruby-cloud-env/pull/16
- [x] https://github.com/googleapis/ruby-style/pull/34
- [x] https://github.com/googleapis/discovery-artifact-manager/pull/1695
- [x] https://github.com/googleapis/gax-ruby/pull/234
- [x] https://github.com/googleapis/signet/pull/188
- [x] https://github.com/googleapis/google-cloud-ruby/pull/11208
