### PR TITLE
refactor(sync-repo-settings): split config out from the bot

### DIFF
--- a/packages/sync-repo-settings/README.md
+++ b/packages/sync-repo-settings/README.md
@@ -19,6 +19,9 @@ squashMergeAllowed: true
 # Defaults to `false`
 mergeCommitAllowed: false
 
+# Automatically delete head branches after merging PRs.  Defaults to `true`.
+deleteBranchOnMerge: true
+
 # Rules for branch protection (add multiple entries to configure multiple branches)
 branchProtectionRules:
 # Identifies the protection rule pattern. Name of the branch to be protected.
@@ -35,8 +38,6 @@ branchProtectionRules:
   requiresCodeOwnerReviews: true
   # Require up to date branches
   requiresStrictStatusChecks: true
-  # Automatically delete head branches after merging PRs.  Defaults to `true`.
-  deleteBranchOnMerge: true
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
     - check1

--- a/packages/sync-repo-settings/src/config.ts
+++ b/packages/sync-repo-settings/src/config.ts
@@ -1,0 +1,122 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {RepoConfig} from './types';
+import {Octokit} from '@octokit/rest';
+import {logger} from 'gcf-utils';
+import Ajv from 'ajv';
+import yaml from 'js-yaml';
+import schema from './schema.json';
+
+// configure the schema validator once
+const ajv = new Ajv();
+const validateSchema = ajv.compile(schema);
+
+export const configFileName = 'sync-repo-settings.yaml';
+
+export interface GetConfigOptions {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+}
+
+export interface ValidateConfigResponse {
+  isValid: boolean;
+  errorText?: string;
+  config?: RepoConfig;
+}
+
+/**
+ * Given a config in its raw yaml form, validate that it matches our config
+ * schema.  Return any validation errors from ajv.
+ * @param configYaml Raw text containing the YAML to validate.
+ * @returns
+ */
+export async function validateConfig(configYaml: string) {
+  const config = yaml.load(configYaml) as RepoConfig;
+  let isValid = false;
+  let errorText: string | undefined;
+  if (typeof config === 'object') {
+    isValid = await validateSchema(config);
+    if (!isValid) {
+      errorText = JSON.stringify(validateSchema.errors, null, 4);
+    }
+  } else {
+    errorText = `${configFileName} is not valid YAML 😱`;
+  }
+  return {isValid, errorText};
+}
+
+/**
+ * Allow repositories to optionally provide their own, localized config.
+ * Check the `.github/sync-repo-settings.yaml` file, and if available,
+ * use that config over any config broadly provided here.
+ */
+export async function getConfig(
+  options: GetConfigOptions
+): Promise<RepoConfig | null> {
+  let config!: RepoConfig | null;
+
+  // attempt to fetch config for the local repository
+  try {
+    config = await getConfigFile(options);
+    return config;
+  } catch (err) {
+    if (err.status === 404) {
+      logger.info('No local config found.');
+    } else {
+      err.message = `Error reading configuration: ${err.message}`;
+      logger.error(err);
+    }
+  }
+
+  // attempt to fetch config for the org level repo
+  try {
+    config = await getConfigFile({
+      octokit: options.octokit,
+      owner: options.owner,
+      repo: '.github',
+    });
+    return config;
+  } catch (err) {
+    if (err.status === 404) {
+      logger.info('No remote config found.');
+    } else {
+      err.message = `Error reading configuration: ${err.message}`;
+      logger.error(err);
+    }
+  }
+  return null;
+}
+
+/**
+ * For a given repository, fetch the config yaml.
+ * @param options GetConfigOptions
+ * @returns an individual Repo config
+ */
+async function getConfigFile(
+  options: GetConfigOptions
+): Promise<RepoConfig | null> {
+  const orgYamlRes = await options.octokit.repos.getContent({
+    owner: options.owner,
+    repo: options.repo,
+    path: `.github/${configFileName}`,
+    headers: {
+      accept: 'application/vnd.github.VERSION.raw',
+    },
+  });
+  const rawYamlConfig = orgYamlRes.data.toString();
+  const orgConfig = yaml.load(rawYamlConfig);
+  return orgConfig as RepoConfig;
+}

--- a/packages/sync-repo-settings/test/test.config.ts
+++ b/packages/sync-repo-settings/test/test.config.ts
@@ -1,0 +1,118 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, afterEach} from 'mocha';
+import nock from 'nock';
+import sinon from 'sinon';
+import assert from 'assert';
+import fs from 'fs';
+import {logger} from 'gcf-utils';
+import {Octokit} from '@octokit/rest';
+import {configFileName, getConfig, validateConfig} from '../src/config';
+
+nock.disableNetConnect();
+
+const owner = 'yoshi';
+const repo = 'saur';
+const host = 'https://api.github.com';
+const octokit = new Octokit();
+
+const localConfig = {
+  rebaseMergeAllowed: false,
+  branchProtectionRules: [
+    {
+      requiresCodeOwnerReviews: true,
+      requiredStatusCheckContexts: ['check1', 'check2'],
+    },
+  ],
+  permissionRules: [
+    {
+      team: 'team1',
+      permission: 'push',
+    },
+  ],
+};
+
+describe('config', () => {
+  afterEach(() => {
+    sinon.restore();
+    nock.cleanAll();
+  });
+  it('should get a config local to a repo', async () => {
+    const scope = nock(host)
+      .get(`/repos/${owner}/${repo}/contents/.github%2F${configFileName}`)
+      .replyWithFile(200, './test/fixtures/localConfig.yaml');
+    const config = await getConfig({octokit, owner, repo});
+    assert.deepStrictEqual(config, localConfig);
+    scope.done();
+  });
+
+  it('should get a remote config if local is not available', async () => {
+    const scope = nock(host)
+      .get(`/repos/${owner}/${repo}/contents/.github%2F${configFileName}`)
+      .reply(404)
+      .get(`/repos/${owner}/.github/contents/.github%2F${configFileName}`)
+      .replyWithFile(200, './test/fixtures/localConfig.yaml');
+    const config = await getConfig({octokit, owner, repo});
+    assert.deepStrictEqual(config, localConfig);
+    scope.done();
+  });
+
+  it('should not throw if the config 404s', async () => {
+    const scope = nock(host)
+      .get(`/repos/${owner}/${repo}/contents/.github%2F${configFileName}`)
+      .reply(404)
+      .get(`/repos/${owner}/.github/contents/.github%2F${configFileName}`)
+      .reply(404);
+    const infoStub = sinon.stub(logger, 'info');
+    const config = await getConfig({octokit, owner, repo});
+    assert.strictEqual(config, null);
+    assert.ok(infoStub.calledTwice);
+    scope.done();
+  });
+
+  it('should log an error if the config request returns a 500', async () => {
+    const scope = nock(host)
+      .get(`/repos/${owner}/${repo}/contents/.github%2F${configFileName}`)
+      .reply(500)
+      .get(`/repos/${owner}/.github/contents/.github%2F${configFileName}`)
+      .reply(500);
+    const errorStub = sinon.stub(logger, 'error');
+    const config = await getConfig({octokit, owner, repo});
+    assert.strictEqual(config, null);
+    scope.done();
+    assert.ok(errorStub.calledTwice);
+  });
+
+  it('should validate a valid config', async () => {
+    const localConfigYaml = fs.readFileSync(
+      './test/fixtures/localConfig.yaml',
+      'utf-8'
+    );
+    const res = await validateConfig(localConfigYaml);
+    assert.ok(res.isValid);
+    assert.strictEqual(res.errorText, undefined);
+  });
+
+  it('should invalidate a invalid config', async () => {
+    const localConfigYaml = fs.readFileSync(
+      './test/fixtures/bogusConfig.yaml',
+      'utf-8'
+    );
+    const res = await validateConfig(localConfigYaml);
+    assert.strictEqual(res.isValid, false);
+    assert.ok(res.errorText);
+    assert.ok(/additionalProperties/.test(res.errorText!));
+  });
+});


### PR DESCRIPTION
This is part of a broader effort to enable organization level configuration for sync-repo-settings.  It starts by:
- Fixing a gaffe I tripped on in the README
- Splitting config validation and fetching out into it's own file
- Introducing config specific tests instead of relying on the bot tests
- Moving away from probot's built in config fetcher, and instead just directly fetching the files.

On the last bit - I did this because eventually I would like to be able to _merge_ the configurations between a local repo, and the upstream `.github` repository where a centralized config will be stored.   The current probot implementation doesn't allow for that, so this should be behaviorally compatible. 