### PR TITLE
feat(trusted): add optional comment configuration

### DIFF
--- a/packages/trusted-contribution/README.md
+++ b/packages/trusted-contribution/README.md
@@ -21,6 +21,9 @@ options:
 | Name | Description | Type | Default |
 |----- | ----------- | ---- | ------- |
 | `trustedContributors` | List of user login names that are considered trusted  | `string[]` | `['renovate-bot', 'release-please[bot]', 'gcf-merge-on-green[bot]']` |
+| `annotations` | The list of annotation objects to leave the on the PR | `object` | `{ type: 'label'; text: 'kokoro:force-run' }` |
+| `annotation.type` | Configure the bot to either comment on the PR or add a label | `comment`|`label` | `label` |
+| `annotation.text` | The label text or comment text to be left on the PR | `string` | `kokoro:force-run`
 
 ## Deployment and Permissions
 

--- a/packages/trusted-contribution/package-lock.json
+++ b/packages/trusted-contribution/package-lock.json
@@ -607,6 +607,41 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.0.5.tgz",
+      "integrity": "sha512-fUt6b15bjV/VW93UP5opNXJxdwZSbK1EdiwnhN7XrQrcpaOhMJpZ/CjwFpM3THpxwA+YviBUJKSuEqKlCK5alw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -820,6 +855,15 @@
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
+      }
+    },
+    "@types/sinon": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.0.tgz",
+      "integrity": "sha512-jDZ55oCKxqlDmoTBBbBBEx+N8ZraUVhggMZ9T5t+6/Dh8/4NiOjSUfpLrPiEwxQDlAe3wpAkoXhWvE6LibtsMQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/fake-timers": "^7.0.4"
       }
     },
     "@types/sonic-boom": {
@@ -3303,6 +3347,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "jwa": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
@@ -3413,6 +3463,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -3777,6 +3833,45 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "nise": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
+      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+          "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "nock": {
       "version": "13.0.11",
@@ -4742,6 +4837,52 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
+    "sinon": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
+      "integrity": "sha512-XAn5DxtGVJBlBWYrcYKEhWCz7FLwZGdyvANRyK06419hyEpdT0dMc5A8Vcxg5SCGHc40CsqoKsc1bt1CbJPfNw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+          "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5094,6 +5235,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/packages/trusted-contribution/package.json
+++ b/packages/trusted-contribution/package.json
@@ -32,11 +32,13 @@
   "devDependencies": {
     "@types/mocha": "^8.0.0",
     "@types/node": "^14.0.22",
+    "@types/sinon": "^10.0.0",
     "c8": "^7.2.0",
     "cross-env": "^7.0.2",
     "gts": "^3.0.0",
     "mocha": "^8.0.1",
     "nock": "^13.0.2",
+    "sinon": "^10.0.0",
     "typescript": "^4.0.0"
   },
   "engines": {

--- a/packages/trusted-contribution/src/trusted-contribution.ts
+++ b/packages/trusted-contribution/src/trusted-contribution.ts
@@ -16,8 +16,14 @@
 import {Probot} from 'probot';
 import {logger} from 'gcf-utils';
 
+interface Annotation {
+  type: 'comment' | 'label';
+  text: string;
+}
+
 interface ConfigurationOptions {
   trustedContributors?: string[];
+  annotations?: Annotation[];
 }
 
 const WELL_KNOWN_CONFIGURATION_FILE = 'trusted-contribution.yml';
@@ -28,6 +34,12 @@ const DEFAULT_TRUSTED_CONTRIBUTORS = [
   'gcf-merge-on-green[bot]',
   'yoshi-code-bot',
   'gcf-owl-bot[bot]',
+];
+const DEFAULT_ANNOTATIONS: Annotation[] = [
+  {
+    type: 'label',
+    text: 'kokoro:force-run',
+  },
 ];
 
 function isTrustedContribution(
@@ -66,11 +78,24 @@ export = (app: Probot) => {
       remoteConfiguration = remoteConfiguration! || {};
       // TODO: add additional verification that only dependency version changes occurred.
       if (isTrustedContribution(remoteConfiguration, PR_AUTHOR)) {
-        const issuesAddLabelsParams = context.repo({
-          issue_number: context.payload.pull_request.number,
-          labels: ['kokoro:force-run'],
-        });
-        await context.octokit.issues.addLabels(issuesAddLabelsParams);
+        const annotations =
+          remoteConfiguration.annotations || DEFAULT_ANNOTATIONS;
+        for (const annotation of annotations) {
+          if (annotation.type === 'label') {
+            const issuesAddLabelsParams = context.repo({
+              issue_number: context.payload.pull_request.number,
+              labels: [annotation.text],
+            });
+            await context.octokit.issues.addLabels(issuesAddLabelsParams);
+          } else if (annotation.type === 'comment') {
+            await context.octokit.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              body: annotation.text,
+              owner: context.repo().owner,
+              repo: context.repo().repo,
+            });
+          }
+        }
       }
     }
   );

--- a/packages/trusted-contribution/test/fixtures/gcbrun.yml
+++ b/packages/trusted-contribution/test/fixtures/gcbrun.yml
@@ -1,0 +1,3 @@
+annotations:
+  - type: comment
+    text: "/gcbrun"


### PR DESCRIPTION
Fixes #1678.  This introduces a config option so that repositories which use Cloud Build can opt into a comment instead of a label.  The config would look like this:

```yaml
annotations:
  - type: comment
    text: "/gcbrun"
``` 

Also some vanity test additions to get coverage to 100%.