### PR TITLE
chore: configure Renovate to update genproto later

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
     },
     {
       "packageNames": ["google.golang.org/genproto"],
-      "schedule": "after 2pm on monday"
+      "schedule": "after 7pm on monday"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
The `genproto` package updates every day. When we upgrade in the morning, then `genproto` updates again, we get a second PR. This schedules the Renovate update to be later in the day so we hopefully only get one PR.