### PR TITLE
fix(serverless-scheduler-proxy): Close secretmanager Client

### DIFF
--- a/serverless-scheduler-proxy/main.go
+++ b/serverless-scheduler-proxy/main.go
@@ -192,6 +192,7 @@ func getBotSecret(ctx context.Context, b botConfig, botName string) ([]byte, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to create secretmanager client: %v", err)
 	}
+	defer client.Close()
 
 	// Build the request.
 	req := &secretmanagerpb.AccessSecretVersionRequest{


### PR DESCRIPTION
Otherwise, the Client never closes its underlying connections and causes OOM errors.

Fixes #1687, which contains more detail about the memory leak.

cc @orthros (can't add as a reviewer).