### PR TITLE
fix(trusted-contribution): should use latest gcf-utils for logs

### DIFF
--- a/packages/trusted-contribution/package-lock.json
+++ b/packages/trusted-contribution/package-lock.json
@@ -146,17 +146,17 @@
       "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
     },
     "@google-cloud/secret-manager": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.5.0.tgz",
-      "integrity": "sha512-gXoxsTTBClpM6rAo04E1dDCox0VBi498+Sq67K+9rqr1SHIKCfrYkzEH4O4knK4LdfDuNN9xg2CwBfj8+vJdpw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.6.0.tgz",
+      "integrity": "sha512-1lSYKYJ57PekYvUV2FLt7wtI4toDhMKrbHxMH5kA5X9XLfECasgm/PZo+EbmJ/uIxtz5i2qzQID/NczLrZNG+w==",
       "requires": {
         "google-gax": "^2.9.2"
       }
     },
     "@google-cloud/storage": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.8.1.tgz",
-      "integrity": "sha512-qP8gCJ2myyMN3JMJN12d82Oo8VBSDO8vO4/x56dtQZX9+WISqcagurntnJVyFX885tIOtS97bsyv8qR1xv6HMg==",
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.8.5.tgz",
+      "integrity": "sha512-i0gB9CRwQeOBYP7xuvn14M40LhHCwMjceBjxE4CTvsqL519sVY5yVKxLiAedHWGwUZHJNRa7Q2CmNfkdRwVNPg==",
       "requires": {
         "@google-cloud/common": "^3.6.0",
         "@google-cloud/paginator": "^3.0.0",
@@ -164,11 +164,11 @@
         "arrify": "^2.0.0",
         "async-retry": "^1.3.1",
         "compressible": "^2.0.12",
-        "date-and-time": "^0.14.2",
+        "date-and-time": "^1.0.0",
         "duplexify": "^4.0.0",
         "extend": "^3.0.2",
         "gaxios": "^4.0.0",
-        "gcs-resumable-upload": "^3.1.3",
+        "gcs-resumable-upload": "^3.1.4",
         "get-stream": "^6.0.0",
         "hash-stream-validation": "^0.2.2",
         "mime": "^2.2.0",
@@ -190,40 +190,23 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.11.tgz",
-      "integrity": "sha512-DZqx3nHBm2OGY7NKq4sppDEfx4nBAsQH/d/H/yxo/+BwpVLWLGs+OorpwQ+Fqd6EgpDEoi4MhqndjGUeLl/5GA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.0.tgz",
+      "integrity": "sha512-fiL7ZaGg2HBiFtmv6m34d5jEgEtNXfctjzB3f7b3iuT7olBX4mHLMOqOBmGTTSOTfNRQJH5+vsyk6mEz3I0Q7Q==",
       "requires": {
-        "@types/node": ">=12.12.47",
-        "google-auth-library": "^6.1.1",
-        "semver": "^6.2.0"
-      },
-      "dependencies": {
-        "google-auth-library": {
-          "version": "6.1.6",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
-          "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
-          "requires": {
-            "arrify": "^2.0.0",
-            "base64-js": "^1.3.0",
-            "ecdsa-sig-formatter": "^1.0.11",
-            "fast-text-encoding": "^1.0.0",
-            "gaxios": "^4.0.0",
-            "gcp-metadata": "^4.2.0",
-            "gtoken": "^5.0.4",
-            "jws": "^4.0.0",
-            "lru-cache": "^6.0.0"
-          }
-        }
+        "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.6.tgz",
-      "integrity": "sha512-DT14xgw3PSzPxwS13auTEwxhMMOoz33DPUKNtmYK/QYbBSpLXJy78FGGs5yVoxVobEqPm4iW9MOIoz0A3bLTRQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.1.tgz",
+      "integrity": "sha512-4DIvEOZhw5nGj3RQngIoiMXRsre3InEH136krZTcirs/G2em3WMXdtx4Lqlnb4E2ertbWGs5gPeVDKU5BHffXw==",
       "requires": {
+        "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
-        "protobufjs": "^6.8.6"
+        "long": "^4.0.0",
+        "protobufjs": "^6.10.0",
+        "yargs": "^16.1.1"
       }
     },
     "@hapi/bourne": {
@@ -264,10 +247,12 @@
       }
     },
     "@octokit/auth-app": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-3.0.0.tgz",
-      "integrity": "sha512-7280Oz7zsyF1cRuJEMJGG0H3zenOKY44P2QZRwN/21qRqyI+aQ0wM7IQny6uQk/xow36B7JNu2U2GtcgEdx8iA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-3.4.0.tgz",
+      "integrity": "sha512-zBVgTnLJb0uoNMGCpcDkkAbPeavHX7oAjJkaDv2nqMmsXSsCw4AbUhjl99EtJQG/JqFY/kLFHM9330Wn0k70+g==",
       "requires": {
+        "@octokit/auth-oauth-app": "^4.1.0",
+        "@octokit/auth-oauth-user": "^1.2.3",
         "@octokit/request": "^5.4.11",
         "@octokit/request-error": "^2.0.0",
         "@octokit/types": "^6.0.3",
@@ -275,6 +260,44 @@
         "deprecation": "^2.3.1",
         "lru-cache": "^6.0.0",
         "universal-github-app-jwt": "^1.0.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/auth-oauth-app": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-4.1.2.tgz",
+      "integrity": "sha512-bdNGNRmuDJjKoHla3mUGtkk/xcxKngnQfBEnyk+7VwMqrABKvQB1wQRSrwSWkPPUX7Lcj2ttkPAPG7+iBkMRnw==",
+      "requires": {
+        "@octokit/auth-oauth-device": "^3.1.1",
+        "@octokit/auth-oauth-user": "^1.2.1",
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.3",
+        "@types/btoa-lite": "^1.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/auth-oauth-device": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-3.1.1.tgz",
+      "integrity": "sha512-ykDZROilszXZJ6pYdl6SZ15UZniCs0zDcKgwOZpMz3U0QDHPUhFGXjHToBCAIHwbncMu+jLt4/Nw4lq3FwAw/w==",
+      "requires": {
+        "@octokit/oauth-methods": "^1.1.0",
+        "@octokit/request": "^5.4.14",
+        "@octokit/types": "^6.10.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/auth-oauth-user": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-1.2.4.tgz",
+      "integrity": "sha512-efOajupCZBP1veqx5w59Qey0lIud1rDUgxTRjjkQDU3eOBmkAasY1pXemDsQwW0I85jb1P/gn2dMejedVxf9kw==",
+      "requires": {
+        "@octokit/auth-oauth-device": "^3.1.1",
+        "@octokit/oauth-methods": "^1.1.0",
+        "@octokit/request": "^5.4.14",
+        "@octokit/types": "^6.12.2",
+        "btoa-lite": "^1.0.0",
         "universal-user-agent": "^6.0.0"
       }
     },
@@ -296,9 +319,9 @@
       }
     },
     "@octokit/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-Dc5NNQOYjgZU5S1goN6A/E500yXOfDUFRGQB8/2Tl16AcfvS3H9PudyOe3ZNE/MaVyHPIfC0htReHMJb1tMrvw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==",
       "requires": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -329,15 +352,32 @@
         "universal-user-agent": "^6.0.0"
       }
     },
+    "@octokit/oauth-authorization-url": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-4.3.1.tgz",
+      "integrity": "sha512-sI/SOEAvzRhqdzj+kJl+2ifblRve2XU6ZB36Lq25Su8R31zE3GoKToSLh64nWFnKePNi2RrdcMm94UEIQZslOw=="
+    },
+    "@octokit/oauth-methods": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-1.2.2.tgz",
+      "integrity": "sha512-CFMUMn9DdPLMcpffhKgkwIIClfv0ZToJM4qcg4O0egCoHMYkVlxl22bBoo9qCnuF1U/xn871KEXuozKIX+bA2w==",
+      "requires": {
+        "@octokit/oauth-authorization-url": "^4.3.1",
+        "@octokit/request": "^5.4.14",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.12.2",
+        "btoa-lite": "^1.0.0"
+      }
+    },
     "@octokit/openapi-types": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-5.3.2.tgz",
-      "integrity": "sha512-NxF1yfYOUO92rCx3dwvA2onF30Vdlg7YUkMVXkeptqpzA3tRLplThhFleV/UKWFgh7rpKu1yYRbvNDUtzSopKA=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.0.0.tgz",
+      "integrity": "sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw=="
     },
     "@octokit/plugin-enterprise-compatibility": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-1.2.9.tgz",
-      "integrity": "sha512-No/4dQ7qPeGCRllaS7DP5wNZDmGbJO8OvQ9qePYHGqacY+fmaj7m95ngxmO1AQ2OcVQmFyV/jBDXB3EfVgWUpg==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-1.2.11.tgz",
+      "integrity": "sha512-bFCxP7q1q2bzK/H9C+NW4JNmdlwvjYFh7+J0SEdjklo9Q0K40s9IhKC4+DUaoCYCVSJv8aiiXIp660Hc15SbtA==",
       "requires": {
         "@octokit/request-error": "^2.0.4",
         "@octokit/types": "^6.0.3"
@@ -357,11 +397,11 @@
       "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "4.13.5",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.13.5.tgz",
-      "integrity": "sha512-kYKcWkFm4Ldk8bZai2RVEP1z97k1C/Ay2FN9FNTBg7JIyKoiiJjks4OtT6cuKeZX39tqa+C3J9xeYc6G+6g8uQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz",
+      "integrity": "sha512-vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==",
       "requires": {
-        "@octokit/types": "^6.12.2",
+        "@octokit/types": "^6.13.1",
         "deprecation": "^2.3.1"
       }
     },
@@ -384,17 +424,15 @@
       }
     },
     "@octokit/request": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.14.tgz",
-      "integrity": "sha512-VkmtacOIQp9daSnBmDI92xNIeLuSRDOIuplp/CJomkvzt7M18NXgG044Cx/LFKLgjKt9T2tZR6AtJayba9GTSA==",
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
+      "integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
         "@octokit/types": "^6.7.1",
-        "deprecation": "^2.0.0",
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.1",
-        "once": "^1.4.0",
         "universal-user-agent": "^6.0.0"
       }
     },
@@ -409,22 +447,22 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.3.5.tgz",
-      "integrity": "sha512-ZPeRms3WhWxQBEvoIh0zzf8xdU2FX0Capa7+lTca8YHmRsO3QNJzf1H3PcuKKsfgp91/xVDRtX91sTe1kexlbw==",
+      "version": "18.5.3",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.3.tgz",
+      "integrity": "sha512-KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==",
       "requires": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "4.13.5"
+        "@octokit/plugin-rest-endpoint-methods": "5.0.1"
       }
     },
     "@octokit/types": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.12.2.tgz",
-      "integrity": "sha512-kCkiN8scbCmSq+gwdJV0iLgHc0O/GTPY1/cffo9kECu1MvatLPh9E+qFhfRIktKfHEA6ZYvv6S1B4Wnv3bi3pA==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.14.2.tgz",
+      "integrity": "sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==",
       "requires": {
-        "@octokit/openapi-types": "^5.3.2"
+        "@octokit/openapi-types": "^7.0.0"
       }
     },
     "@octokit/webhooks": {
@@ -447,12 +485,22 @@
       }
     },
     "@probot/octokit-plugin-config": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@probot/octokit-plugin-config/-/octokit-plugin-config-1.0.3.tgz",
-      "integrity": "sha512-WQ33rxFmMiY8FqefOmpLxM8ZrUJlEQMYK1q0uARkzJ6izJFbU/+q7galALJL8xz3zXFP0uH/TDuloEsPmilTqw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@probot/octokit-plugin-config/-/octokit-plugin-config-1.0.5.tgz",
+      "integrity": "sha512-UH5SkS6bPkNNBHLEZnxN5ZR5fZAs1y+tsea067W9x0W0np/pjfJAUVnEA4dVWSQ53dktMhwF8M+EGkRnUhe1hQ==",
       "requires": {
-        "@types/js-yaml": "^4.0.0",
-        "js-yaml": "^4.0.0"
+        "@types/js-yaml": "^4.0.1",
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
       }
     },
     "@probot/pino": {
@@ -522,47 +570,47 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@sentry/core": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.3.tgz",
-      "integrity": "sha512-GpfHoSJiXchVXgyaMWVtIPVw2t97KkD1OJ4JdL3/TeH3auX5XvsN5iHTk+x/Er8t13IpOnvidH1xWdV1dnax2w==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.5.tgz",
+      "integrity": "sha512-VR2ibDy33mryD0mT6d9fGhKjdNzS2FSwwZPe9GvmNOjkyjly/oV91BKVoYJneCqOeq8fyj2lvkJGKuupdJNDqg==",
       "requires": {
-        "@sentry/hub": "6.2.3",
-        "@sentry/minimal": "6.2.3",
-        "@sentry/types": "6.2.3",
-        "@sentry/utils": "6.2.3",
+        "@sentry/hub": "6.3.5",
+        "@sentry/minimal": "6.3.5",
+        "@sentry/types": "6.3.5",
+        "@sentry/utils": "6.3.5",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.3.tgz",
-      "integrity": "sha512-D5Horfo2l0p52S7KPvy7qwWNMrE4IsCN8ODbfcCsfJu7hEXJmItbkbohIVSqO5neukhn5nu+x8kyCe9Q5u1Q6g==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.5.tgz",
+      "integrity": "sha512-ZYFo7VYKwdPVjuV9BDFiYn+MpANn6eZMz5QDBfZ2dugIvIVbuOyOOLx8PSa3ZXJoVTZZ7s2wD2fi/ZxKjNjZOQ==",
       "requires": {
-        "@sentry/types": "6.2.3",
-        "@sentry/utils": "6.2.3",
+        "@sentry/types": "6.3.5",
+        "@sentry/utils": "6.3.5",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.3.tgz",
-      "integrity": "sha512-Gpn9x4NQAG7E94EK1+hAz9GUcYrffTuqJ/XgqvHYk0jsHZ6RfsXYrmBac0ZwUxOivMf2t0n5opK0v5rhMDfF2w==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.5.tgz",
+      "integrity": "sha512-4RqIGAU0+8iI/1sw0GYPTr4SUA88/i2+JPjFJ+qloh5ANVaNwhFPRChw+Ys9xpre8LV9JZrEsEf8AvQr4fkNbA==",
       "requires": {
-        "@sentry/hub": "6.2.3",
-        "@sentry/types": "6.2.3",
+        "@sentry/hub": "6.3.5",
+        "@sentry/types": "6.3.5",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.2.3.tgz",
-      "integrity": "sha512-MaT8Uj+dOi1FPR4GkRGoQwaqxWKtfz+KpZ2RUT+x6aMqE8nieDFKts0i7O2vALg7LbRFzVsDsvK2GWcunfYkpA==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.3.5.tgz",
+      "integrity": "sha512-scPB+DoAEPaqkYuyb8d/gVWbFmX5PhaYSNHybeHncaP/P4itLdq/AoAWGNxl0Hj4EQokfT4OZWxaaJi7SCYnaw==",
       "requires": {
-        "@sentry/core": "6.2.3",
-        "@sentry/hub": "6.2.3",
-        "@sentry/tracing": "6.2.3",
-        "@sentry/types": "6.2.3",
-        "@sentry/utils": "6.2.3",
+        "@sentry/core": "6.3.5",
+        "@sentry/hub": "6.3.5",
+        "@sentry/tracing": "6.3.5",
+        "@sentry/types": "6.3.5",
+        "@sentry/utils": "6.3.5",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -577,28 +625,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.3.tgz",
-      "integrity": "sha512-OnQZKp7qVera+Z4ly6hgybGgyf10p2VDXqwueXkMVeLD+PwlPG8a8NMpKkZ+QxwRbQbSFhRLQaib3NX34tusBQ==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.3.5.tgz",
+      "integrity": "sha512-TNKAST1ge2g24BlTfVxNp4gP5t3drbi0OVCh8h8ah+J7UjHSfdiqhd9W2h5qv1GO61gGlpWeN/TyioyQmOxu0Q==",
       "requires": {
-        "@sentry/hub": "6.2.3",
-        "@sentry/minimal": "6.2.3",
-        "@sentry/types": "6.2.3",
-        "@sentry/utils": "6.2.3",
+        "@sentry/hub": "6.3.5",
+        "@sentry/minimal": "6.3.5",
+        "@sentry/types": "6.3.5",
+        "@sentry/utils": "6.3.5",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.3.tgz",
-      "integrity": "sha512-BpA+9FherWgYlkMD/82bGFh/gAqZNlZX5UE8vWLKyyzNyOEEz3v9ScxE8dOSWE4v5iXJR1O3jjxaTcRQxPVgCA=="
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.5.tgz",
+      "integrity": "sha512-tY/3pkAmGYJ3F0BtwInsdt/uclNvF8aNG7XHsTPQNzk7BkNVWjCXx0sjxi6CILirl5nwNxYxVeTr2ZYAEZ/dSQ=="
     },
     "@sentry/utils": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.3.tgz",
-      "integrity": "sha512-YnkJm97wSvck39eRpqWjIuuwbvzPilvAcMqhbUy9yK/UBQMDGUzAKCOKH40udw1DwMUCWjJ71mOCDgUorE4Fog==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.5.tgz",
+      "integrity": "sha512-kHUcZ37QYlNzz7c9LVdApITXHaNmQK7+sw/If3M/qpff1fd5XoecA8laLfcYuz+Cw5mRhVmdhPcCRM3Xi1IGXg==",
       "requires": {
-        "@sentry/types": "6.2.3",
+        "@sentry/types": "6.3.5",
         "tslib": "^1.9.3"
       }
     },
@@ -664,6 +712,11 @@
         "@types/node": "*"
       }
     },
+    "@types/btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg=="
+    },
     "@types/bunyan": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.6.tgz",
@@ -673,9 +726,9 @@
       }
     },
     "@types/configstore": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-4.0.0.tgz",
-      "integrity": "sha512-SvCBBPzOIe/3Tu7jTl2Q8NjITjLmq9m7obzjSyb8PXWWZ31xVK6w4T6v8fOx+lrgQnqk3Yxc00LDolFsSakKCA=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-5.0.0.tgz",
+      "integrity": "sha512-A48oa2v2dKyy5QNqfAlfvibgiJagh2mkWmsGMOE1LtqtwUH2WkS76VNfAUZ55h42TCr3jADpz/s6TbPfIjOuvw=="
     },
     "@types/connect": {
       "version": "3.4.34",
@@ -731,9 +784,9 @@
       }
     },
     "@types/ioredis": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.22.1.tgz",
-      "integrity": "sha512-GxXT828fkvBeThO68ZJg8cD2haqea5ANBJaxA+UZqLranNkEnQ8N7QLPtykwWbN/sRQz75O7kj+PNmCKF4CEKw==",
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.1.tgz",
+      "integrity": "sha512-k9f+bda6y0ZNrwUMNYI9mqIPqjPZ4Jqc+jTRTUyhFz8aD8cHQBk+uenTKCZj9RhdfrU4sSqrot5sn5LqkAHODw==",
       "requires": {
         "@types/node": "*"
       }
@@ -756,9 +809,9 @@
       "dev": true
     },
     "@types/js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-4vlpCM5KPCL5CfGmTbpjwVKbISRYhduEJvvUWsH5EB7QInhEj94XPZ3ts/9FPiLZFqYO0xoW4ZL8z2AabTGgJA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.1.tgz",
+      "integrity": "sha512-xdOvNmXmrZqqPy3kuCQ+fz6wA0xU5pji9cd1nDrflWaAWtYLLGk5ykW0H6yg5TVyehHP1pfmuuSaZkhP+kspVA=="
     },
     "@types/json-schema": {
       "version": "7.0.7",
@@ -813,19 +866,28 @@
       "dev": true
     },
     "@types/pino": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.6.tgz",
-      "integrity": "sha512-yVgSyMGzNDYe/XNMJyuIkklDeZbFdGAxRztYLoN1QQrrgiLJ1oJPmnS8Ge5xpzI9ODKEddKH97VFQ7cWO6Pumw==",
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.8.tgz",
+      "integrity": "sha512-E47CmRy1FNMaCN8r0d8ECQOjXen9O0p6GGsUjLfmawlxRKosZ82WP1oWVKj+ikTkMDHxWzN5BuKmplo44ynrIg==",
       "requires": {
         "@types/node": "*",
+        "@types/pino-pretty": "*",
         "@types/pino-std-serializers": "*",
         "@types/sonic-boom": "*"
       }
     },
     "@types/pino-http": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@types/pino-http/-/pino-http-5.4.0.tgz",
-      "integrity": "sha512-d2OqdD3BWZA7JupHHkWHl/9aqzpGOI2jwD9FGcoWqbg/1f/HaXENI8T4gqzCHZg3ELkhrTaPjrLWbAfD8bGJ3g==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@types/pino-http/-/pino-http-5.4.1.tgz",
+      "integrity": "sha512-G/iRh3egjicSm6DPomAfFel0fUsuwKEd4vtLALSEohravku684VHhO3W14UibyHo7gWW0F1v4LxGR/pe27cNdA==",
+      "requires": {
+        "@types/pino": "*"
+      }
+    },
+    "@types/pino-pretty": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.0.tgz",
+      "integrity": "sha512-fIZ+VXf9gJoJR4tiiM7G+j/bZkPoZEfFGzA4d8tAWCTpTVyvVaBwnmdLs3wEXYpMjw8eXulrOzNCjmGHT3FgHw==",
       "requires": {
         "@types/pino": "*"
       }
@@ -1197,9 +1259,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "before-after-hook": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.0.tgz",
-      "integrity": "sha512-jH6rKQIfroBbhEXVmI7XmXe3ix5S/PgJqpzdDPnR8JGLHWNYLsYZ6tK5iWOF/Ra3oqEX0NobXGlzbiylIzVphQ=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
+      "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw=="
     },
     "bignumber.js": {
       "version": "9.0.1",
@@ -1337,6 +1399,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -1721,9 +1788,9 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
     "date-and-time": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.14.2.tgz",
-      "integrity": "sha512-EFTCh9zRSEpGPmJaexg7HTuzZHh6cnJj1ui7IGCFNXzd2QdpsNh05Db5TF3xzJm30YN+A8/6xHSuRcQqoc3kFA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-1.0.0.tgz",
+      "integrity": "sha512-477D7ypIiqlXBkxhU7YtG9wWZJEQ+RUpujt2quTfgf4+E8g5fNUkB0QIL0bVyP5/TKBg8y55Hfa1R/c4bt3dEw=="
     },
     "dateformat": {
       "version": "4.5.1",
@@ -2333,9 +2400,9 @@
       "dev": true
     },
     "fast-redact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.1.tgz",
+      "integrity": "sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw=="
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
@@ -2552,9 +2619,9 @@
       }
     },
     "gaxios": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.2.0.tgz",
-      "integrity": "sha512-Ms7fNifGv0XVU+6eIyL9LB7RVESeML9+cMvkwGS70xyD6w2Z80wl6RiqiJ9k1KFlJCUTQqFFc8tXmPQfSKUe8g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.2.1.tgz",
+      "integrity": "sha512-s+rTywpw6CmfB8r9TXYkpix7YFeuRjnR/AqhaJrQqsNhsAqej+IAiCc3hadzQH3gHyWth30tvYjxH8EVjQt/8Q==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -2564,16 +2631,16 @@
       }
     },
     "gcf-utils": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-7.1.3.tgz",
-      "integrity": "sha512-02jU49wrv7CNYSncNe2ptLTC5M4ra26uLe76uathVA5rfHLzkkMZeZXmkuWgnmP/S4N+oP/AJfQVMGwKjc4CFg==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-7.2.2.tgz",
+      "integrity": "sha512-4aHEORCXXRWvith4dCnprpfd0JJ4drwGQOq+uU9pthAL/PmALkzIbB3CB93vFw9UzFY8L1nRPKImrsogJ5hMhg==",
       "requires": {
         "@google-cloud/kms": "^2.0.0",
         "@google-cloud/secret-manager": "^3.0.0",
         "@google-cloud/storage": "^5.3.0",
         "@google-cloud/tasks": "^2.0.0",
-        "@octokit/plugin-enterprise-compatibility": "1.2.9",
-        "@octokit/rest": "^18.0.6",
+        "@octokit/plugin-enterprise-compatibility": "1.2.11",
+        "@octokit/rest": "^18.5.2",
         "@probot/octokit-plugin-config": "^1.0.0",
         "@types/bunyan": "^1.8.6",
         "@types/dotenv": "^6.1.1",
@@ -2588,9 +2655,9 @@
         "gaxios": "^4.0.0",
         "get-stream": "^6.0.0",
         "into-stream": "^6.0.0",
-        "octokit-auth-probot": "^1.2.2",
+        "octokit-auth-probot": "^1.2.4",
         "pino": "^6.3.2",
-        "probot": "11.0.6",
+        "probot": "^11.1.1",
         "tmp": "^0.2.0",
         "uuid": "^8.3.0",
         "yargs": "^16.0.0"
@@ -2606,9 +2673,9 @@
       }
     },
     "gcs-resumable-upload": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.3.tgz",
-      "integrity": "sha512-LjVrv6YVH0XqBr/iBW0JgRA1ndxhK6zfEFFJR4im51QVTj/4sInOXimY2evDZuSZ75D3bHxTaQAdXRukMc1y+w==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.4.tgz",
+      "integrity": "sha512-5dyDfHrrVcIskiw/cPssVD4HRiwoHjhk1Nd6h5W3pQ/qffDvhfy4oNCr1f3ZXFPwTnxkCbibsB+73oOM+NvmJQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "configstore": "^5.0.0",
@@ -2691,9 +2758,9 @@
       }
     },
     "google-auth-library": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.0.2.tgz",
-      "integrity": "sha512-vjyNZR3pDLC0u7GHLfj+Hw9tGprrJwoMwkYGqURCXYITjCrP9HprOyxVV+KekdLgATtWGuDkQG2MTh0qpUPUgg==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.0.4.tgz",
+      "integrity": "sha512-o8irYyeijEiecTXeoEe8UKNEzV1X+uhR4b2oNdapDMZixypp0J+eHimGOyx5Joa3UAeokGngdtDLXtq9vDqG2Q==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -2707,12 +2774,12 @@
       }
     },
     "google-gax": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.11.2.tgz",
-      "integrity": "sha512-PNqXv7Oi5XBMgoMWVxLZHUidfMv7cPHrDSDXqLyEd6kY6pqFnVKC8jt2T1df4JPSc2+VLPdeo6L7X9mbdQG8Xw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.12.0.tgz",
+      "integrity": "sha512-UDx4ZZx85vXBe6GZ0sdRSzuegLrRQdRjCxlauX+U7i5YwOoSgcSaIM71BhcdHwGPhEkvO/SSHrEfc1wpL/J6JA==",
       "requires": {
-        "@grpc/grpc-js": "~1.2.0",
-        "@grpc/proto-loader": "^0.5.1",
+        "@grpc/grpc-js": "~1.3.0",
+        "@grpc/proto-loader": "^0.6.1",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
@@ -2720,6 +2787,7 @@
         "google-auth-library": "^7.0.2",
         "is-stream-ended": "^0.1.4",
         "node-fetch": "^2.6.1",
+        "object-hash": "^2.1.1",
         "protobufjs": "^6.10.2",
         "retry-request": "^4.0.0"
       }
@@ -2806,9 +2874,9 @@
       }
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -2847,11 +2915,11 @@
       "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ=="
     },
     "hbs": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.1.1.tgz",
-      "integrity": "sha512-6QsbB4RwbpL4cb4DNyjEEPF+suwp+3yZqFVlhILEn92ScC0U4cDCR+FDX53jkfKJPhutcqhAvs+rOLZw5sQrDA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.1.2.tgz",
+      "integrity": "sha512-WfBnQbozbdiTLjJu6P6Wturgvy0FN8xtRmIjmP0ebX9OGQrt+2S6UC7xX0IebHTCS1sXe20zfTzQ7yhjrEvrfQ==",
       "requires": {
-        "handlebars": "4.7.6",
+        "handlebars": "4.7.7",
         "walk": "2.3.14"
       }
     },
@@ -3031,9 +3099,9 @@
       }
     },
     "ioredis": {
-      "version": "4.24.3",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.24.3.tgz",
-      "integrity": "sha512-ANE2YT2fCa+KE0EUmx8VMZuJ+LaTNVXhjyAUDAxom9nqJGAXzCbNBMcujrUSJbz6xc2ZMaMxGB5y10cfYo/0IA==",
+      "version": "4.27.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.2.tgz",
+      "integrity": "sha512-7OpYymIthonkC2Jne5uGWXswdhlua1S1rWGAERaotn0hGJWTSURvxdHA9G6wNbT/qKCloCja/FHsfKXW8lpTmg==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.1",
@@ -3249,6 +3317,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
       "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -3628,16 +3697,16 @@
       "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
     },
     "mime-db": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
     },
     "mime-types": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
       "requires": {
-        "mime-db": "1.46.0"
+        "mime-db": "1.47.0"
       }
     },
     "mimic-fn": {
@@ -3938,12 +4007,17 @@
         "path-key": "^3.0.0"
       }
     },
+    "object-hash": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.1.1.tgz",
+      "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ=="
+    },
     "octokit-auth-probot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/octokit-auth-probot/-/octokit-auth-probot-1.2.3.tgz",
-      "integrity": "sha512-SQE+buuW3mnin1T4qBihY9ATsOVLXIP2xK6rBdVI2wUHYENjj9pSWtMPBcq9hYjMhKSW2i0Nqr17LcpEx3jpCA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/octokit-auth-probot/-/octokit-auth-probot-1.2.4.tgz",
+      "integrity": "sha512-u/3Xl1sZ5Scppk1v1Qtvkg75OslVEFBN9F8pBlVrJBCthmuukEKEHYTNP3yJcTvkYSAaFAqrZMngG92Pf/Y+Eg==",
       "requires": {
-        "@octokit/auth-app": "^3.0.0",
+        "@octokit/auth-app": "^3.3.0",
         "@octokit/auth-token": "^2.4.4",
         "@octokit/auth-unauthenticated": "^2.0.2",
         "@octokit/types": "^6.1.1"
@@ -4125,15 +4199,15 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
     "pino": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.2.tgz",
-      "integrity": "sha512-bmzxwbrIPxQUlAuMkF4PWVErUGERU4z37HazlhflKFg08crsNE3fACGN6gPwg5xtKOK47Ux5cZm8YCuLV4wWJg==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.3.tgz",
+      "integrity": "sha512-drPtqkkSf0ufx2gaea3TryFiBHdNIdXKf5LN0hTM82SXI4xVIve2wLwNg92e1MT6m3jASLu6VO7eGY6+mmGeyw==",
       "requires": {
         "fast-redact": "^3.0.0",
         "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.12",
         "pino-std-serializers": "^3.1.0",
-        "quick-format-unescaped": "4.0.1",
+        "quick-format-unescaped": "^4.0.3",
         "sonic-boom": "^1.0.2"
       }
     },
@@ -4213,14 +4287,14 @@
       }
     },
     "probot": {
-      "version": "11.0.6",
-      "resolved": "https://registry.npmjs.org/probot/-/probot-11.0.6.tgz",
-      "integrity": "sha512-KvX931ZXno/jveNbMk+1QeWa63XOJWfnGHDGiE1R+r54VHEg7dQAeLpaOjTX34DiZpTlFUvyulXZoFMDFnQsYQ==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-11.3.0.tgz",
+      "integrity": "sha512-Af+CJJ9MR982HnMRThzOUnp9QKKjxmpkzi5y0mHeAE6Rk7PXwuFcfIZlT1+L5CjLYkEhcTJhucrgzGW4QUJ8Pw==",
       "requires": {
         "@octokit/core": "^3.2.4",
         "@octokit/plugin-enterprise-compatibility": "^1.2.8",
         "@octokit/plugin-paginate-rest": "^2.6.2",
-        "@octokit/plugin-rest-endpoint-methods": "^4.4.1",
+        "@octokit/plugin-rest-endpoint-methods": "^5.0.1",
         "@octokit/plugin-retry": "^3.0.6",
         "@octokit/plugin-throttling": "^3.3.4",
         "@octokit/types": "^6.1.1",
@@ -4272,9 +4346,9 @@
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -4299,9 +4373,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
-      "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -4314,15 +4388,8 @@
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.47",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.47.tgz",
-          "integrity": "sha512-R6851wTjN1YJza8ZIeX6puNBSi/ZULHVh4WVleA7q256l+cP2EtXnKbO455fTs2ytQk3dL9qkU+Wh8l/uROdKg=="
-        }
       }
     },
     "proxy-addr": {
@@ -4383,9 +4450,9 @@
       "dev": true
     },
     "quick-format-unescaped": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
-      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
+      "integrity": "sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg=="
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -4938,9 +5005,9 @@
       "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
     },
     "sonic-boom": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.0.tgz",
-      "integrity": "sha512-1xUAszhQBOrjk7uisbStQZYkZxD3vkYlCUw5qzOblWQ1ILN5v0dVPAs+QPgszzoPmbdWx6jyT9XiLJ95JdlLiQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
       "requires": {
         "atomic-sleep": "^1.0.0",
         "flatstr": "^1.0.12"
@@ -5271,9 +5338,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.2.tgz",
-      "integrity": "sha512-SbMu4D2Vo95LMC/MetNaso1194M1htEA+JrqE9Hk+G2DhI+itfS9TRu9ZKeCahLDNa/J3n4MqUJ/fOHMzQpRWw==",
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.5.tgz",
+      "integrity": "sha512-xtB8yEqIkn7zmOyS2zUNBsYCBRhDkvlNxMMY2smuJ/qA8NCHeQvKCF3i9Z4k8FJH4+PJvZRtMrPynfZ75+CSZw==",
       "optional": true
     },
     "unique-string": {

--- a/packages/trusted-contribution/package.json
+++ b/packages/trusted-contribution/package.json
@@ -27,7 +27,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "gcf-utils": "^7.1.1"
+    "gcf-utils": "^7.2.2"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",


### PR DESCRIPTION
We need the latest gcf-utils for metrics.

Refs: https://github.com/googleapis/repo-automation-bots/pull/1721