### PR TITLE
build: add next major label

### DIFF
--- a/packages/label-sync/src/labels.json
+++ b/packages/label-sync/src/labels.json
@@ -176,6 +176,11 @@
       "color": "86d9d7"
     },
     {
+      "name": "next major: breaking change",
+      "description": "this is a change that we should wait to bundle into the next major version",
+      "color": "b5e67b"
+    },
+    {
       "name": "samples",
       "description": "Issues that are directly related to samples.",
       "color": "9932CC"


### PR DESCRIPTION
So that we can bundle changes on repos and reduce the amount of breaking changes