### PR TITLE
feat(auto-label): support datascienceonramp label

### DIFF
--- a/packages/auto-label/src/helper.ts
+++ b/packages/auto-label/src/helper.ts
@@ -89,14 +89,8 @@ export function autoDetectLabel(
   let firstPart = match ? match[1] : title;
 
   // Remove common prefixes. For example,
-  // https://github.com/GoogleCloudPlatform/java-docs-samples/issues/3578 and
-  // https://github.com/GoogleCloudPlatform/python-docs-samples/issues/5657.
-  const trimPrefixes = [
-    'com.example.',
-    'com.google.',
-    'snippets.',
-    'data-science-onramp.',
-  ];
+  // https://github.com/GoogleCloudPlatform/java-docs-samples/issues/3578
+  const trimPrefixes = ['com.example.', 'com.google.', 'snippets.'];
   for (const prefix of trimPrefixes) {
     if (firstPart.startsWith(prefix)) {
       firstPart = firstPart.slice(prefix.length);

--- a/packages/auto-label/test/auto-label.ts
+++ b/packages/auto-label/test/auto-label.ts
@@ -842,7 +842,7 @@ describe('auto-label', () => {
         {title: 'fix(snippets.spanner.helper): ignored', want: 'api: spanner'},
         {title: 'snippets.video: ignored', want: 'api: videointelligence'},
         {
-          title: 'data-science-onramp.video-intelligence.ignored: ignored',
+          title: 'video-intelligence.ignored: ignored',
           want: 'api: videointelligence',
         },
         {title: 'unknown: ignored', want: undefined},


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/repo-automation-bots/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Now we have `api: datascienceonramp`, we need auto-label to not skip those. Previous had it ignored because the label was not available and to correctly label products.

Fixes #1649 🦕
