### PR TITLE
fix: use a token when cloning library repos

### DIFF
--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -69,7 +69,9 @@ export async function copyCodeAndCreatePullRequest(
   const cmd = newCmd(logger);
 
   // Clone the dest repo.
-  const cloneUrl = destRepo.getCloneUrl();
+  const cloneUrl = destRepo.getCloneUrl(
+    await octokitFactory.getGitHubShortLivedAccessToken()
+  );
   cmd(`git clone --single-branch "${cloneUrl}" ${destDir}`);
 
   // Check out a dest branch.


### PR DESCRIPTION
so that owl-bot can also clone private repos

Fixes https://github.com/googleapis/repo-automation-bots/issues/1738