### PR TITLE
fix(owl-bot): bump timeout for post-processor to 20 minutes

### DIFF
--- a/packages/owl-bot/cloud-build/update-pr.yaml
+++ b/packages/owl-bot/cloud-build/update-pr.yaml
@@ -84,3 +84,6 @@ steps:
       - origin
       - ${_PR_BRANCH}
     dir: ${_REPOSITORY}
+
+# allow 20 minutes for the post-processor image to run
+timeout: '1200s'


### PR DESCRIPTION
Fixes #1744
