### PR TITLE
chore: add release config for bot-config-utils

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages/datastore-lock": "0.1.0",
   "packages/datastore-lock": "1.0.0",
   "packages/gcf-utils": "7.2.2",
   "packages/mono-repo-publish": "1.1.2",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/datastore-lock": "0.1.0",
+  "packages/bot-config-utils": "0.1.0",
   "packages/datastore-lock": "1.0.0",
   "packages/gcf-utils": "7.2.2",
   "packages/mono-repo-publish": "1.1.2",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,9 @@
 {
   "bootstrap-sha": "12426076b2f8b66a0ea0af2fa77e566d99bfb649",
   "packages": {
+    "packages/bot-config-utils": {
+      "release-type": "node"
+    },
     "packages/gcf-utils": {
       "release-type": "node"
     },


### PR DESCRIPTION

#1770 is the `1.0.0` release.