### PR TITLE
fix(flakybot): use lock for updating an issue

### DIFF
--- a/packages/flakybot/package-lock.json
+++ b/packages/flakybot/package-lock.json
@@ -130,6 +130,60 @@
         }
       }
     },
+    "@github-automations/datastore-lock": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@github-automations/datastore-lock/-/datastore-lock-1.0.0.tgz",
+      "integrity": "sha512-SwP8sjG7vSys5nmOEOKc2+aUL+9gT+1mTrSdrI2rgCnAAzbnQOKOOdQCj47mjYThxVAZzBKqarizyik8OVgmIg==",
+      "requires": {
+        "@google-cloud/datastore": "^6.4.0",
+        "gcf-utils": "^7.2.2",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@octokit/plugin-enterprise-compatibility": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-1.2.11.tgz",
+          "integrity": "sha512-bFCxP7q1q2bzK/H9C+NW4JNmdlwvjYFh7+J0SEdjklo9Q0K40s9IhKC4+DUaoCYCVSJv8aiiXIp660Hc15SbtA==",
+          "requires": {
+            "@octokit/request-error": "^2.0.4",
+            "@octokit/types": "^6.0.3"
+          }
+        },
+        "gcf-utils": {
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-7.2.2.tgz",
+          "integrity": "sha512-4aHEORCXXRWvith4dCnprpfd0JJ4drwGQOq+uU9pthAL/PmALkzIbB3CB93vFw9UzFY8L1nRPKImrsogJ5hMhg==",
+          "requires": {
+            "@google-cloud/kms": "^2.0.0",
+            "@google-cloud/secret-manager": "^3.0.0",
+            "@google-cloud/storage": "^5.3.0",
+            "@google-cloud/tasks": "^2.0.0",
+            "@octokit/plugin-enterprise-compatibility": "1.2.11",
+            "@octokit/rest": "^18.5.2",
+            "@probot/octokit-plugin-config": "^1.0.0",
+            "@types/bunyan": "^1.8.6",
+            "@types/dotenv": "^6.1.1",
+            "@types/end-of-stream": "^1.4.0",
+            "@types/express": "^4.17.0",
+            "@types/into-stream": "^3.1.1",
+            "@types/ioredis": "^4.14.8",
+            "@types/lru-cache": "^5.1.0",
+            "@types/sonic-boom": "^0.7.0",
+            "@types/uuid": "^8.3.0",
+            "express": "^4.17.1",
+            "gaxios": "^4.0.0",
+            "get-stream": "^6.0.0",
+            "into-stream": "^6.0.0",
+            "octokit-auth-probot": "^1.2.4",
+            "pino": "^6.3.2",
+            "probot": "^11.1.1",
+            "tmp": "^0.2.0",
+            "uuid": "^8.3.0",
+            "yargs": "^16.0.0"
+          }
+        }
+      }
+    },
     "@google-cloud/common": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.6.0.tgz",
@@ -144,6 +198,22 @@
         "google-auth-library": "^7.0.2",
         "retry-request": "^4.1.1",
         "teeny-request": "^7.0.0"
+      }
+    },
+    "@google-cloud/datastore": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/datastore/-/datastore-6.4.0.tgz",
+      "integrity": "sha512-UpCaQejB/npGXUUNtBZ3RBOxJfFRWBzll8t1EzjU3Lv6I4zrbHP3frKAKRmYqox33aiLWPPKh+syEoK543gWog==",
+      "requires": {
+        "@google-cloud/promisify": "^2.0.0",
+        "arrify": "^2.0.1",
+        "concat-stream": "^2.0.0",
+        "extend": "^3.0.2",
+        "google-gax": "^2.9.2",
+        "is": "^3.3.0",
+        "pumpify": "^2.0.1",
+        "split-array-stream": "^2.0.0",
+        "stream-events": "^1.0.5"
       }
     },
     "@google-cloud/kms": {
@@ -1460,6 +1530,11 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -1758,6 +1833,17 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "configstore": {
       "version": "5.0.1",
@@ -3277,6 +3363,11 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -5341,6 +5432,14 @@
       "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
+    "split-array-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-2.0.0.tgz",
+      "integrity": "sha512-hmMswlVY91WvGMxs0k8MRgq8zb2mSen4FmDNc5AFiTWtrBpdZN6nwD6kROVe4vNL+ywrvbCKsWVCnEd4riELIg==",
+      "requires": {
+        "is-stream-ended": "^0.1.4"
+      }
+    },
     "split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -5613,6 +5712,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/packages/flakybot/package-lock.json
+++ b/packages/flakybot/package-lock.json
@@ -130,10 +130,10 @@
         }
       }
     },
-    "@github-automations/datastore-lock": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@github-automations/datastore-lock/-/datastore-lock-1.0.0.tgz",
-      "integrity": "sha512-SwP8sjG7vSys5nmOEOKc2+aUL+9gT+1mTrSdrI2rgCnAAzbnQOKOOdQCj47mjYThxVAZzBKqarizyik8OVgmIg==",
+    "@google-automations/datastore-lock": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@google-automations/datastore-lock/-/datastore-lock-2.0.0.tgz",
+      "integrity": "sha512-wjp33c/mjq+c/aj+kZzgeYoHNy0WGXaZFZcXZJErC6nkQS7CRcreCAH/GBcidJd8V2S+EkH7Tn6LJZ5IMKYzwA==",
       "requires": {
         "@google-cloud/datastore": "^6.4.0",
         "gcf-utils": "^7.2.2",

--- a/packages/flakybot/package.json
+++ b/packages/flakybot/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "ajv": "^8.3.0",
     "js-yaml": "^4.1.0",
-    "@github-automations/datastore-lock": "^1.0.0",
+    "@google-automations/datastore-lock": "^2.0.0",
     "@octokit/openapi-types": "^7.0.0",
     "@octokit/types": "^6.14.2",
     "@octokit/rest": "^18.5.3",

--- a/packages/flakybot/package.json
+++ b/packages/flakybot/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "ajv": "^8.3.0",
     "js-yaml": "^4.1.0",
+    "@github-automations/datastore-lock": "^1.0.0",
     "@octokit/openapi-types": "^7.0.0",
     "@octokit/types": "^6.14.2",
     "@octokit/rest": "^18.5.3",

--- a/packages/flakybot/src/flakybot.ts
+++ b/packages/flakybot/src/flakybot.ts
@@ -25,7 +25,7 @@
 // eslint-disable-next-line node/no-extraneous-import
 import {Probot, Logger} from 'probot';
 import xmljs from 'xml-js';
-import {DatastoreLock} from '@github-automations/datastore-lock';
+import {DatastoreLock} from '@google-automations/datastore-lock';
 // eslint-disable-next-line node/no-extraneous-import
 import {Octokit} from '@octokit/rest';
 import {components} from '@octokit/openapi-types';

--- a/packages/flakybot/test/flakybot.test.ts
+++ b/packages/flakybot/test/flakybot.test.ts
@@ -14,6 +14,7 @@
 
 import {resolve} from 'path';
 // eslint-disable-next-line node/no-extraneous-import
+import {DatastoreLock} from '@github-automations/datastore-lock';
 import {Probot, ProbotOctokit} from 'probot';
 import snapshot from 'snap-shot-it';
 import nock from 'nock';
@@ -52,6 +53,12 @@ function nockIssues(repo: string, issues: Array<{}> = []) {
       `/repos/GoogleCloudPlatform/${repo}/issues?per_page=100&labels=flakybot%3A%20issue&state=all`
     )
     .reply(200, issues);
+}
+
+function nockGetIssue(repo: string, issueNumber: number, issue: {}) {
+  return nock('https://api.github.com')
+    .get(`/repos/GoogleCloudPlatform/${repo}/issues/${issueNumber}`)
+    .reply(200, issue);
 }
 
 function nockNewIssue(repo: string) {
@@ -104,7 +111,15 @@ function nockIssuePatch(repo: string, issueNumber: number) {
 
 describe('flakybot', () => {
   let probot: Probot;
-
+  const sandbox = sinon.createSandbox();
+  const datastoreLockAcquireStub = sandbox.stub(
+    DatastoreLock.prototype,
+    'acquire'
+  );
+  const datastoreLockReleaseStub = sandbox.stub(
+    DatastoreLock.prototype,
+    'release'
+  );
   beforeEach(() => {
     probot = new Probot({
       githubToken: 'abc123',
@@ -114,6 +129,12 @@ describe('flakybot', () => {
       }),
     });
     probot.load(flakybot);
+    // DatastoreLock just succeeds.
+    datastoreLockAcquireStub.resolves(true);
+    datastoreLockReleaseStub.resolves(true);
+  });
+  afterEach(() => {
+    sandbox.reset();
   });
 
   describe('pullRequestHandler', () => {
@@ -418,16 +439,17 @@ describe('flakybot', () => {
           buildURL: 'http://example.com',
           testsFailed: true,
         };
-
+        const issues = [
+          {
+            title: formatTestCase({passed: false}),
+            number: 16,
+            body: 'Failure!',
+            state: 'open',
+          },
+        ];
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({passed: false}),
-              number: 16,
-              body: 'Failure!',
-              state: 'open',
-            },
-          ]),
+          nockIssues('golang-samples', issues),
+          nockGetIssue('golang-samples', 16, issues[0]),
           nockGetIssueComments('golang-samples', 16),
           nockIssueComment('golang-samples', 16),
           nockGetConfig('golang-samples', ''),
@@ -581,33 +603,34 @@ describe('flakybot', () => {
 
       it('comments on existing issue', async () => {
         const payload = buildPayload('one_failed.xml', 'golang-samples');
-
+        const issues = [
+          // Duplicate issue that's closed. The open one should be updated.
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
+              testCase: 'TestSample',
+              passed: false,
+            }),
+            number: 15,
+            body: 'Failure!',
+            state: 'closed',
+          },
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
+              testCase: 'TestSample',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+            state: 'open',
+          },
+        ];
         const scopes = [
-          nockIssues('golang-samples', [
-            // Duplicate issue that's closed. The open one should be updated.
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
-                testCase: 'TestSample',
-                passed: false,
-              }),
-              number: 15,
-              body: 'Failure!',
-              state: 'closed',
-            },
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
-                testCase: 'TestSample',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-              state: 'open',
-            },
-          ]),
+          nockIssues('golang-samples', issues),
+          nockGetIssue('golang-samples', 16, issues[1]),
           nockGetIssueComments('golang-samples', 16),
           nockIssueComment('golang-samples', 16),
           nockGetConfig('golang-samples', ''),
@@ -627,33 +650,35 @@ describe('flakybot', () => {
           'many_failed_same_pkg.xml',
           'golang-samples'
         );
-
+        const issues = [
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
+              testCase: 'TestBucketLock',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+            labels: [{name: 'flakybot: flaky'}],
+            state: 'open',
+          },
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
+              testCase: 'TestUniformBucketLevelAccess',
+              passed: false,
+            }),
+            number: 17,
+            body: 'Failure!',
+            state: 'open',
+          },
+        ];
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
-                testCase: 'TestBucketLock',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-              labels: [{name: 'flakybot: flaky'}],
-              state: 'open',
-            },
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
-                testCase: 'TestUniformBucketLevelAccess',
-                passed: false,
-              }),
-              number: 17,
-              body: 'Failure!',
-              state: 'open',
-            },
-          ]),
+          nockIssues('golang-samples', issues),
+          nockGetIssue('golang-samples', 16, issues[0]),
+          nockGetIssue('golang-samples', 17, issues[1]),
           nockGetIssueComments('golang-samples', 17),
           nockIssueComment('golang-samples', 17),
           nockGetConfig('golang-samples', ''),
@@ -674,32 +699,36 @@ describe('flakybot', () => {
           'golang-samples'
         );
 
+        const issues = [
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
+              testCase: 'TestBucketLock',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+            labels: [{name: 'flakybot: quiet'}],
+            state: 'open',
+          },
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
+              testCase: 'TestUniformBucketLevelAccess',
+              passed: false,
+            }),
+            number: 17,
+            body: 'Failure!',
+            state: 'open',
+          },
+        ];
+
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
-                testCase: 'TestBucketLock',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-              labels: [{name: 'flakybot: quiet'}],
-              state: 'open',
-            },
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/storage/buckets',
-                testCase: 'TestUniformBucketLevelAccess',
-                passed: false,
-              }),
-              number: 17,
-              body: 'Failure!',
-              state: 'open',
-            },
-          ]),
+          nockIssues('golang-samples', issues),
+          nockGetIssue('golang-samples', 16, issues[0]),
+          nockGetIssue('golang-samples', 17, issues[1]),
           nockGetIssueComments('golang-samples', 17),
           nockIssueComment('golang-samples', 17),
           nockGetConfig('golang-samples', ''),
@@ -737,30 +766,31 @@ describe('flakybot', () => {
         // Closed yesterday. So, it should be reopened.
         const closedAt = new Date();
         closedAt.setDate(closedAt.getDate() - 1);
-
+        const issues = [
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
+              testCase: 'TestSample',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+            // All of these labels should be kept. New priority and type
+            // labels should not be added.
+            labels: [
+              {name: 'flakybot: flaky'},
+              {name: 'api: spanner'},
+              {name: 'priority: p2'},
+              {name: 'type: cleanup'},
+            ],
+            state: 'closed',
+            closed_at: closedAt.toISOString(),
+          },
+        ];
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
-                testCase: 'TestSample',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-              // All of these labels should be kept. New priority and type
-              // labels should not be added.
-              labels: [
-                {name: 'flakybot: flaky'},
-                {name: 'api: spanner'},
-                {name: 'priority: p2'},
-                {name: 'type: cleanup'},
-              ],
-              state: 'closed',
-              closed_at: closedAt.toISOString(),
-            },
-          ]),
+          nockIssues('golang-samples', issues),
+          nockGetIssue('golang-samples', 16, issues[0]),
           nockIssueComment('golang-samples', 16),
           nockIssuePatch('golang-samples', 16),
           nockGetConfig('golang-samples', ''),
@@ -777,19 +807,20 @@ describe('flakybot', () => {
 
       it('closes an issue for a passing test [Go]', async () => {
         const payload = buildPayload('passed.xml', 'golang-samples');
+        const issues = [
+          {
+            title: formatTestCase({
+              package: 'github.com/GoogleCloudPlatform/golang-samples',
+              testCase: 'TestBadFiles',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+          },
+        ];
 
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package: 'github.com/GoogleCloudPlatform/golang-samples',
-                testCase: 'TestBadFiles',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-            },
-          ]),
+          nockIssues('golang-samples', issues),
           nockIssueComment('golang-samples', 16),
           nockGetIssueComments('golang-samples', 16),
           nockIssuePatch('golang-samples', 16),
@@ -810,19 +841,20 @@ describe('flakybot', () => {
           'python_one_passed.xml',
           'python-docs-samples'
         );
+        const issues = [
+          {
+            title: formatTestCase({
+              package: 'appengine.standard.app_identity.asserting.main_test',
+              testCase: 'test_app',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+          },
+        ];
 
         const scopes = [
-          nockIssues('python-docs-samples', [
-            {
-              title: formatTestCase({
-                package: 'appengine.standard.app_identity.asserting.main_test',
-                testCase: 'test_app',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-            },
-          ]),
+          nockIssues('python-docs-samples', issues),
           nockIssueComment('python-docs-samples', 16),
           nockGetIssueComments('python-docs-samples', 16),
           nockIssuePatch('python-docs-samples', 16),
@@ -840,19 +872,20 @@ describe('flakybot', () => {
 
       it('closes an issue for a passing test [Java]', async () => {
         const payload = buildPayload('java_one_passed.xml', 'java-vision');
+        const issues = [
+          {
+            title: formatTestCase({
+              package: 'com.google.cloud.vision.it.ITSystemTest(sponge_log)',
+              testCase: 'detectLocalizedObjectsTest',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+          },
+        ];
 
         const scopes = [
-          nockIssues('java-vision', [
-            {
-              title: formatTestCase({
-                package: 'com.google.cloud.vision.it.ITSystemTest(sponge_log)',
-                testCase: 'detectLocalizedObjectsTest',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-            },
-          ]),
+          nockIssues('java-vision', issues),
           nockIssueComment('java-vision', 16),
           nockGetIssueComments('java-vision', 16),
           nockIssuePatch('java-vision', 16),
@@ -870,20 +903,21 @@ describe('flakybot', () => {
 
       it('does not close an issue that did not explicitly pass', async () => {
         const payload = buildPayload('passed.xml', 'golang-samples');
+        const issues = [
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/fake/test',
+              testCase: 'TestFake',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+          },
+        ];
 
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/fake/test',
-                testCase: 'TestFake',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-            },
-          ]),
+          nockIssues('golang-samples', issues),
           nockGetConfig('golang-samples', ''),
         ];
 
@@ -898,19 +932,20 @@ describe('flakybot', () => {
 
       it('keeps an issue open for a passing test that failed in the same build (comment)', async () => {
         const payload = buildPayload('passed.xml', 'golang-samples');
+        const issues = [
+          {
+            title: formatTestCase({
+              package: 'github.com/GoogleCloudPlatform/golang-samples',
+              testCase: 'TestBadFiles',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+          },
+        ];
 
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package: 'github.com/GoogleCloudPlatform/golang-samples',
-                testCase: 'TestBadFiles',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-            },
-          ]),
+          nockIssues('golang-samples', issues),
           nock('https://api.github.com')
             .get('/repos/GoogleCloudPlatform/golang-samples/issues/16/comments')
             .reply(200, [
@@ -935,21 +970,22 @@ describe('flakybot', () => {
 
       it('keeps an issue open for a passing test that failed in the same build (issue body)', async () => {
         const payload = buildPayload('passed.xml', 'golang-samples');
+        const issues = [
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/appengine/go11x/helloworld',
+              testCase: 'TestIndexHandler',
+              passed: false,
+            }),
+            number: 16,
+            body:
+              'status: failed\ncommit: 123\nbuildURL: [Build Status](example.com/failure)',
+          },
+        ];
 
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/appengine/go11x/helloworld',
-                testCase: 'TestIndexHandler',
-                passed: false,
-              }),
-              number: 16,
-              body:
-                'status: failed\ncommit: 123\nbuildURL: [Build Status](example.com/failure)',
-            },
-          ]),
+          nockIssues('golang-samples', issues),
           nockIssueComment('golang-samples', 16),
           nockIssuePatch('golang-samples', 16),
           nockGetConfig('golang-samples', ''),
@@ -966,20 +1002,22 @@ describe('flakybot', () => {
 
       it('does not comment for failure in the same build [Go]', async () => {
         const payload = buildPayload('one_failed.xml', 'golang-samples');
+        const issues = [
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
+              testCase: 'TestSample',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+          },
+        ];
 
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
-                testCase: 'TestSample',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-            },
-          ]),
+          nockIssues('golang-samples', issues),
+          nockGetIssue('golang-samples', 16, issues[0]),
           nock('https://api.github.com')
             .get('/repos/GoogleCloudPlatform/golang-samples/issues/16/comments')
             .reply(200, [
@@ -1001,21 +1039,22 @@ describe('flakybot', () => {
 
       it('keeps an issue open for a passing flaky test', async () => {
         const payload = buildPayload('passed.xml', 'golang-samples');
+        const issues = [
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
+              testCase: 'TestSample',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+            labels: [{name: 'flakybot: flaky'}],
+          },
+        ];
 
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
-                testCase: 'TestSample',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-              labels: [{name: 'flakybot: flaky'}],
-            },
-          ]),
+          nockIssues('golang-samples', issues),
           nockGetConfig('golang-samples', ''),
         ];
 
@@ -1033,21 +1072,22 @@ describe('flakybot', () => {
           'many_failed_same_pkg.xml',
           'golang-samples'
         );
+        const issues = [
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
+              testCase: 'TestSample',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+            state: 'closed',
+          },
+        ];
 
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
-                testCase: 'TestSample',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-              state: 'closed',
-            },
-          ]),
+          nockIssues('golang-samples', issues),
           nockNewIssue('golang-samples'),
           nockNewIssue('golang-samples'),
           nockGetConfig('golang-samples', ''),
@@ -1130,23 +1170,25 @@ describe('flakybot', () => {
           testCase: 'TestSample',
           passed: false,
         });
+        const issues = [
+          {
+            title,
+            number: 18,
+            body: 'Failure!',
+            state: 'closed',
+          },
+          {
+            title,
+            number: 19,
+            body: 'Failure!',
+            labels: [{name: 'flakybot: flaky'}],
+            state: 'closed',
+          },
+        ];
 
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title,
-              number: 18,
-              body: 'Failure!',
-              state: 'closed',
-            },
-            {
-              title,
-              number: 19,
-              body: 'Failure!',
-              labels: [{name: 'flakybot: flaky'}],
-              state: 'closed',
-            },
-          ]),
+          nockIssues('golang-samples', issues),
+          nockGetIssue('golang-samples', 19, issues[1]),
           nockIssueComment('golang-samples', 19),
           nockIssuePatch('golang-samples', 19),
           nockGetConfig('golang-samples', ''),
@@ -1176,23 +1218,26 @@ describe('flakybot', () => {
         const fiveDaysAgo = new Date();
         fiveDaysAgo.setDate(fiveDaysAgo.getDate() - 5);
 
+        const issues = [
+          {
+            title,
+            number: 18,
+            body: 'Failure!',
+            state: 'closed',
+            closed_at: sixDaysAgo.toISOString(),
+          },
+          {
+            title,
+            number: 19, // Newer issue closed more recently.
+            body: 'Failure!',
+            state: 'closed',
+            closed_at: fiveDaysAgo.toISOString(),
+          },
+        ];
+
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title,
-              number: 18,
-              body: 'Failure!',
-              state: 'closed',
-              closed_at: sixDaysAgo.toISOString(),
-            },
-            {
-              title,
-              number: 19, // Newer issue closed more recently.
-              body: 'Failure!',
-              state: 'closed',
-              closed_at: fiveDaysAgo.toISOString(),
-            },
-          ]),
+          nockIssues('golang-samples', issues),
+          nockGetIssue('golang-samples', 19, issues[1]),
           nockIssueComment('golang-samples', 19),
           nockIssuePatch('golang-samples', 19),
           nockGetConfig('golang-samples', ''),
@@ -1227,22 +1272,24 @@ describe('flakybot', () => {
 
       it('opens a new issue when the original is locked [Go]', async () => {
         const payload = buildPayload('one_failed.xml', 'golang-samples');
+        const issues = [
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
+              testCase: 'TestSample',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+            state: 'closed',
+            locked: true,
+          },
+        ];
 
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
-                testCase: 'TestSample',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-              state: 'closed',
-              locked: true,
-            },
-          ]),
+          nockIssues('golang-samples', issues),
+          nockGetIssue('golang-samples', 16, issues[0]),
           nockNewIssue('golang-samples'),
           nockGetConfig('golang-samples', ''),
         ];
@@ -1261,21 +1308,24 @@ describe('flakybot', () => {
 
         const closedAt = new Date();
         closedAt.setDate(closedAt.getDate() - 20);
+
+        const issues = [
+          {
+            title: formatTestCase({
+              package:
+                'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
+              testCase: 'TestSample',
+              passed: false,
+            }),
+            number: 16,
+            body: 'Failure!',
+            state: 'closed',
+            closed_at: closedAt.toISOString(),
+          },
+        ];
         const scopes = [
-          nockIssues('golang-samples', [
-            {
-              title: formatTestCase({
-                package:
-                  'github.com/GoogleCloudPlatform/golang-samples/spanner/spanner_snippets',
-                testCase: 'TestSample',
-                passed: false,
-              }),
-              number: 16,
-              body: 'Failure!',
-              state: 'closed',
-              closed_at: closedAt.toISOString(),
-            },
-          ]),
+          nockIssues('golang-samples', issues),
+          nockGetIssue('golang-samples', 16, issues[0]),
           nockNewIssue('golang-samples'),
           nockGetConfig('golang-samples', ''),
         ];
@@ -1290,6 +1340,13 @@ describe('flakybot', () => {
       });
 
       describe('Grouped issues', () => {
+        const groupedIssue = {
+          title: flakybot.formatGroupedTitle('Spanner'),
+          number: 10,
+          body: 'Group failure!',
+          state: 'open',
+        };
+
         it('opens a single issue for many tests in the same package', async () => {
           const payload = buildPayload('node_group.xml', 'nodejs-spanner');
 
@@ -1336,13 +1393,9 @@ describe('flakybot', () => {
                 body: 'Failed',
                 state: 'open,',
               },
-              {
-                title: flakybot.formatGroupedTitle('Spanner'),
-                number: 10,
-                body: 'Group failure!',
-                state: 'open',
-              },
+              groupedIssue,
             ]),
+            nockGetIssue('nodejs-spanner', 10, groupedIssue),
             nockGetIssueComments('nodejs-spanner', 10),
             nockIssueComment('nodejs-spanner', 10),
             nockGetIssueComments('nodejs-spanner', 9),
@@ -1365,14 +1418,8 @@ describe('flakybot', () => {
 
           const testCase = flakybot.groupedTestCase('Spanner');
           const scopes = [
-            nockIssues('nodejs-spanner', [
-              {
-                title: flakybot.formatGroupedTitle('Spanner'),
-                number: 10,
-                body: 'Group failure!',
-                state: 'open',
-              },
-            ]),
+            nockIssues('nodejs-spanner', [groupedIssue]),
+            nockGetIssue('nodejs-spanner', 10, groupedIssue),
             nockGetIssueComments('nodejs-spanner', 10, [
               {
                 body: flakybot.formatBody(testCase, '123', 'build.url'),
@@ -1405,12 +1452,7 @@ describe('flakybot', () => {
                 body: 'Failed',
                 state: 'open,',
               },
-              {
-                title: flakybot.formatGroupedTitle('Spanner'),
-                number: 10,
-                body: 'Group failure!',
-                state: 'open',
-              },
+              groupedIssue,
             ]),
             nockIssueComment('nodejs-spanner', 9),
             nockGetIssueComments('nodejs-spanner', 9),

--- a/packages/flakybot/test/flakybot.test.ts
+++ b/packages/flakybot/test/flakybot.test.ts
@@ -14,7 +14,7 @@
 
 import {resolve} from 'path';
 // eslint-disable-next-line node/no-extraneous-import
-import {DatastoreLock} from '@github-automations/datastore-lock';
+import {DatastoreLock} from '@google-automations/datastore-lock';
 import {Probot, ProbotOctokit} from 'probot';
 import snapshot from 'snap-shot-it';
 import nock from 'nock';


### PR DESCRIPTION
fixes #483

I think this will fix #483.
This PR acquires a lock per issue. Another approach is to acquire a lock per repo, but I think it'll be problematic because one build may contain many test failures and taking a long time to process.
