### PR TITLE
fix(bot-config-utils): fix getConfig

### DIFF
--- a/packages/bot-config-utils/src/bot-config-utils.ts
+++ b/packages/bot-config-utils/src/bot-config-utils.ts
@@ -17,7 +17,6 @@ import yaml from 'js-yaml';
 import path from 'path';
 
 import {Octokit} from '@octokit/rest';
-
 import {logger} from 'gcf-utils';
 
 type Conclusion =

--- a/packages/bot-config-utils/src/bot-config-utils.ts
+++ b/packages/bot-config-utils/src/bot-config-utils.ts
@@ -17,6 +17,7 @@ import yaml from 'js-yaml';
 import path from 'path';
 
 import {Octokit} from '@octokit/rest';
+
 import {logger} from 'gcf-utils';
 
 type Conclusion =
@@ -35,6 +36,14 @@ export interface OctokitContext {
 export interface ValidateConfigResult {
   isValid: boolean;
   errorText: string | undefined;
+}
+
+interface File {
+  content: string | undefined;
+}
+
+function isFile(file: File | unknown): file is File {
+  return (file as File).content !== undefined;
 }
 
 export class ConfigChecker<T> {
@@ -151,9 +160,16 @@ export async function getConfig<T>(
       repo: repo,
       path: path,
     });
-    const loaded =
-      yaml.load(Buffer.from(resp.data.toString(), 'base64').toString()) || {};
-    return Object.assign({}, undefined, loaded);
+    if (isFile(resp.data)) {
+      const loaded =
+        yaml.load(
+          Buffer.from(resp.data.content.toString(), 'base64').toString()
+        ) || {};
+      return Object.assign({}, undefined, loaded);
+    } else {
+      // This should not happen.
+      throw new Error('could not handle getContent result.');
+    }
   } catch (err) {
     if (err.status === 404 && repo !== '.github') {
       // Try to get it from the `.github` repo.
@@ -163,10 +179,16 @@ export async function getConfig<T>(
           repo: '.github',
           path: path,
         });
-        const loaded =
-          yaml.load(Buffer.from(resp.data.toString(), 'base64').toString()) ||
-          {};
-        return Object.assign({}, undefined, loaded);
+        if (isFile(resp.data)) {
+          const loaded =
+            yaml.load(
+              Buffer.from(resp.data.content.toString(), 'base64').toString()
+            ) || {};
+          return Object.assign({}, undefined, loaded);
+        } else {
+          // This should not happen.
+          throw new Error('could not handle getContent result.');
+        }
       } catch (err) {
         if (err.status === 404) {
           return null;
@@ -194,9 +216,16 @@ export async function getConfigWithDefault<T>(
       repo: repo,
       path: path,
     });
-    const loaded =
-      yaml.load(Buffer.from(resp.data.toString(), 'base64').toString()) || {};
-    return Object.assign({}, defaultConfig, loaded);
+    if (isFile(resp.data)) {
+      const loaded =
+        yaml.load(
+          Buffer.from(resp.data.content.toString(), 'base64').toString()
+        ) || {};
+      return Object.assign({}, defaultConfig, loaded);
+    } else {
+      // This should not happen.
+      throw new Error('could not handle getContent result.');
+    }
   } catch (err) {
     if (err.status === 404 && repo !== '.github') {
       // Try to get it from the `.github` repo.
@@ -206,10 +235,16 @@ export async function getConfigWithDefault<T>(
           repo: '.github',
           path: path,
         });
-        const loaded =
-          yaml.load(Buffer.from(resp.data.toString(), 'base64').toString()) ||
-          {};
-        return Object.assign({}, defaultConfig, loaded);
+        if (isFile(resp.data)) {
+          const loaded =
+            yaml.load(
+              Buffer.from(resp.data.content.toString(), 'base64').toString()
+            ) || {};
+          return Object.assign({}, defaultConfig, loaded);
+        } else {
+          // This should not happen.
+          throw new Error('could not handle getContent result.');
+        }
       } catch (err) {
         if (err.status === 404) {
           return defaultConfig;

--- a/packages/bot-config-utils/test/bot-config-utils.ts
+++ b/packages/bot-config-utils/test/bot-config-utils.ts
@@ -240,13 +240,35 @@ function getConfigFile(
   status: number,
   responseFile?: string
 ) {
-  let config: Buffer;
+  const response = {
+    name: '',
+    path: '',
+    sha: '',
+    size: 48,
+    url: '',
+    html_url: '',
+    git_url: '',
+    download_url: '',
+    type: 'file',
+    content: '',
+    encoding: 'base64',
+    _links: {
+      self: '',
+      git: '',
+      html: '',
+    },
+  };
   if (status === 200) {
     if (responseFile) {
-      config = fs.readFileSync(resolve(fixturesPath, responseFile));
+      const config = fs.readFileSync(resolve(fixturesPath, responseFile));
+      const content = config.toString('base64');
+      response.name = responseFile;
+      response.path = `.github/${responseFile}`;
+      response.content = content;
+      response.size = content.length;
       return nock('https://api.github.com')
         .get(`/repos/${owner}/${repo}/contents/.github%2F${filename}`)
-        .reply(200, Buffer.from(config).toString('base64'));
+        .reply(200, response);
     } else {
       throw Error('responseFile is needed for status 200');
     }


### PR DESCRIPTION
fixes #1784

@github-automations/bot-config-utils 1.0.0 has a bug in getConfig and getConfigWithDefault.

This is because of the weirdness of the response type of getContent.
The tests were passing because the tests were incorrectly returning config files.

Now the tests are returning responses similar to the actual API.
