### PR TITLE
docs(google-automations): fix the package name in README

### DIFF
--- a/packages/bot-config-utils/README.md
+++ b/packages/bot-config-utils/README.md
@@ -5,7 +5,7 @@ This is a small library for handling bot config file.
 ## Install
 
 ```bash
-npm i @github-automations/bot-config-utils
+npm i @google-automations/bot-config-utils
 ```
 
 ## Get the config
@@ -16,7 +16,7 @@ interface. The code assumes we're in the probot handler.
 ```typescript
 import {
   getConfig,
-} from '@github-automations/bot-config-utils';
+} from '@google-automations/bot-config-utils';
 
 interface Config {
   myConfig: string;
@@ -38,7 +38,7 @@ You can use a similar method that supports default value.
 ```typescript
 import {
   getConfigWithDefault,
-} from '@github-automations/bot-config-utils';
+} from '@google-automations/bot-config-utils';
 
 interface Config {
   myConfig: string;
@@ -88,7 +88,7 @@ You also need to provide a schema definition. Here is an example definition:
 
 Here is a sample handler(this assumes you're developping a Probot app):
 ```typescript
-import {ConfigChecker} from '@github-automations/bot-config-utils';
+import {ConfigChecker} from '@google-automations/bot-config-utils';
 import schema from './config-schema.json';
 
 // ...

--- a/packages/datastore-lock/README.md
+++ b/packages/datastore-lock/README.md
@@ -11,13 +11,13 @@ library allows the bot to acquire a lock on sth.
 ### Install
 
 ```bash
-npm i @github-automations/datastore-lock
+npm i @google-automations/datastore-lock
 ```
 
 ### Usage
 
 ```typescript
-import {DatastoreLock} from '@github-automations/datastore-lock';
+import {DatastoreLock} from '@google-automations/datastore-lock';
 
 // Most of the cases, you can just pass `lockId` and `target`.
 // `lockId` is usually the bot name.


### PR DESCRIPTION
This PR is just to fix the package name in the READMEs.
