### PR TITLE
fix: use the docker image provided by actools team for bazel bot

### DIFF
--- a/packages/bazel-bot/docker-image/Dockerfile
+++ b/packages/bazel-bot/docker-image/Dockerfile
@@ -25,7 +25,7 @@ RUN cargo build --release
 
 ##########################################################
 # Build the image.
-FROM gcr.io/gapic-images/googleapis-bazel
+FROM gcr.io/gapic-images/googleapis:prod
 COPY --from=0 /jwt-cli/target/release/jwt /bin/jwt
 
 # Install the github command line tool, and jq to parse json responses.
@@ -34,17 +34,6 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
 RUN apt-add-repository https://cli.github.com/packages
 RUN apt-get update
 RUN apt-get install -y gh jq
-
-# TODO: Remove this chunk when it gets added to the upstream gcr.io/gapic-images/googleapis-bazel
-### Requirement: Set the correct locale so Ruby strings default to UTF-8, needed for template engine to work
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    locales \
-    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
-    && locale-gen en_US.UTF-8 \
-    && rm -f /var/lib/apt/lists/*_*
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en
 
 # Copy the source files from this directory.
 COPY generate-googleapis-gen.sh /generate-googleapis-gen.sh


### PR DESCRIPTION
Using actools' team's docker image makes it less likely that bazel bot will fail when the googleapis/googleapis kokoro build test succeeds.

cc @vam-google 