### PR TITLE
fix(bot-config-utils)!: match the return type of getConfigs

### DIFF
--- a/packages/bot-config-utils/src/bot-config-utils.ts
+++ b/packages/bot-config-utils/src/bot-config-utils.ts
@@ -51,12 +51,13 @@ export class ConfigChecker<T> {
   private configPath: string;
   private badConfigPaths: Array<string>;
   private configName: string;
-  private config: T | undefined;
+  private config: T | null;
   constructor(schema: object, configFileName: string) {
     this.schema = schema;
     this.ajv = new Ajv();
     this.configPath = `.github/${configFileName}`;
     this.badConfigPaths = new Array<string>();
+    this.config = null;
     const parsed = path.parse(this.configPath);
     if (parsed.ext === '.yml') {
       this.badConfigPaths.push(`${parsed.dir}/${parsed.name}.yaml`);
@@ -87,7 +88,7 @@ export class ConfigChecker<T> {
     return {isValid: isValid, errorText: errorText};
   }
 
-  public getConfig(): T | undefined {
+  public getConfig(): T | null {
     return this.config;
   }
 

--- a/packages/bot-config-utils/test/bot-config-utils.ts
+++ b/packages/bot-config-utils/test/bot-config-utils.ts
@@ -41,7 +41,7 @@ const CONFIG_FILENAME_YML = 'test.yml';
 
 const defaultConfig: TestConfig = {testConfig: 'defaultValue'};
 
-let configFromConfigChecker: TestConfig | undefined;
+let configFromConfigChecker: TestConfig | null;
 
 // Test app
 const app = (app: Probot) => {
@@ -163,8 +163,8 @@ describe('config test app', () => {
       }),
     });
     probot.load(app);
-    // It always start from undefined.
-    configFromConfigChecker = undefined;
+    // It always start from null.
+    configFromConfigChecker = null;
   });
   afterEach(() => {
     nock.cleanAll();
@@ -205,7 +205,7 @@ describe('config test app', () => {
       for (const scope of scopes) {
         scope.done();
       }
-      assert.strictEqual(configFromConfigChecker, undefined);
+      assert.strictEqual(configFromConfigChecker, null);
     });
     it('creates a failing status check for broken yaml file', async () => {
       const payload = require(resolve(fixturesPath, 'pr_event'));
@@ -222,7 +222,7 @@ describe('config test app', () => {
       for (const scope of scopes) {
         scope.done();
       }
-      assert.strictEqual(configFromConfigChecker, undefined);
+      assert.strictEqual(configFromConfigChecker, null);
     });
     it('creates a failing status check for a wrong file name', async () => {
       const payload = require(resolve(fixturesPath, 'pr_event'));
@@ -237,7 +237,7 @@ describe('config test app', () => {
       for (const scope of scopes) {
         scope.done();
       }
-      assert.strictEqual(configFromConfigChecker, undefined);
+      assert.strictEqual(configFromConfigChecker, null);
     });
   });
 });


### PR DESCRIPTION
I made a mistake in 2.1.0.
I should match the return type of ConfigChecker.getConfig() and
getConfig().

This PR fixes this inconsistency.

Strictly saying this is a breaking change, so I'd release it as 3.0.0.