### PR TITLE
fix(header-checker-lint): use config from PR head

### DIFF
--- a/packages/header-checker-lint/README.md
+++ b/packages/header-checker-lint/README.md
@@ -10,8 +10,8 @@ You can install this bot [from GitHub][github-app-link].
 ### Configuration
 
 To configure the bot, you can create a configuration file:
-`.github/header-checker-lint.yml`. The contents of this file define a JSON object
-with the following options:
+`.github/header-checker-lint.yml`. The contents of this yaml file
+define a JSON object with the following options:
 
 | Name | Description | Type | Default |
 |----- | ----------- | ---- | ------- |
@@ -19,6 +19,28 @@ with the following options:
 | `allowedLicenses` | The allowed licenses. | `string[]` | `["Apache-2.0", "MIT", "BSD-3"]` |
 | `ignoreFiles` | List of files to ignore. These values will be treated as path globs | `string[]` | `[]` |
 | `sourceFileExtensions` | List of file extensions that will be treated as source files | `string[]` | `["ts", "js", "java"]` |
+
+Here is the default configuration:
+
+```yaml
+allowedCopyrightHolders:
+  - 'Google LLC'
+allowedLicenses:
+  - 'Apache-2.0'
+  - 'MIT'
+  - 'BSD-3'
+sourceFileExtensions:
+  - 'ts'
+  - 'js'
+  - 'java'
+# ignoreFiles are empty
+```
+
+The config is not additive, so if you want to add ignoreFiles, you
+should copy other fields into your config file.
+
+Normally our bot reads configuration file from the default branch, but
+this bot is exceptionally reading the config file from the PR head.
 
 ## Development
 

--- a/packages/header-checker-lint/__snapshots__/header-checker-lint.js
+++ b/packages/header-checker-lint/__snapshots__/header-checker-lint.js
@@ -184,3 +184,14 @@ exports['HeaderCheckerLint updated pull request ignores a deleted file 1'] = {
     "text": "Header check successful"
   }
 }
+
+exports['HeaderCheckerLint opened pull request ignores due to the config from the PR head 1'] = {
+  "name": "header-check",
+  "conclusion": "success",
+  "head_sha": "87139750cdcf551e8fe8d90c129527a4f358321c",
+  "output": {
+    "title": "Headercheck",
+    "summary": "Header check successful",
+    "text": "Header check successful"
+  }
+}

--- a/packages/header-checker-lint/package-lock.json
+++ b/packages/header-checker-lint/package-lock.json
@@ -113,9 +113,9 @@
       }
     },
     "@google-automations/bot-config-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@google-automations/bot-config-utils/-/bot-config-utils-2.0.0.tgz",
-      "integrity": "sha512-LyjQE9m+Q7wGG+ccwroIsacMCbDj1DVIyYAFaUXA2fCd8zrlSIy5tatnAahCgkx+L33wacyRkO2QKgQI9XzMcA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@google-automations/bot-config-utils/-/bot-config-utils-2.1.0.tgz",
+      "integrity": "sha512-LutThTg5MIk0+vBlf3S7fnYeXLK7lLX6ZFWD41KfqazTJhVKB5vxNjS658Xbh7+fh8KJAsZ3MzuRT9tpDcCcfQ==",
       "requires": {
         "@octokit/rest": "^18.5.3",
         "@octokit/types": "^6.14.2",
@@ -124,56 +124,10 @@
         "js-yaml": "^4.1.0"
       },
       "dependencies": {
-        "@octokit/auth-app": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-3.4.0.tgz",
-          "integrity": "sha512-zBVgTnLJb0uoNMGCpcDkkAbPeavHX7oAjJkaDv2nqMmsXSsCw4AbUhjl99EtJQG/JqFY/kLFHM9330Wn0k70+g==",
-          "requires": {
-            "@octokit/auth-oauth-app": "^4.1.0",
-            "@octokit/auth-oauth-user": "^1.2.3",
-            "@octokit/request": "^5.4.11",
-            "@octokit/request-error": "^2.0.0",
-            "@octokit/types": "^6.0.3",
-            "@types/lru-cache": "^5.1.0",
-            "deprecation": "^2.3.1",
-            "lru-cache": "^6.0.0",
-            "universal-github-app-jwt": "^1.0.1",
-            "universal-user-agent": "^6.0.0"
-          }
-        },
         "@octokit/openapi-types": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.0.0.tgz",
           "integrity": "sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw=="
-        },
-        "@octokit/plugin-enterprise-compatibility": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-1.2.11.tgz",
-          "integrity": "sha512-bFCxP7q1q2bzK/H9C+NW4JNmdlwvjYFh7+J0SEdjklo9Q0K40s9IhKC4+DUaoCYCVSJv8aiiXIp660Hc15SbtA==",
-          "requires": {
-            "@octokit/request-error": "^2.0.4",
-            "@octokit/types": "^6.0.3"
-          }
-        },
-        "@octokit/plugin-rest-endpoint-methods": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz",
-          "integrity": "sha512-vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==",
-          "requires": {
-            "@octokit/types": "^6.13.1",
-            "deprecation": "^2.3.1"
-          }
-        },
-        "@octokit/rest": {
-          "version": "18.5.3",
-          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.3.tgz",
-          "integrity": "sha512-KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==",
-          "requires": {
-            "@octokit/core": "^3.2.3",
-            "@octokit/plugin-paginate-rest": "^2.6.2",
-            "@octokit/plugin-request-log": "^1.0.2",
-            "@octokit/plugin-rest-endpoint-methods": "5.0.1"
-          }
         },
         "@octokit/types": {
           "version": "6.14.2",
@@ -194,138 +148,18 @@
             "uri-js": "^4.2.2"
           }
         },
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "gcf-utils": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-7.2.2.tgz",
-          "integrity": "sha512-4aHEORCXXRWvith4dCnprpfd0JJ4drwGQOq+uU9pthAL/PmALkzIbB3CB93vFw9UzFY8L1nRPKImrsogJ5hMhg==",
-          "requires": {
-            "@google-cloud/kms": "^2.0.0",
-            "@google-cloud/secret-manager": "^3.0.0",
-            "@google-cloud/storage": "^5.3.0",
-            "@google-cloud/tasks": "^2.0.0",
-            "@octokit/plugin-enterprise-compatibility": "1.2.11",
-            "@octokit/rest": "^18.5.2",
-            "@probot/octokit-plugin-config": "^1.0.0",
-            "@types/bunyan": "^1.8.6",
-            "@types/dotenv": "^6.1.1",
-            "@types/end-of-stream": "^1.4.0",
-            "@types/express": "^4.17.0",
-            "@types/into-stream": "^3.1.1",
-            "@types/ioredis": "^4.14.8",
-            "@types/lru-cache": "^5.1.0",
-            "@types/sonic-boom": "^0.7.0",
-            "@types/uuid": "^8.3.0",
-            "express": "^4.17.1",
-            "gaxios": "^4.0.0",
-            "get-stream": "^6.0.0",
-            "into-stream": "^6.0.0",
-            "octokit-auth-probot": "^1.2.4",
-            "pino": "^6.3.2",
-            "probot": "^11.1.1",
-            "tmp": "^0.2.0",
-            "uuid": "^8.3.0",
-            "yargs": "^16.0.0"
-          }
-        },
         "js-yaml": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
           "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
           "requires": {
             "argparse": "^2.0.1"
-          },
-          "dependencies": {
-            "argparse": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-              "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-            }
           }
         },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        },
-        "octokit-auth-probot": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/octokit-auth-probot/-/octokit-auth-probot-1.2.4.tgz",
-          "integrity": "sha512-u/3Xl1sZ5Scppk1v1Qtvkg75OslVEFBN9F8pBlVrJBCthmuukEKEHYTNP3yJcTvkYSAaFAqrZMngG92Pf/Y+Eg==",
-          "requires": {
-            "@octokit/auth-app": "^3.3.0",
-            "@octokit/auth-token": "^2.4.4",
-            "@octokit/auth-unauthenticated": "^2.0.2",
-            "@octokit/types": "^6.1.1"
-          }
-        },
-        "probot": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/probot/-/probot-11.3.0.tgz",
-          "integrity": "sha512-Af+CJJ9MR982HnMRThzOUnp9QKKjxmpkzi5y0mHeAE6Rk7PXwuFcfIZlT1+L5CjLYkEhcTJhucrgzGW4QUJ8Pw==",
-          "requires": {
-            "@octokit/core": "^3.2.4",
-            "@octokit/plugin-enterprise-compatibility": "^1.2.8",
-            "@octokit/plugin-paginate-rest": "^2.6.2",
-            "@octokit/plugin-rest-endpoint-methods": "^5.0.1",
-            "@octokit/plugin-retry": "^3.0.6",
-            "@octokit/plugin-throttling": "^3.3.4",
-            "@octokit/types": "^6.1.1",
-            "@octokit/webhooks": "7.21.0",
-            "@probot/get-private-key": "^1.1.0",
-            "@probot/octokit-plugin-config": "^1.0.0",
-            "@probot/pino": "^2.2.0",
-            "@types/express": "^4.17.9",
-            "@types/ioredis": "^4.17.8",
-            "@types/pino": "^6.3.4",
-            "@types/pino-http": "^5.0.6",
-            "@types/update-notifier": "^5.0.0",
-            "commander": "^6.2.0",
-            "deepmerge": "^4.2.2",
-            "deprecation": "^2.3.1",
-            "dotenv": "^8.2.0",
-            "eventsource": "^1.0.7",
-            "express": "^4.17.1",
-            "hbs": "^4.1.1",
-            "ioredis": "^4.19.2",
-            "js-yaml": "^3.14.1",
-            "lru-cache": "^6.0.0",
-            "octokit-auth-probot": "^1.2.2",
-            "pino": "^6.7.0",
-            "pino-http": "^5.3.0",
-            "pkg-conf": "^3.1.0",
-            "resolve": "^1.19.0",
-            "semver": "^7.3.4",
-            "update-dotenv": "^1.1.1",
-            "update-notifier": "^5.0.1",
-            "uuid": "^8.3.2"
-          },
-          "dependencies": {
-            "js-yaml": {
-              "version": "3.14.1",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-              "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-              }
-            }
-          }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },

--- a/packages/header-checker-lint/package.json
+++ b/packages/header-checker-lint/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "gcf-utils": "^7.2.2",
-    "@google-automations/bot-config-utils": "^2.0.0",
+    "@google-automations/bot-config-utils": "^2.1.0",
     "minimatch": "^3.0.4"
   },
   "devDependencies": {

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -89,17 +89,22 @@ export = (app: Probot) => {
         context.payload.pull_request.head.sha,
         context.payload.pull_request.number
       );
+      const configFromHead = configChecker.getConfig();
       let remoteConfiguration: ConfigurationOptions | null;
-      try {
-        remoteConfiguration = await getConfig<ConfigurationOptions>(
-          context.octokit,
-          owner,
-          repo,
-          WELL_KNOWN_CONFIGURATION_FILE
-        );
-      } catch (err) {
-        logger.error('Error parsing configuration: ' + err);
-        return;
+      if (configFromHead) {
+        remoteConfiguration = configFromHead;
+      } else {
+        try {
+          remoteConfiguration = await getConfig<ConfigurationOptions>(
+            context.octokit,
+            owner,
+            repo,
+            WELL_KNOWN_CONFIGURATION_FILE
+          );
+        } catch (err) {
+          logger.error('Error parsing configuration: ' + err);
+          return;
+        }
       }
       const configuration = new Configuration({
         ...DEFAULT_CONFIGURATION,


### PR DESCRIPTION
fixes #1038

With this PR, the bot will start using config from PR head.

This will allow users to add header-checker-lint.yml file to suppress
false positives in the same PR.

With #1802, the code will be cleaner, but not a blocker.