### PR TITLE
fix(sync-repo-settings): check against the correct ref structure

### DIFF
--- a/packages/sync-repo-settings/src/bot.ts
+++ b/packages/sync-repo-settings/src/bot.ts
@@ -114,7 +114,7 @@ export function handler(app: Probot) {
   app.on('push', async context => {
     const branch = context.payload.ref;
     const defaultBranch = context.payload.repository.default_branch;
-    if (branch !== `refs/head/${defaultBranch}`) {
+    if (branch !== `refs/heads/${defaultBranch}`) {
       logger.info(`skipping non-default branch: ${branch}`);
       return;
     }

--- a/packages/sync-repo-settings/test/test.bot.ts
+++ b/packages/sync-repo-settings/test/test.bot.ts
@@ -398,7 +398,7 @@ describe('Sync repo settings', () => {
     await probot.receive({
       name: 'push',
       payload: {
-        ref: 'refs/head/main',
+        ref: 'refs/heads/main',
         repository: {
           name: repo,
           owner: {
@@ -421,7 +421,7 @@ describe('Sync repo settings', () => {
     await probot.receive({
       name: 'push',
       payload: {
-        ref: 'refs/head/not-default-lol',
+        ref: 'refs/heads/not-default-lol',
         repository: {
           name: repo,
           owner: {
@@ -450,7 +450,7 @@ describe('Sync repo settings', () => {
     await probot.receive({
       name: 'push',
       payload: {
-        ref: 'refs/head/main',
+        ref: 'refs/heads/main',
         repository: {
           name: repo,
           owner: {


### PR DESCRIPTION
The `ref` payload is actual `refs/heads/[BRANCH_NAME]`.

https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push

Fixes #1753
Fixes #1615
