### PR TITLE
fix(gcf-utils)!: fix getAuthenticatedOctokit

### DIFF
--- a/cloudbuild-test/Dockerfile
+++ b/cloudbuild-test/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM node:12-stretch
+
+USER root
+
+ENV PROJECT_ID=repo-automation-bots
+ENV GCF_SHORT_FUNCTION_NAME=snippet_bot
+ENV INSTALLATION_ID=9602930
+
+COPY . /workspace
+RUN cd /workspace/packages/gcf-utils && \
+    npm i && \
+    npm run system-test

--- a/cloudbuild-test/cloudbuild.yaml
+++ b/cloudbuild-test/cloudbuild.yaml
@@ -1,0 +1,3 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [ 'build', '--network=cloudbuild', '-t', 'test-result', '-f', 'cloudbuild-test/Dockerfile', '.']

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -397,12 +397,12 @@ export class GCFBootstrapper {
       const LoggingOctokit = Octokit.plugin(LoggingOctokitPlugin)
         .plugin(ConfigPlugin)
         .defaults({authStrategy: createProbotAuth});
-      return new LoggingOctokit(opts);
+      return new LoggingOctokit({auth: opts});
     } else {
       const DefaultOctokit = Octokit.plugin(ConfigPlugin).defaults({
         authStrategy: createProbotAuth,
       });
-      return new DefaultOctokit(opts);
+      return new DefaultOctokit({auth: opts});
     }
   }
 

--- a/packages/gcf-utils/test/integration/gcf-bootstrapper-integration.ts
+++ b/packages/gcf-utils/test/integration/gcf-bootstrapper-integration.ts
@@ -59,17 +59,14 @@ describe('GCFBootstrapper Integration', () => {
     afterEach(() => {});
 
     it('creates authenticated Octokit', async () => {
-      const installationId =
-        process.env.INSTALLATION_ID || '';
+      const installationId = process.env.INSTALLATION_ID || '';
       const octokit = await bootstrapper.getAuthenticatedOctokit(
         Number(installationId)
       );
-      await octokit.apps.listReposAccessibleToInstallation(
-        {
-          per_page: 1,
-          page: 1
-        }
-      );
+      await octokit.apps.listReposAccessibleToInstallation({
+        per_page: 1,
+        page: 1,
+      });
     });
   });
   describe('getProbotConfig', () => {

--- a/packages/gcf-utils/test/integration/gcf-bootstrapper-integration.ts
+++ b/packages/gcf-utils/test/integration/gcf-bootstrapper-integration.ts
@@ -26,7 +26,9 @@ import {VERSION as OCTOKIT_LOGGING_PLUGIN_VERSION} from '../../src/logging/loggi
  *
  * 1. Create a GitHub personal access token:
  *    https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
- * 2. Create a test GitHub App and give it the necessary permissions
+ * 2. Create a test GitHub App and give it the necessary permissions,
+ *    then note the installation id.
+ *
  * 3. Navigate to https://github.com/settings/apps/{your-app} to find
  *    the necessary information for step 4
  * 4. Enable secret manager on your GCP project and create a new secret
@@ -40,10 +42,36 @@ import {VERSION as OCTOKIT_LOGGING_PLUGIN_VERSION} from '../../src/logging/loggi
  * 5. Create a file in gcf-utils root directory called ".env" with the following:
  *    PROJECT_ID=<your GCP project id>
  *    GCF_SHORT_FUNCTION_NAME=<the name of your secret>
+ *    INSTALLATION_ID=<installation id of your bot>
+ *
  * 6. Run these tests by calling 'npm run system-test'
  */
 
 describe('GCFBootstrapper Integration', () => {
+  describe('getAuthenticatedOctokit', () => {
+    let bootstrapper: GCFBootstrapper;
+
+    beforeEach(async () => {
+      bootstrapper = new GCFBootstrapper();
+      config({path: resolve(__dirname, '../../../.env')});
+    });
+
+    afterEach(() => {});
+
+    it('creates authenticated Octokit', async () => {
+      const installationId =
+        process.env.INSTALLATION_ID || '';
+      const octokit = await bootstrapper.getAuthenticatedOctokit(
+        Number(installationId)
+      );
+      await octokit.apps.listReposAccessibleToInstallation(
+        {
+          per_page: 1,
+          page: 1
+        }
+      );
+    });
+  });
   describe('getProbotConfig', () => {
     let bootstrapper: GCFBootstrapper;
 

--- a/packages/gcf-utils/test/integration/gcf-logger-integration.ts
+++ b/packages/gcf-utils/test/integration/gcf-logger-integration.ts
@@ -41,6 +41,9 @@ describe('GCFLogger Integration', () => {
 
   function testAllLevels() {
     for (const level of Object.keys(logLevels)) {
+      if (level === 'metric') {
+        continue;
+      }
       it(`logs ${level} level string`, done => {
         logger[level]('hello world');
         destination.on('ready', () => {


### PR DESCRIPTION
fixes #1825
fixes #1827 

This change fixed the snippet-bot scheduler run at least locally.

According to:
https://github.com/octokit/auth-app.js/

We need to pass `{auth: opts}` instead of just `opts`.

This is a significant change, so I'm marking this as a breaking change.