### PR TITLE
fix(snippet-bot): fix the scheduler handler

### DIFF
--- a/packages/snippet-bot/package-lock.json
+++ b/packages/snippet-bot/package-lock.json
@@ -3118,15 +3118,15 @@
       }
     },
     "gcf-utils": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-7.2.1.tgz",
-      "integrity": "sha512-g+DUGEKp2Qv9LJgsyVSxWE1YlIKCC3/sMCrOgyUh8WSHlgY9zj2Wffs/G7gQczu8VLVOOhSiVJQuPsCISFqR6A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-8.0.0.tgz",
+      "integrity": "sha512-lR/yrc8NJZRI45mzCnr8By8uY+wLAUx3jX93tEWrbcCyx+UQ+tYvXTOgNzqyuBHCMmpyH4Y5WTMBRLCbc/9Jiw==",
       "requires": {
         "@google-cloud/kms": "^2.0.0",
         "@google-cloud/secret-manager": "^3.0.0",
         "@google-cloud/storage": "^5.3.0",
         "@google-cloud/tasks": "^2.0.0",
-        "@octokit/plugin-enterprise-compatibility": "1.2.10",
+        "@octokit/plugin-enterprise-compatibility": "1.2.11",
         "@octokit/rest": "^18.5.2",
         "@probot/octokit-plugin-config": "^1.0.0",
         "@types/bunyan": "^1.8.6",
@@ -3148,6 +3148,17 @@
         "tmp": "^0.2.0",
         "uuid": "^8.3.0",
         "yargs": "^16.0.0"
+      },
+      "dependencies": {
+        "@octokit/plugin-enterprise-compatibility": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-1.2.11.tgz",
+          "integrity": "sha512-bFCxP7q1q2bzK/H9C+NW4JNmdlwvjYFh7+J0SEdjklo9Q0K40s9IhKC4+DUaoCYCVSJv8aiiXIp660Hc15SbtA==",
+          "requires": {
+            "@octokit/request-error": "^2.0.4",
+            "@octokit/types": "^6.0.3"
+          }
+        }
       }
     },
     "gcp-metadata": {

--- a/packages/snippet-bot/package.json
+++ b/packages/snippet-bot/package.json
@@ -31,7 +31,7 @@
     "@google-automations/bot-config-utils": "^3.0.0",
     "@google-automations/label-utils": "^1.0.0",
     "@google-cloud/storage": "^5.4.0",
-    "gcf-utils": "^7.2.1",
+    "gcf-utils": "^8.0.0",
     "minimatch": "^3.0.4",
     "node-fetch": "^2.6.0",
     "parse-diff": "^0.8.0",


### PR DESCRIPTION
fixes #1825

gcf-utils@8.0.0 should fix the broken scheduler handler for organization tasks.

I'd like to start with snippet-bot because I know its behavior well (easy to tell if it's working).