### PR TITLE
chore(auto-approve): add logging

### DIFF
--- a/packages/auto-approve/src/check-pr.ts
+++ b/packages/auto-approve/src/check-pr.ts
@@ -93,6 +93,9 @@ export async function checkPRAgainstConfig(
     if (fileAndFileRule) {
       // TODO: make the checks conditional based on the different kinds of conditions
       // to be checked, i.e., runDependencyUpgradeValidation, etc.
+      logger.info(
+        `Special rules were found for ${repoOwner}/${repo}/${prNumber}`
+      );
       if (!runVersioningValidation(fileAndFileRule)) return false;
     }
 


### PR DESCRIPTION
This PR adds logging but also hopefully triggers a rebuild for auto-approve, as the last deployment failed and it's been too long to retrigger in the UI.