### PR TITLE
build: quote cron schedules

### DIFF
--- a/packages/merge-on-green/cron.yaml
+++ b/packages/merge-on-green/cron.yaml
@@ -1,6 +1,6 @@
 cron:
   - name: merge-on-green
-    schedule: */2 * * * *
+    schedule: "*/2 * * * *"
     description: merge on green for googleapis
     params:
       installation:
@@ -10,7 +10,7 @@ cron:
       find_hanging_prs: false
   - name: merge-on-green-clean-up
     description: "cleans up MOG datastore table"
-    schedule: */30 * * * *
+    schedule: "*/30 * * * *"
     params:
       installation:
         id: 6648093
@@ -19,7 +19,7 @@ cron:
       find_hanging_prs: false
   - name: merge-on-green-hanging-prs
     description: "picks up hanging PRs if the webhook was missed"
-    schedule: 0 * * * *
+    schedule: "0 * * * *"
     params:
       installation:
         id: 6648093
@@ -28,7 +28,7 @@ cron:
       find_hanging_prs: true
   - name: merge-on-green-hanging-prs-gcp
   description: "picks up hanging PRs if the webhook was missed (GoogleCloudPlatform)"
-  schedule: 0 * * * *
+  schedule: "0 * * * *"
   params:
     installation:
       id: 6882761

--- a/packages/slo-stat-bot/cron.yaml
+++ b/packages/slo-stat-bot/cron.yaml
@@ -1,6 +1,6 @@
 cron:
   - name: slo_stat_bot
-    schedule: */5 * * * *
+    schedule: "*/5 * * * *"
     params:
       installation:
         id: 11112564


### PR DESCRIPTION
Deployments failed for slo-stat-bot and merge-on-green because the cron schedules with `/` broke the yaml syntax