### PR TITLE
feat(trusted-contribution): migrate to bot-config-utils

### DIFF
--- a/packages/trusted-contribution/__snapshots__/validation-test.js
+++ b/packages/trusted-contribution/__snapshots__/validation-test.js
@@ -1,0 +1,10 @@
+exports['trusted-contribution bot config schema check on PRs should create a failing status check for a broken config 1'] = {
+  'name': 'trusted-contribution config schema',
+  'conclusion': 'failure',
+  'head_sha': '87139750cdcf551e8fe8d90c129527a4f358321c',
+  'output': {
+    'title': 'Config schema error',
+    'summary': 'An error found in the config file',
+    'text': '[\n    {\n        "instancePath": "/annotations",\n        "schemaPath": "#/properties/annotations/type",\n        "keyword": "type",\n        "params": {\n            "type": "array"\n        },\n        "message": "must be array"\n    }\n]'
+  }
+}

--- a/packages/trusted-contribution/package-lock.json
+++ b/packages/trusted-contribution/package-lock.json
@@ -43,6 +43,16 @@
         }
       }
     },
+    "@bahmutov/data-driven": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bahmutov/data-driven/-/data-driven-1.0.0.tgz",
+      "integrity": "sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==",
+      "dev": true,
+      "requires": {
+        "check-more-types": "2.24.0",
+        "lazy-ass": "1.6.0"
+      }
+    },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -99,6 +109,36 @@
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
           }
+        }
+      }
+    },
+    "@google-automations/bot-config-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-automations/bot-config-utils/-/bot-config-utils-3.0.0.tgz",
+      "integrity": "sha512-JOsvvZPnB+VWxdhMU+a5epM7tFRrFPyyzfd9Lk9uqtc8EqvjMr/n/7iMYvN/pB9vylBeslZVpyUhj9xiY1cqxA==",
+      "requires": {
+        "@octokit/rest": "^18.5.3",
+        "@octokit/types": "^6.14.2",
+        "ajv": "^8.3.0",
+        "gcf-utils": "^7.2.2",
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+          "integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
     },
@@ -1185,6 +1225,12 @@
         "picomatch": "^2.0.4"
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1582,6 +1628,12 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "dev": true
+    },
     "chokidar": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
@@ -1683,6 +1735,12 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+    },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
     },
     "compressible": {
       "version": "2.0.18",
@@ -1893,6 +1951,48 @@
         "path-type": "^4.0.0"
       }
     },
+    "disparity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/disparity/-/disparity-3.0.0.tgz",
+      "integrity": "sha512-n94Rzbv2ambRaFzrnBf34IEiyOdIci7maRpMkoQWB6xFYGA7Nbs0Z5YQzMfTeyQeelv23nayqOcssBoc6rKrgw==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "diff": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1998,6 +2098,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-quotes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-quotes/-/escape-quotes-1.0.2.tgz",
+      "integrity": "sha1-tIltSmz4LdWzP0m3E0CMY4D2zZc=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2364,8 +2473,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -2520,6 +2628,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "dev": true
+    },
+    "folktale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/folktale/-/folktale-2.3.2.tgz",
+      "integrity": "sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ==",
       "dev": true
     },
     "foreachasync": {
@@ -2899,10 +3013,33 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-only": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/has-only/-/has-only-1.1.1.tgz",
+      "integrity": "sha512-3GuFy9rDw0xvovCHb4SOKiRImbZ+a8boFBUyGNRPVd2mRyQOzYdau5G9nodUXC1ZKYN59hrHFkW1lgBQscYfTg==",
+      "dev": true
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -3297,6 +3434,12 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "its-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/its-name/-/its-name-1.0.0.tgz",
+      "integrity": "sha1-IGXxiD7LVoxl9xEt2/EjQB+uSvA=",
+      "dev": true
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
@@ -3314,13 +3457,18 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
         "argparse": "^2.0.1"
       }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-bigint": {
       "version": "1.0.0",
@@ -3462,6 +3610,12 @@
       "requires": {
         "package-json": "^6.3.0"
       }
+    },
+    "lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "dev": true
     },
     "leven": {
       "version": "2.1.0",
@@ -3757,6 +3911,12 @@
         }
       }
     },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
+    },
     "mocha": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.2.tgz",
@@ -3811,6 +3971,15 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
         },
         "locate-path": {
           "version": "6.0.0",
@@ -4006,6 +4175,12 @@
       "requires": {
         "path-key": "^3.0.0"
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-hash": {
       "version": "2.1.1",
@@ -4260,6 +4435,12 @@
         "load-json-file": "^5.2.0"
       }
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4458,6 +4639,18 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
+    "quote": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
+      "integrity": "sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE=",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
       "dev": true
     },
     "randombytes": {
@@ -4697,8 +4890,7 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "requires-port": {
       "version": "1.0.0",
@@ -5003,6 +5195,72 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
       "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
+    },
+    "snap-shot-compare": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/snap-shot-compare/-/snap-shot-compare-3.0.0.tgz",
+      "integrity": "sha512-bdwNOAGuKwPU+qsn0ASxTv+QfkXU+3VmkcDOkt965tes+JQQc8d6SfoLiEiRVhCey4v+ip2IjNUSbZm5nnkI9g==",
+      "dev": true,
+      "requires": {
+        "check-more-types": "2.24.0",
+        "debug": "4.1.1",
+        "disparity": "3.0.0",
+        "folktale": "2.3.2",
+        "lazy-ass": "1.6.0",
+        "strip-ansi": "5.2.0",
+        "variable-diff": "1.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "snap-shot-core": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/snap-shot-core/-/snap-shot-core-10.2.4.tgz",
+      "integrity": "sha512-A7tkcfmvnRKge4VzFLAWA4UYMkvFY4TZKyL+D6hnHjI3HJ4pTepjG5DfR2ACeDKMzCSTQ5EwR2iOotI+Z37zsg==",
+      "dev": true,
+      "requires": {
+        "arg": "4.1.3",
+        "check-more-types": "2.24.0",
+        "common-tags": "1.8.0",
+        "debug": "4.3.1",
+        "escape-quotes": "1.0.2",
+        "folktale": "2.3.2",
+        "is-ci": "2.0.0",
+        "jsesc": "2.5.2",
+        "lazy-ass": "1.6.0",
+        "mkdirp": "1.0.4",
+        "pluralize": "8.0.0",
+        "quote": "0.4.0",
+        "ramda": "0.27.1"
+      }
+    },
+    "snap-shot-it": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/snap-shot-it/-/snap-shot-it-7.9.6.tgz",
+      "integrity": "sha512-t/ADZfQ8EUk4J76S5cmynye7qg1ecUFqQfANiOMNy0sFmYUaqfx9K/AWwpdcpr3vFsDptM+zSuTtKD0A1EOLqA==",
+      "dev": true,
+      "requires": {
+        "@bahmutov/data-driven": "1.0.0",
+        "check-more-types": "2.24.0",
+        "common-tags": "1.8.0",
+        "debug": "4.3.1",
+        "has-only": "1.1.1",
+        "its-name": "1.0.0",
+        "lazy-ass": "1.6.0",
+        "pluralize": "8.0.0",
+        "ramda": "0.27.1",
+        "snap-shot-compare": "3.0.0",
+        "snap-shot-core": "10.2.4"
+      }
     },
     "sonic-boom": {
       "version": "1.4.1",
@@ -5435,7 +5693,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       },
@@ -5443,8 +5700,7 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-          "dev": true
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
     },
@@ -5513,6 +5769,58 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "variable-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/variable-diff/-/variable-diff-1.1.0.tgz",
+      "integrity": "sha1-0r1cZtt2wTh52W5qMG7cmJ35eNo=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "object-assign": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "vary": {

--- a/packages/trusted-contribution/package.json
+++ b/packages/trusted-contribution/package.json
@@ -27,18 +27,22 @@
     "lint": "gts check"
   },
   "dependencies": {
+    "@google-automations/bot-config-utils": "^3.0.0",
     "gcf-utils": "^7.2.2"
   },
   "devDependencies": {
+    "@octokit/rest": "^18.5.3",
     "@types/mocha": "^8.0.0",
     "@types/node": "^14.0.22",
     "@types/sinon": "^10.0.0",
     "c8": "^7.2.0",
     "cross-env": "^7.0.2",
     "gts": "^3.0.0",
+    "js-yaml": "^4.1.0",
     "mocha": "^8.0.1",
     "nock": "^13.0.2",
     "sinon": "^10.0.0",
+    "snap-shot-it": "^7.9.6",
     "typescript": "^4.0.0"
   },
   "engines": {

--- a/packages/trusted-contribution/src/config-schema.json
+++ b/packages/trusted-contribution/src/config-schema.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "trusted-contribution config",
+    "description": "Schema for defining the trusted-contribution config",
+    "additionalProperties": false,
+    "type": "object",
+    "definitions": {
+	"Annotation": {
+	    "additionalProperties": false,
+	    "required": ["type", "text"],
+	    "type": "object",
+	    "properties": {
+		"type": {
+		    "enum": ["comment", "label"]
+		},
+		"text": {
+		    "type": "string"
+		}
+	    }
+	}
+    },
+    "properties": {
+	"trustedContributors": {
+	    "type": "array",
+	    "items": {
+		"type": "string"
+	    }
+	},
+	"annotations": {
+	    "type": "array",
+	    "items": {
+		"$ref": "#/definitions/Annotation"
+	    }
+	},
+	"disabled": {
+	    "type": "boolean"
+	}
+    }
+}

--- a/packages/trusted-contribution/src/config.ts
+++ b/packages/trusted-contribution/src/config.ts
@@ -1,0 +1,26 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export interface Annotation {
+  type: 'comment' | 'label';
+  text: string;
+}
+
+export interface ConfigurationOptions {
+  trustedContributors?: string[];
+  annotations?: Annotation[];
+  disabled?: boolean;
+}
+
+export const WELL_KNOWN_CONFIGURATION_FILE = 'trusted-contribution.yml';

--- a/packages/trusted-contribution/test/fixtures/broken.yml
+++ b/packages/trusted-contribution/test/fixtures/broken.yml
@@ -1,0 +1,3 @@
+annotations:
+    type: comment
+    text: "/gcbrun"

--- a/packages/trusted-contribution/test/fixtures/disabled.yml
+++ b/packages/trusted-contribution/test/fixtures/disabled.yml
@@ -1,0 +1,6 @@
+trustedContributors:
+  - custom-user
+annotations:
+  - type: comment
+    text: "/gcbrun"
+disabled: true

--- a/packages/trusted-contribution/test/validation-test.ts
+++ b/packages/trusted-contribution/test/validation-test.ts
@@ -1,0 +1,109 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// eslint-disable-next-line node/no-extraneous-import
+import {Probot, createProbot, ProbotOctokit} from 'probot';
+import {describe, it, beforeEach} from 'mocha';
+import {resolve} from 'path';
+import * as fs from 'fs';
+import sinon from 'sinon';
+import nock from 'nock';
+import snapshot from 'snap-shot-it';
+import * as botConfigModule from '@google-automations/bot-config-utils';
+
+import {WELL_KNOWN_CONFIGURATION_FILE} from '../src/config';
+import myProbotApp from '../src/trusted-contribution';
+
+nock.disableNetConnect();
+const fixturesPath = resolve(__dirname, '../../test/fixtures');
+
+const OWNER = 'chingor13';
+const REPO = 'google-auth-library-java';
+const PR_NUMBER = 3;
+
+// Emulate getContent and getBlob.
+function createConfigResponse(configFile: string) {
+  const config = fs.readFileSync(resolve(fixturesPath, configFile));
+  const base64Config = config.toString('base64');
+  return {
+    size: base64Config.length,
+    content: base64Config,
+    encoding: 'base64',
+  };
+}
+
+// Emulate the given config file is modified in the PR.
+function fetchFilesInPR(configFile: string) {
+  return nock('https://api.github.com')
+    .get(`/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/files?per_page=100`)
+    .reply(200, [
+      {
+        filename: `.github/${WELL_KNOWN_CONFIGURATION_FILE}`,
+        sha: 'testsha',
+      },
+    ])
+    .get(`/repos/${OWNER}/${REPO}/git/blobs/testsha`)
+    .reply(200, createConfigResponse(configFile));
+}
+
+describe('trusted-contribution bot', () => {
+  const sandbox = sinon.createSandbox();
+  let probot: Probot;
+  let getConfigStub: sinon.SinonStub;
+  const payload = require(resolve(fixturesPath, './pull_request_opened'));
+
+  beforeEach(() => {
+    probot = createProbot({
+      overrides: {
+        githubToken: 'abc123',
+        Octokit: ProbotOctokit.defaults({
+          retry: {enabled: false},
+          throttle: {enabled: false},
+        }),
+      },
+    });
+    probot.load(myProbotApp);
+    getConfigStub = sandbox.stub(botConfigModule, 'getConfig');
+    // This test is only for config validation.
+    getConfigStub.resolves({disabled: true});
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    nock.cleanAll();
+  });
+
+  describe('config schema check on PRs', () => {
+    it('should not create a failing status check for a custom config', async () => {
+      const scope = fetchFilesInPR('custom.yml');
+      await probot.receive({name: 'pull_request', payload, id: 'abc123'});
+      scope.done();
+    });
+    it('should not create a failing status check for a disabled config', async () => {
+      const scope = fetchFilesInPR('disabled.yml');
+      await probot.receive({name: 'pull_request', payload, id: 'abc123'});
+      scope.done();
+    });
+    it('should create a failing status check for a broken config', async () => {
+      const scope = fetchFilesInPR('broken.yml')
+        .post(`/repos/${OWNER}/${REPO}/check-runs`, body => {
+          snapshot(body);
+          return true;
+        })
+        .reply(200);
+      await probot.receive({name: 'pull_request', payload, id: 'abc123'});
+      scope.done();
+    });
+  });
+});

--- a/packages/trusted-contribution/tsconfig.json
+++ b/packages/trusted-contribution/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "rootDir": ".",
-    "outDir": "build"
+    "outDir": "build",
+    "resolveJsonModule": true
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
The bot will start validating config schema on PRs.
It will create a failing status check if the config doesn't follow the schema.

I also added `disabled` field for opting out from this bot.
Related: #131

The bot needs Read/Write permission on Checks.
I added the permission to the bot. The org admins need to approve the requests.