### PR TITLE
fix: one more github limit

### DIFF
--- a/packages/owl-bot/src/create-pr.ts
+++ b/packages/owl-bot/src/create-pr.ts
@@ -30,13 +30,10 @@ export function resplit(
 ): {title: string; body: string} {
   if (title.length > MAX_TITLE_LENGTH) {
     const splitIndex = MAX_TITLE_LENGTH - 3; // 3 dots.
-    body = ('...' + title.substring(splitIndex) + '\n\n' + body).substring(
-      0,
-      MAX_BODY_LENGTH
-    );
+    body = '...' + title.substring(splitIndex) + '\n\n' + body;
     title = title.substring(0, splitIndex) + '...';
   }
-  return {title, body};
+  return {title, body: body.substring(0, MAX_BODY_LENGTH)};
 }
 
 export async function createPullRequestFromLastCommit(

--- a/packages/owl-bot/test/create-pr.ts
+++ b/packages/owl-bot/test/create-pr.ts
@@ -37,10 +37,18 @@ describe('resplit', () => {
     });
   });
 
-  it('truncates a long body', () => {
+  it('truncates a long title and a long body', () => {
     const body = loremIpsum.repeat(64 * 4);
     const tb = resplit(loremIpsum, body);
     assert.strictEqual(tb.title.length, MAX_TITLE_LENGTH);
+    assert.strictEqual(tb.body.length, MAX_BODY_LENGTH);
+    assert.ok(tb.body.length < body.length);
+  });
+
+  it('truncates a long body', () => {
+    const body = loremIpsum.repeat(64 * 4);
+    const tb = resplit('title', body);
+    assert.strictEqual(tb.title, 'title');
     assert.strictEqual(tb.body.length, MAX_BODY_LENGTH);
     assert.ok(tb.body.length < body.length);
   });


### PR DESCRIPTION
Addendum to https://github.com/googleapis/repo-automation-bots/pull/1897

There was one path through `resplit()` that wasn't tested.  I added a test, and naturally, it was broken.  Fixed it.

Fixes https://github.com/googleapis/repo-automation-bots/issues/1895

