### PR TITLE
feat(owlbot): allow webhook events to be run from CLI

### DIFF
--- a/packages/owl-bot/.gitignore
+++ b/packages/owl-bot/.gitignore
@@ -6,4 +6,5 @@ tmp
 .env
 __pycache__/*
 lerna-debug.log
+payload.json
 *.pem

--- a/packages/owl-bot/package-lock.json
+++ b/packages/owl-bot/package-lock.json
@@ -625,6 +625,11 @@
         "debug": "^4.0.0"
       }
     },
+    "@octokit/webhooks-types": {
+      "version": "3.75.2",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-3.75.2.tgz",
+      "integrity": "sha512-e51GBHuWbQIpH0POeGtabdM5U4ZPjD7YN3Ck39bLFbSh6/cEDY2dHgPCbRKtx0nBkXtZ0UkL4TwMMRc0F2Mbwg=="
+    },
     "@probot/get-private-key": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@probot/get-private-key/-/get-private-key-1.1.0.tgz",

--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -11,7 +11,7 @@
     "node": ">=12.10.0"
   },
   "scripts": {
-    "start": "probot run ./build/src/owl-bot-post-processor.js",
+    "start": "probot run ./build/src/run-probot-locally.js",
     "clean": "gts clean",
     "compile": "tsc -p .",
     "fix": "gts fix",

--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@google-cloud/cloudbuild": "^2.0.6",
     "@octokit/rest": "^18.5.3",
+    "@octokit/webhooks-types": "^3.75.2",
     "ajv": "^8.0.5",
     "code-suggester": "^2.0.0",
     "firebase-admin": "^9.4.2",

--- a/packages/owl-bot/src/app.ts
+++ b/packages/owl-bot/src/app.ts
@@ -15,12 +15,12 @@
 // eslint-disable-next-line node/no-extraneous-import
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
-import owlBot from './owl-bot';
+import {OwlBot} from './owl-bot';
 const bootstrap = new GCFBootstrapper();
 // Unlike other probot apps, owl-bot-post-processor requires the ability
 // to generate its own auth token for Cloud Build, we use the helper in
 // GCFBootstrapper to load this from Secret Manager:
 module.exports.owl_bot = bootstrap.gcf(async (app: Probot) => {
   const config = await bootstrap.getProbotConfig(false);
-  owlBot(config.privateKey, app);
+  OwlBot(config.privateKey, app);
 });

--- a/packages/owl-bot/src/bin/commands/test-webhook.ts
+++ b/packages/owl-bot/src/bin/commands/test-webhook.ts
@@ -1,0 +1,93 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {handlePullRequestLabeled} from '../../owl-bot';
+import yargs = require('yargs');
+import {octokitFrom} from '../../octokit-util';
+import {readFileSync} from 'fs';
+
+interface Args {
+  'pem-path': string;
+  'app-id': number;
+  installation: number;
+  org: string;
+  project: string;
+  'payload-path': string;
+  event: string;
+  trigger: string;
+}
+
+export const testWebhook: yargs.CommandModule<{}, Args> = {
+  command: 'test-webhook',
+  describe: 'test webhook handler with a given payload',
+  builder(yargs) {
+    return yargs
+      .option('pem-path', {
+        describe: 'provide path to private key for requesting JWT',
+        type: 'string',
+        demand: true,
+      })
+      .option('app-id', {
+        describe: 'GitHub AppID',
+        type: 'number',
+        demand: true,
+      })
+      .option('installation', {
+        describe: 'installation ID for GitHub app',
+        type: 'number',
+        demand: true,
+      })
+      .option('org', {
+        describe: 'organization to scan for configuration files',
+        type: 'string',
+        demand: true,
+      })
+      .option('project', {
+        describe: 'project with config database',
+        type: 'string',
+        demand: true,
+      })
+      .option('payload-path', {
+        describe: 'path to payload to test',
+        type: 'string',
+        demand: true,
+      })
+      .option('event', {
+        describe: 'event to test',
+        default: 'pull_request.labeled',
+        choices: ['pull_request.labeled'],
+      })
+      .option('trigger', {
+        describe: 'cloud build trigger to run',
+        default: 'ff6ace31-d5f9-41ff-a92c-459ed1755e35',
+      });
+  },
+  async handler(argv) {
+    const payload = JSON.parse(readFileSync(argv['payload-path'], 'utf8'));
+    const privateKey = readFileSync(argv['pem-path'], 'utf8');
+    const octokit = await octokitFrom(argv);
+    switch (argv.event) {
+      case 'pull_request.labeled':
+        await handlePullRequestLabeled(
+          argv['app-id'],
+          privateKey,
+          argv.project,
+          argv.trigger,
+          payload,
+          octokit
+        );
+        break;
+    }
+  },
+};

--- a/packages/owl-bot/src/bin/owl-bot.ts
+++ b/packages/owl-bot/src/bin/owl-bot.ts
@@ -25,6 +25,7 @@ import {copyCodeAndCreatePullRequestCommand} from './commands/copy-code-and-crea
 import {scanGoogleapisGenAndCreatePullRequestsCommand} from './commands/scan-googleapis-gen-and-create-pull-requests';
 import {writeLock} from './commands/write-lock';
 import {maybeCreatePullRequestForLockUpdateCommand} from './commands/maybe-create-pull-request-for-lock-update';
+import {testWebhook} from './commands/test-webhook';
 
 yargs(process.argv.slice(2))
   .command(triggerBuildCommand)
@@ -38,6 +39,7 @@ yargs(process.argv.slice(2))
   .command(copyCodeAndCreatePullRequestCommand)
   .command(writeLock)
   .command(maybeCreatePullRequestForLockUpdateCommand)
+  .command(testWebhook)
   .demandCommand(1)
   .strictCommands()
   .parse();

--- a/packages/owl-bot/src/run-probot-locally.ts
+++ b/packages/owl-bot/src/run-probot-locally.ts
@@ -1,0 +1,13 @@
+import {OwlBot} from './owl-bot';
+import {readFileSync} from 'fs';
+// eslint-disable-next-line node/no-extraneous-import
+import {Probot} from 'probot';
+
+module.exports = (app: Probot) => {
+  console.info('gots here');
+  if (!process.env.PRIVATE_KEY_PATH) {
+    throw Error('must provide path to GitHub app private key');
+  }
+  const privateKey = readFileSync(process.env.PRIVATE_KEY_PATH, 'utf8');
+  OwlBot(privateKey, app);
+};

--- a/packages/owl-bot/src/run-probot-locally.ts
+++ b/packages/owl-bot/src/run-probot-locally.ts
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {OwlBot} from './owl-bot';
 import {readFileSync} from 'fs';
 // eslint-disable-next-line node/no-extraneous-import

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -17,7 +17,7 @@ import {core} from '../src/core';
 import * as handlers from '../src/handlers';
 import {describe, it, beforeEach} from 'mocha';
 import {logger} from 'gcf-utils';
-import owlBot from '../src/owl-bot';
+import {OwlBot} from '../src/owl-bot';
 // eslint-disable-next-line node/no-extraneous-import
 import {Probot, createProbot, ProbotOctokit} from 'probot';
 import * as sinon from 'sinon';
@@ -46,7 +46,7 @@ describe('owlBot', () => {
     });
     await probot.load((app: Probot) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      owlBot('abc123', app, sandbox.stub() as any);
+      OwlBot('abc123', app, sandbox.stub() as any);
     });
   });
   afterEach(() => {
@@ -635,7 +635,7 @@ describe('owlBot', () => {
         }, 100);
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      owlBot('abc123', app, sandbox.stub() as any);
+      OwlBot('abc123', app, sandbox.stub() as any);
     });
     const loggerStub = sandbox.stub(logger, 'info');
     await probot.receive({


### PR DESCRIPTION
Introduces the command line option `test-webhook` which allows a troublesome webhook payload to be tested from the CLI in isolation.

This is in pursuit of addressing bugs with the `owlbot:run` label noticed in #1877.