### PR TITLE
fix(owlbot): address bugs with running owlbot against fork

### DIFF
--- a/packages/owl-bot/src/bin/commands/test-webhook.ts
+++ b/packages/owl-bot/src/bin/commands/test-webhook.ts
@@ -54,7 +54,7 @@ export const testWebhook: yargs.CommandModule<{}, Args> = {
         demand: true,
       })
       .option('project', {
-        describe: 'project with config database',
+        describe: 'project to execute cloud build against',
         type: 'string',
         demand: true,
       })
@@ -70,7 +70,8 @@ export const testWebhook: yargs.CommandModule<{}, Args> = {
       })
       .option('trigger', {
         describe: 'cloud build trigger to run',
-        default: 'ff6ace31-d5f9-41ff-a92c-459ed1755e35',
+        // OwlBot post processor image:
+        default: '637fc67f-fec0-4b62-a5f1-df81a6808c17',
       });
   },
   async handler(argv) {

--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -318,9 +318,10 @@ export async function getOwlBotLock(
     repo,
     pull_number: pullNumber,
   });
+  const [prOwner, prRepo] = prData.head.repo.full_name.split('/');
   const configString = await getFileContent(
-    owner,
-    repo,
+    prOwner,
+    prRepo,
     owlBotLockPath,
     prData.head.ref,
     octokit

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -173,7 +173,7 @@ export async function handlePullRequestLabeled(
 ) {
   const head = payload.pull_request.head.repo.full_name;
   const base = payload.pull_request.base.repo.full_name;
-  const [owner, repo] = head.split('/');
+  const [owner, repo] = base.split('/');
   const installation = payload.installation?.id;
   const prNumber = payload.pull_request.number;
 
@@ -253,7 +253,7 @@ const runPostProcessor = async (
     );
   }
   // Fetch the .Owlbot.lock.yaml from the head ref:
-  const lock = await core.getOwlBotLock(opts.head, opts.prNumber, octokit);
+  const lock = await core.getOwlBotLock(opts.base, opts.prNumber, octokit);
   if (!lock) {
     logger.info(`no .OwlBot.lock.yaml found for ${opts.head}`);
     return;
@@ -267,7 +267,7 @@ const runPostProcessor = async (
       privateKey,
       appId,
       installation: opts.installation,
-      repo: opts.head,
+      repo: opts.base,
       pr: opts.prNumber,
       trigger,
       defaultBranch: opts.defaultBranch,
@@ -281,7 +281,7 @@ const runPostProcessor = async (
       appId,
       installation: opts.installation,
       pr: opts.prNumber,
-      repo: opts.head,
+      repo: opts.base,
       text: buildStatus.text,
       summary: buildStatus.summary,
       conclusion: buildStatus.conclusion,

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -252,7 +252,7 @@ const runPostProcessor = async (
       `too many OwlBot updates created in a row for ${opts.owner}/${opts.repo}`
     );
   }
-  // Fetch the .Owlbot.lock.yaml from the head ref:
+  // Fetch the .Owlbot.lock.yaml from head of PR:
   const lock = await core.getOwlBotLock(opts.base, opts.prNumber, octokit);
   if (!lock) {
     logger.info(`no .OwlBot.lock.yaml found for ${opts.head}`);

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -708,7 +708,7 @@ describe('owlBot', () => {
     image: node
     digest: sha256:9205bb385656cd196f5303b03983282c95c2dfab041d275465c525b501574e5c`;
     const githubMock = nock('https://api.github.com')
-      .get('/repos/bcoe/owl-bot-testing/pulls/33')
+      .get('/repos/rennie/owl-bot-testing/pulls/33')
       .reply(200, payload.pull_request)
       .get(
         '/repos/bcoe/owl-bot-testing/contents/.github%2F.OwlBot.lock.yaml?ref=abc123'
@@ -717,7 +717,7 @@ describe('owlBot', () => {
         content: Buffer.from(config).toString('base64'),
         encoding: 'base64',
       })
-      .delete('/repos/bcoe/owl-bot-testing/issues/33/labels/owlbot%3Arun')
+      .delete('/repos/rennie/owl-bot-testing/issues/33/labels/owlbot%3Arun')
       .reply(200);
     const triggerBuildStub = sandbox
       .stub(core, 'triggerPostProcessBuild')


### PR DESCRIPTION
API calls that interact with the PR must be made against base, but API calls that
clone source should be made against the fork.

See: https://github.com/googleapis/nodejs-phishing-protection/pull/300
Fixes #1717
