### PR TITLE
Revert "feat(snippet-bot): start validating config schema upon retrieval"

### DIFF
--- a/packages/snippet-bot/__snapshots__/snippet-bot.js
+++ b/packages/snippet-bot/__snapshots__/snippet-bot.js
@@ -339,7 +339,7 @@ exports[
     title: 'Config schema error',
     summary: 'An error found in the config file',
     text:
-      'the given config is not valid YAML 😱 \nend of the stream or a document separator is expected (2:13)\n\n 1 | --\n 2 | brokenConfig: true\n-----------------^',
+      '.github/.github/snippet-bot.yml is not valid YAML 😱 \nend of the stream or a document separator is expected (2:13)\n\n 1 | --\n 2 | brokenConfig: true\n-----------------^',
   },
 };
 

--- a/packages/snippet-bot/package-lock.json
+++ b/packages/snippet-bot/package-lock.json
@@ -131,9 +131,9 @@
       }
     },
     "@google-automations/bot-config-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@google-automations/bot-config-utils/-/bot-config-utils-3.1.0.tgz",
-      "integrity": "sha512-EXnHs3OHJf6k+OYUFHSQSdbPSBFcTQaNn0YsBKJ7FF0fkSjpK2T8TmtLbeK42n+uVqonIcPU9CEzvp6+AF9DcA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-automations/bot-config-utils/-/bot-config-utils-3.0.0.tgz",
+      "integrity": "sha512-JOsvvZPnB+VWxdhMU+a5epM7tFRrFPyyzfd9Lk9uqtc8EqvjMr/n/7iMYvN/pB9vylBeslZVpyUhj9xiY1cqxA==",
       "requires": {
         "@octokit/rest": "^18.5.3",
         "@octokit/types": "^6.14.2",
@@ -142,6 +142,11 @@
         "js-yaml": "^4.1.0"
       },
       "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.0.0.tgz",
+          "integrity": "sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw=="
+        },
         "@octokit/plugin-enterprise-compatibility": {
           "version": "1.2.11",
           "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-1.2.11.tgz",
@@ -149,6 +154,14 @@
           "requires": {
             "@octokit/request-error": "^2.0.4",
             "@octokit/types": "^6.0.3"
+          }
+        },
+        "@octokit/types": {
+          "version": "6.14.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.14.2.tgz",
+          "integrity": "sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==",
+          "requires": {
+            "@octokit/openapi-types": "^7.0.0"
           }
         },
         "gcf-utils": {

--- a/packages/snippet-bot/package.json
+++ b/packages/snippet-bot/package.json
@@ -28,7 +28,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "@google-automations/bot-config-utils": "^3.1.0",
+    "@google-automations/bot-config-utils": "^3.0.0",
     "@google-automations/label-utils": "^1.0.0",
     "@google-cloud/storage": "^5.4.0",
     "@octokit/rest": "^18.5.3",

--- a/packages/snippet-bot/src/snippet-bot.ts
+++ b/packages/snippet-bot/src/snippet-bot.ts
@@ -588,8 +588,7 @@ export = (app: Probot) => {
       context.octokit,
       owner,
       repo,
-      CONFIGURATION_FILE_PATH,
-      {schema: schema}
+      CONFIGURATION_FILE_PATH
     );
     if (configOptions === null) {
       logger.info(`snippet-bot is not configured for ${owner}/${repo}.`);
@@ -615,8 +614,7 @@ export = (app: Probot) => {
       context.octokit,
       owner,
       repo,
-      CONFIGURATION_FILE_PATH,
-      {schema: schema}
+      CONFIGURATION_FILE_PATH
     );
 
     if (configOptions === null) {
@@ -653,8 +651,7 @@ export = (app: Probot) => {
       context.octokit,
       owner,
       repo,
-      CONFIGURATION_FILE_PATH,
-      {schema: schema}
+      CONFIGURATION_FILE_PATH
     );
 
     if (configOptions === null) {
@@ -771,8 +768,7 @@ export = (app: Probot) => {
         context.octokit,
         owner,
         repo,
-        CONFIGURATION_FILE_PATH,
-        {schema: schema}
+        CONFIGURATION_FILE_PATH
       );
       if (configOptions === null) {
         logger.info(`snippet-bot is not configured for ${repoUrl}.`);


### PR DESCRIPTION
Reverts googleapis/repo-automation-bots#1920

It turns out that bot-config-utils throws an error for an empty config file. I think snippet-bot is the only bot which uses empty config file.