### PR TITLE
fix(bot-config-utils): handle an empty config file

### DIFF
--- a/packages/bot-config-utils/src/bot-config-utils.ts
+++ b/packages/bot-config-utils/src/bot-config-utils.ts
@@ -96,10 +96,15 @@ export function validateConfig<ConfigType>(
   let errorText: string | undefined;
   let config: ConfigType | undefined;
   try {
-    const candidate = yaml.load(configYaml) as unknown as ConfigType;
+    // When the config file is empty, the result of `yaml.load` is
+    // undefined. We use an empty object in that case because bot
+    // config is usually an object.
+    // Note: Bot must use `object` config if it wants to handle an
+    // empty config file.
+    const candidate = yaml.load(configYaml) || {};
     isValid = validateSchema(candidate);
     if (isValid) {
-      config = candidate;
+      config = candidate as unknown as ConfigType;
     } else {
       errorText = JSON.stringify(validateSchema.errors, null, 4);
     }

--- a/packages/bot-config-utils/test/bot-config-utils.ts
+++ b/packages/bot-config-utils/test/bot-config-utils.ts
@@ -433,6 +433,26 @@ describe('config', () => {
         scope.done();
       }
     });
+    it('fetch an empty config file from the repo', async () => {
+      const owner = 'googleapis';
+      const repo = 'repo-automation-bots';
+      const filename = 'flakybot.yaml';
+
+      const scopes = [
+        getConfigFile('flakybot.yaml', owner, repo, 200, 'empty.yaml'),
+      ];
+
+      const fetchedConfig = await getConfig<TestConfig>(
+        octokit,
+        owner,
+        repo,
+        filename
+      );
+      assert.strictEqual(fetchedConfig?.testConfig, undefined);
+      for (const scope of scopes) {
+        scope.done();
+      }
+    });
     it('fetch the config file from a branch', async () => {
       const owner = 'googleapis';
       const repo = 'repo-automation-bots';
@@ -637,6 +657,28 @@ describe('config', () => {
         defaultConfig
       );
       assert.strictEqual(fetchedConfig?.testConfig, 'testValue');
+      for (const scope of scopes) {
+        scope.done();
+      }
+    });
+    it('fetch an empty config file from the repo with a schema', async () => {
+      const owner = 'googleapis';
+      const repo = 'repo-automation-bots';
+      const filename = 'flakybot.yaml';
+
+      const scopes = [
+        getConfigFile('flakybot.yaml', owner, repo, 200, 'empty.yaml'),
+      ];
+
+      const fetchedConfig = await getConfigWithDefault<TestConfig>(
+        octokit,
+        owner,
+        repo,
+        filename,
+        defaultConfig,
+        {schema: schema}
+      );
+      assert.strictEqual(fetchedConfig?.testConfig, 'defaultValue');
       for (const scope of scopes) {
         scope.done();
       }


### PR DESCRIPTION
fixes #1927
