### PR TITLE
fix(datastore-lock): use hashed value for datastore key

### DIFF
--- a/packages/datastore-lock/.mocharc.js
+++ b/packages/datastore-lock/.mocharc.js
@@ -14,7 +14,7 @@
 const config = {
   "enable-source-maps": true,
   "throw-deprecation": true,
-  "timeout": 10000
+  "timeout": 20000
 }
 if (process.env.MOCHA_THROW_DEPRECATION === 'false') {
   delete config['throw-deprecation'];

--- a/packages/datastore-lock/package-lock.json
+++ b/packages/datastore-lock/package-lock.json
@@ -155,11 +155,11 @@
       }
     },
     "@google-cloud/kms": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-2.3.1.tgz",
-      "integrity": "sha512-bJhtO3t5W5iYE8EiDbp0efIQdAWOWsgfklRz1ihF+h7Orge2KPsRI0wKuMrhRwakxWH3ewPmXUhRrPw1RFaqSQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-2.3.3.tgz",
+      "integrity": "sha512-mpovAlA+hGRGpdJXmYDDD83haIL5OCL1F9I6bj3fMW3GFIelMROr5joPuz3DJ5XMuOSiDQxrAYsI/z7HIiaJkg==",
       "requires": {
-        "google-gax": "^2.9.2"
+        "google-gax": "^2.12.0"
       }
     },
     "@google-cloud/paginator": {
@@ -182,11 +182,11 @@
       "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
     },
     "@google-cloud/secret-manager": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.6.0.tgz",
-      "integrity": "sha512-1lSYKYJ57PekYvUV2FLt7wtI4toDhMKrbHxMH5kA5X9XLfECasgm/PZo+EbmJ/uIxtz5i2qzQID/NczLrZNG+w==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.7.1.tgz",
+      "integrity": "sha512-QXFNBQai0/6VW7m8u5GobyqnHOyn4xt/9RlflWvQKzgzetkOasZr7YbG5umhon/Gp70nTiDySLUV0NjCDQcY2g==",
       "requires": {
-        "google-gax": "^2.9.2"
+        "google-gax": "^2.12.0"
       }
     },
     "@google-cloud/storage": {
@@ -218,11 +218,11 @@
       }
     },
     "@google-cloud/tasks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-2.3.0.tgz",
-      "integrity": "sha512-09Ah1wWe2oueTxUUvPzgtiN7/sfM0Q9pWclKmeEhdu5i7AGaxTHDtZ07pVMoiV8I7dCVRe/LpKMH5T1B3KQbzA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-2.3.2.tgz",
+      "integrity": "sha512-pO+SFnvY/mn8criCauJrk88aLS57V9Mt78uST4TXN79DgESufyICUFNncOhcd4jxQybCG4UTtDQILBJoYua5uQ==",
       "requires": {
-        "google-gax": "^2.9.2"
+        "google-gax": "^2.12.0"
       }
     },
     "@grpc/grpc-js": {
@@ -283,11 +283,11 @@
       }
     },
     "@octokit/auth-app": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-3.4.0.tgz",
-      "integrity": "sha512-zBVgTnLJb0uoNMGCpcDkkAbPeavHX7oAjJkaDv2nqMmsXSsCw4AbUhjl99EtJQG/JqFY/kLFHM9330Wn0k70+g==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-3.4.1.tgz",
+      "integrity": "sha512-YnmIawfVQOgkZ8/r7NKU5sQl5mR5HhkGsChAVeunQxjn8kJhDyPmfeLvrlJSYITTCgHBtUkw6+lrzDPilIHIuQ==",
       "requires": {
-        "@octokit/auth-oauth-app": "^4.1.0",
+        "@octokit/auth-oauth-app": "^4.3.0",
         "@octokit/auth-oauth-user": "^1.2.3",
         "@octokit/request": "^5.4.11",
         "@octokit/request-error": "^2.0.0",
@@ -300,9 +300,9 @@
       }
     },
     "@octokit/auth-oauth-app": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-4.1.2.tgz",
-      "integrity": "sha512-bdNGNRmuDJjKoHla3mUGtkk/xcxKngnQfBEnyk+7VwMqrABKvQB1wQRSrwSWkPPUX7Lcj2ttkPAPG7+iBkMRnw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-4.3.0.tgz",
+      "integrity": "sha512-cETmhmOQRHCz6cLP7StThlJROff3A/ln67Q961GuIr9zvyFXZ4lIJy9RE6Uw5O7D8IXWPU3jhDnG47FTSGQr8Q==",
       "requires": {
         "@octokit/auth-oauth-device": "^3.1.1",
         "@octokit/auth-oauth-user": "^1.2.1",
@@ -314,9 +314,9 @@
       }
     },
     "@octokit/auth-oauth-device": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-3.1.1.tgz",
-      "integrity": "sha512-ykDZROilszXZJ6pYdl6SZ15UZniCs0zDcKgwOZpMz3U0QDHPUhFGXjHToBCAIHwbncMu+jLt4/Nw4lq3FwAw/w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-3.1.2.tgz",
+      "integrity": "sha512-w7Po4Ck6N2aAn2VQyKLuojruiyKROTBv4qs6IwE5rbwF7HhBXXp4A/NKmkpoFIZkiXQtM+N8QtkSck4ApYWdGg==",
       "requires": {
         "@octokit/oauth-methods": "^1.1.0",
         "@octokit/request": "^5.4.14",
@@ -379,9 +379,9 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.1.tgz",
-      "integrity": "sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.2.tgz",
+      "integrity": "sha512-WmsIR1OzOr/3IqfG9JIczI8gMJUMzzyx5j0XXQ4YihHtKlQc+u35VpVoOXhlKAlaBntvry1WpAzPl/a+s3n89Q==",
       "requires": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^6.0.3",
@@ -406,9 +406,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.0.0.tgz",
-      "integrity": "sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw=="
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.2.3.tgz",
+      "integrity": "sha512-V1ycxkR19jqbIl3evf2RQiMRBvTNRi+Iy9h20G5OP5dPfEF6GJ1DPlUeiZRxo2HJxRr+UA4i0H1nn4btBDPFrw=="
     },
     "@octokit/plugin-enterprise-compatibility": {
       "version": "1.2.11",
@@ -433,11 +433,11 @@
       "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz",
-      "integrity": "sha512-vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.1.tgz",
+      "integrity": "sha512-3B2iguGmkh6bQQaVOtCsS0gixrz8Lg0v4JuXPqBcFqLKuJtxAUf3K88RxMEf/naDOI73spD+goJ/o7Ie7Cvdjg==",
       "requires": {
-        "@octokit/types": "^6.13.1",
+        "@octokit/types": "^6.16.2",
         "deprecation": "^2.3.1"
       }
     },
@@ -451,9 +451,9 @@
       }
     },
     "@octokit/plugin-throttling": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.4.1.tgz",
-      "integrity": "sha512-qCQ+Z4AnL9OrXvV59EH3GzPxsB+WyqufoCjiCJXJxTbnt3W+leXbXw5vHrMp4NG9ltw00McFWIxIxNQAzLNoTA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.4.2.tgz",
+      "integrity": "sha512-BXoH4qZlISv4S25HDDya87TIWQ6L7f2ojMDblEX3GXuS3xwgLsLtJN4oRo5ZhxPfLqpoMKMZdlZkYR/0LfAbdQ==",
       "requires": {
         "@octokit/types": "^6.0.1",
         "bottleneck": "^2.15.3"
@@ -483,22 +483,22 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.5.3",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.3.tgz",
-      "integrity": "sha512-KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==",
+      "version": "18.5.6",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.6.tgz",
+      "integrity": "sha512-8HdG6ZjQdZytU6tCt8BQ2XLC7EJ5m4RrbyU/EARSkAM1/HP3ceOzMG/9atEfe17EDMer3IVdHWLedz2wDi73YQ==",
       "requires": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.0.1"
+        "@octokit/plugin-rest-endpoint-methods": "5.3.1"
       }
     },
     "@octokit/types": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.14.2.tgz",
-      "integrity": "sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.2.tgz",
+      "integrity": "sha512-wWPSynU4oLy3i4KGyk+J1BLwRKyoeW2TwRHgwbDz17WtVFzSK2GOErGliruIx8c+MaYtHSYTx36DSmLNoNbtgA==",
       "requires": {
-        "@octokit/openapi-types": "^7.0.0"
+        "@octokit/openapi-types": "^7.2.3"
       }
     },
     "@octokit/webhooks": {
@@ -521,9 +521,9 @@
       }
     },
     "@probot/octokit-plugin-config": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@probot/octokit-plugin-config/-/octokit-plugin-config-1.0.5.tgz",
-      "integrity": "sha512-UH5SkS6bPkNNBHLEZnxN5ZR5fZAs1y+tsea067W9x0W0np/pjfJAUVnEA4dVWSQ53dktMhwF8M+EGkRnUhe1hQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@probot/octokit-plugin-config/-/octokit-plugin-config-1.1.0.tgz",
+      "integrity": "sha512-qZl1Q4MkAzp/Uubyk0QCZQ3fxaX2lPrZJY3GepheLAVW4JAl5Yvcej56SkqZ3FPfDh8Ywf9Jhu5KQUwvzwIUnw==",
       "requires": {
         "@types/js-yaml": "^4.0.1",
         "js-yaml": "^4.1.0"
@@ -545,12 +545,12 @@
       }
     },
     "@probot/pino": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@probot/pino/-/pino-2.3.1.tgz",
-      "integrity": "sha512-aHM1+U/u924DFkPD8efW9Kc7rrFUFepK8JaoloDBq3mPQRWXD8pCr01WPtZ3z6tTQ6PhGc8UE6N/JsnXPn1Zrw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@probot/pino/-/pino-2.3.3.tgz",
+      "integrity": "sha512-wGBsld796kigf4AjglhnDRuaKwLwAtwrj8FSfOFcnOnazN7rV5XsZLMfmaiv8TVaDlZdZjv0VE7IWiEPdXpmwA==",
       "requires": {
         "@sentry/node": "^6.0.0",
-        "pino-pretty": "^4.2.1",
+        "pino-pretty": "^5.0.0",
         "pump": "^3.0.0",
         "readable-stream": "^3.6.0",
         "split2": "^3.2.2"
@@ -611,47 +611,47 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@sentry/core": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.6.tgz",
-      "integrity": "sha512-w6BRizAqh7BaiM9oeKzO6aACXwRijUPacYaVLX/OfhqCSueF9uDxpMRT7+4D/eCeDVqgJYhBJ4Vsu2NSstkk4A==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.5.1.tgz",
+      "integrity": "sha512-Mh3sl/iUOT1myHmM6RlDy2ARzkUClx/g4DAt1rJ/IpQBOlDYQraplXSIW80i/hzRgQDfwhwgf4wUa5DicKBjKw==",
       "requires": {
-        "@sentry/hub": "6.3.6",
-        "@sentry/minimal": "6.3.6",
-        "@sentry/types": "6.3.6",
-        "@sentry/utils": "6.3.6",
+        "@sentry/hub": "6.5.1",
+        "@sentry/minimal": "6.5.1",
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.6.tgz",
-      "integrity": "sha512-foBZ3ilMnm9Gf9OolrAxYHK8jrA6IF72faDdJ3Al+1H27qcpnBaMdrdEp2/jzwu/dgmwuLmbBaMjEPXaGH/0JQ==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.5.1.tgz",
+      "integrity": "sha512-lBRMBVMYP8B4PfRiM70murbtJAXiIAao/asDEMIRNGMP6pI2ArqXfJCBYDkStukhikYD0Kqb4trXq+JYF07Hbg==",
       "requires": {
-        "@sentry/types": "6.3.6",
-        "@sentry/utils": "6.3.6",
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.6.tgz",
-      "integrity": "sha512-uM2/dH0a6zfvI5f+vg+/mST+uTBdN6Jgpm585ipH84ckCYQwIIDRg6daqsen4S1sy/xgg1P1YyC3zdEC4G6b1Q==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.5.1.tgz",
+      "integrity": "sha512-q9Do/oreu1RP695CXCLowVDuQyk7ilE6FGdz2QLpTXAfx8247qOwk6+zy9Kea/Djk93+BoSDVQUSneNiVwl0nQ==",
       "requires": {
-        "@sentry/hub": "6.3.6",
-        "@sentry/types": "6.3.6",
+        "@sentry/hub": "6.5.1",
+        "@sentry/types": "6.5.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.3.6.tgz",
-      "integrity": "sha512-QVWakREgVUV/rocm4uMq+RkC0/g9d/z2BYic+2b0ZZMZD2aXF5RulrUQlAO2MzoXcO+bqpkXQsqdhMccqB4Zeg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.5.1.tgz",
+      "integrity": "sha512-Yh8J/QJ5e8gRBVL9VLCDpUvmiaxsxVZm0CInPHw3V/smgMkrzSKEiqxSeMq8ImPlaJrCFECqdpv4gnvYKI+mQQ==",
       "requires": {
-        "@sentry/core": "6.3.6",
-        "@sentry/hub": "6.3.6",
-        "@sentry/tracing": "6.3.6",
-        "@sentry/types": "6.3.6",
-        "@sentry/utils": "6.3.6",
+        "@sentry/core": "6.5.1",
+        "@sentry/hub": "6.5.1",
+        "@sentry/tracing": "6.5.1",
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -666,28 +666,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.3.6.tgz",
-      "integrity": "sha512-dfyYY2eESJGt5Qbigmfmb2U9ntqbwPhLNAOcjKaVg9WQRV5q2RkHCVctPoYk7TEAvfNeNRXCD8SnuFOZhttt8g==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.5.1.tgz",
+      "integrity": "sha512-y1W/xFC2hAuKqSuuaovkElHY4pbli3XoXrreesg8PtO7ilX6ZbatOQbHsEsHQyoUv0F6aVA+MABOxWH2jt7tfw==",
       "requires": {
-        "@sentry/hub": "6.3.6",
-        "@sentry/minimal": "6.3.6",
-        "@sentry/types": "6.3.6",
-        "@sentry/utils": "6.3.6",
+        "@sentry/hub": "6.5.1",
+        "@sentry/minimal": "6.5.1",
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.6.tgz",
-      "integrity": "sha512-93cFJdJkWyCfyZeWFARSU11qnoHVOS/R2h5WIsEf+jbQmkqG2C+TXVz/19s6nHVsfDrwpvYpwALPv4/nrxfU7g=="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.5.1.tgz",
+      "integrity": "sha512-b/7a6CMoytaeFPx4IBjfxPw3nPvsQh7ui1C8Vw0LxNNDgBwVhPLzUOWeLWbo5YZCVbGEMIWwtCUQYWxneceZSA=="
     },
     "@sentry/utils": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.6.tgz",
-      "integrity": "sha512-HnYlDBf8Dq8MEv7AulH7B6R1D/2LAooVclGdjg48tSrr9g+31kmtj+SAj2WWVHP9+bp29BWaC7i5nkfKrOibWw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.5.1.tgz",
+      "integrity": "sha512-Wv86JYGQH+ZJ5XGFQX7h6ijl32667ikenoL9EyXMn8UoOYX/MLwZoQZin1P60wmKkYR9ifTNVmpaI9OoTaH+UQ==",
       "requires": {
-        "@sentry/types": "6.3.6",
+        "@sentry/types": "6.5.1",
         "tslib": "^1.9.3"
       }
     },
@@ -811,9 +811,9 @@
       }
     },
     "@types/express": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
-      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.12.tgz",
+      "integrity": "sha512-pTYas6FrP15B1Oa0bkN5tQMNqOcVXa9j4FTFtO8DWI9kppKib+6NJtfTOOLcwxuuYvcX2+dVG6et1SxW/Kc17Q==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -822,9 +822,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
-      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.21.tgz",
+      "integrity": "sha512-gwCiEZqW6f7EoR8TTEfalyEhb1zA5jQJnRngr97+3pzMaO1RKoI1w2bw07TK72renMUVWcWS5mLI6rk1NqN0nA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -840,9 +840,9 @@
       }
     },
     "@types/ioredis": {
-      "version": "4.26.3",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.3.tgz",
-      "integrity": "sha512-2YiIUTo/MCZidXXfHAIoh2DUlGEG7zYFMfz0VXzTpI5934/wBCT5a/pR24lHCKk9WQNIlYauIFxQHcAF93w1FA==",
+      "version": "4.26.4",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.4.tgz",
+      "integrity": "sha512-QFbjNq7EnOGw6d1gZZt2h26OFXjx7z+eqEnbCHSrDI1OOLEgOHMKdtIajJbuCr9uO+X9kQQRe7Lz6uxqxl5XKg==",
       "requires": {
         "@types/node": "*"
       }
@@ -1897,9 +1897,9 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
     "date-and-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-1.0.0.tgz",
-      "integrity": "sha512-477D7ypIiqlXBkxhU7YtG9wWZJEQ+RUpujt2quTfgf4+E8g5fNUkB0QIL0bVyP5/TKBg8y55Hfa1R/c4bt3dEw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-1.0.1.tgz",
+      "integrity": "sha512-7u+uNfnjWkX+YFQfivvW24TjaJG6ahvTrfw1auq7KlC7osuGcZBIWGBvB9UcENjH6JnLVhMqlRripk1dSHjAUA=="
     },
     "dateformat": {
       "version": "4.5.1",
@@ -2648,9 +2648,9 @@
       }
     },
     "forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "fresh": {
       "version": "0.5.2",
@@ -2754,9 +2754,9 @@
       }
     },
     "gcf-utils": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-7.2.2.tgz",
-      "integrity": "sha512-4aHEORCXXRWvith4dCnprpfd0JJ4drwGQOq+uU9pthAL/PmALkzIbB3CB93vFw9UzFY8L1nRPKImrsogJ5hMhg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-8.0.1.tgz",
+      "integrity": "sha512-Dp7TAOqmGC6lCkr5URmQ+YXoBIKGx6dY4vyiK4LbeRM9MWZFk+rzyrLMqBZ5NuQfWZQkT7fuMjZPVVkPhpVbsw==",
       "requires": {
         "@google-cloud/kms": "^2.0.0",
         "@google-cloud/secret-manager": "^3.0.0",
@@ -3246,9 +3246,9 @@
       }
     },
     "ioredis": {
-      "version": "4.27.2",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.2.tgz",
-      "integrity": "sha512-7OpYymIthonkC2Jne5uGWXswdhlua1S1rWGAERaotn0hGJWTSURvxdHA9G6wNbT/qKCloCja/FHsfKXW8lpTmg==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.4.tgz",
+      "integrity": "sha512-1n91WZ+L1tHL4hEN9pT16s3f0+Dg82GfvyJGaD47BhEvQb63gIsmDkt/dmzDFBTYfwwlQn8TsT/QSPcjHiT3CQ==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.1",
@@ -3858,16 +3858,16 @@
       "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
     },
     "mime-db": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
     },
     "mime-types": {
-      "version": "2.1.30",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
-      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
       "requires": {
-        "mime-db": "1.47.0"
+        "mime-db": "1.48.0"
       }
     },
     "mimic-fn": {
@@ -4370,11 +4370,12 @@
       }
     },
     "pino-pretty": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.8.0.tgz",
-      "integrity": "sha512-mhQfHG4rw5ZFpWL44m0Utjo4GC2+HMfdNvxyA8lLw0sIqn6fCf7uQe6dPckUcW/obly+OQHD7B/MTso6LNizYw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-5.0.2.tgz",
+      "integrity": "sha512-nOoRoQXYZgURqtSwsM+FLFHBTrZRjuMKfQhELMeewjHnM8xdNhlkqLEGxBpcSCkFlfjHX3jdav9TQzQljjSL9w==",
       "requires": {
         "@hapi/bourne": "^2.0.0",
+        "@types/node": "^15.3.0",
         "args": "^5.0.1",
         "chalk": "^4.0.0",
         "dateformat": "^4.5.1",
@@ -4386,6 +4387,13 @@
         "rfdc": "^1.3.0",
         "split2": "^3.1.1",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "15.12.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.0.tgz",
+          "integrity": "sha512-+aHJvoCsVhO2ZCuT4o5JtcPrCPyDE3+1nvbDprYes+pPkEsbjH7AGUCNtjMOXS0fqH14t+B7yLzaqSz92FPWyw=="
+        }
       }
     },
     "pino-std-serializers": {
@@ -4469,9 +4477,9 @@
       }
     },
     "probot": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/probot/-/probot-11.3.0.tgz",
-      "integrity": "sha512-Af+CJJ9MR982HnMRThzOUnp9QKKjxmpkzi5y0mHeAE6Rk7PXwuFcfIZlT1+L5CjLYkEhcTJhucrgzGW4QUJ8Pw==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-11.4.0.tgz",
+      "integrity": "sha512-FrFL30D0gygWiDmP6z6oO5XpNMVKVdUgZJjRRf9KU9Px5Kcb6Ph9rjZ0NE2ogo9NT6bNxeoTYduczxm65TMmcw==",
       "requires": {
         "@octokit/core": "^3.2.4",
         "@octokit/plugin-enterprise-compatibility": "^1.2.8",
@@ -4563,11 +4571,11 @@
       }
     },
     "proxy-addr": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
     },
@@ -5356,9 +5364,9 @@
       }
     },
     "teeny-request": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.1.tgz",
-      "integrity": "sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.0.tgz",
+      "integrity": "sha512-hPfSc05a7Mf3syqVhSkrVMb844sMiP60MrfGMts3ft6V6UlSkEIGQzgwf0dy1KjdE3FV2lJ5s7QCBFcaoQLA6g==",
       "requires": {
         "http-proxy-agent": "^4.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -5504,9 +5512,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
-      "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA==",
+      "version": "3.13.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
+      "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
       "optional": true
     },
     "unique-string": {

--- a/packages/datastore-lock/package.json
+++ b/packages/datastore-lock/package.json
@@ -7,7 +7,6 @@
     "pretest": "npm run compile && docker pull google/cloud-sdk",
     "prepare": "npm run compile",
     "test": "cross-env NODE_ENV=test LOG_LEVEL=fatal c8 mocha ./build/test",
-    "system-test": "npm run pretest && cross-env LOG_LEVEL=fatal mocha ./build/test/integration",
     "fix": "gts fix",
     "lint": "gts check"
   },
@@ -17,7 +16,7 @@
   "bugs": "https://github.com/googleapis/repo-automation-bots/issues",
   "dependencies": {
     "@google-cloud/datastore": "^6.4.0",
-    "gcf-utils": "^7.2.2",
+    "gcf-utils": "^8.0.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
fixes #1943

In our use case, the targets are very similar (URL of the PR),
so in order to avoid datastore contention, it's better to use
hashed value for the datastore key.