### PR TITLE
chore: explicitly use trim-newlines@3.0.1

### DIFF
--- a/packages/auto-label/package-lock.json
+++ b/packages/auto-label/package-lock.json
@@ -5687,9 +5687,9 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
     "tslib": {

--- a/packages/auto-label/package.json
+++ b/packages/auto-label/package.json
@@ -47,6 +47,7 @@
     "sinon": "^11.0.0",
     "smee-client": "^1.2.2",
     "snap-shot-it": "^7.9.3",
+    "trim-newlines": "^3.0.1",
     "typescript": "~4.3.0"
   },
   "engines": {

--- a/packages/flakybot/package-lock.json
+++ b/packages/flakybot/package-lock.json
@@ -3983,6 +3983,12 @@
         "yargs-parser": "^20.2.3"
       },
       "dependencies": {
+        "trim-newlines": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+          "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+          "dev": true
+        },
         "type-fest": {
           "version": "0.18.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
@@ -5717,9 +5723,9 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
     "tslib": {

--- a/packages/flakybot/package.json
+++ b/packages/flakybot/package.json
@@ -49,6 +49,7 @@
     "nock": "^13.0.0",
     "sinon": "^11.0.0",
     "snap-shot-it": "^7.8.0",
+    "trim-newlines": "^3.0.1",
     "typescript": "~4.3.0"
   },
   "engines": {

--- a/packages/generated-files-bot/package-lock.json
+++ b/packages/generated-files-bot/package-lock.json
@@ -5776,9 +5776,9 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
     "tslib": {

--- a/packages/generated-files-bot/package.json
+++ b/packages/generated-files-bot/package.json
@@ -49,6 +49,7 @@
     "sinon": "^11.0.0",
     "smee-client": "^1.1.0",
     "snap-shot-it": "^7.8.0",
+    "trim-newlines": "^3.0.1",
     "typescript": "~4.3.0"
   },
   "engines": {

--- a/packages/label-utils/package-lock.json
+++ b/packages/label-utils/package-lock.json
@@ -2739,9 +2739,9 @@
       }
     },
     "gcf-utils": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-7.2.2.tgz",
-      "integrity": "sha512-4aHEORCXXRWvith4dCnprpfd0JJ4drwGQOq+uU9pthAL/PmALkzIbB3CB93vFw9UzFY8L1nRPKImrsogJ5hMhg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-8.0.1.tgz",
+      "integrity": "sha512-Dp7TAOqmGC6lCkr5URmQ+YXoBIKGx6dY4vyiK4LbeRM9MWZFk+rzyrLMqBZ5NuQfWZQkT7fuMjZPVVkPhpVbsw==",
       "requires": {
         "@google-cloud/kms": "^2.0.0",
         "@google-cloud/secret-manager": "^3.0.0",
@@ -3793,6 +3793,12 @@
         "yargs-parser": "^20.2.3"
       },
       "dependencies": {
+        "trim-newlines": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+          "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+          "dev": true
+        },
         "type-fest": {
           "version": "0.18.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
@@ -5500,9 +5506,9 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
     "tslib": {

--- a/packages/label-utils/package.json
+++ b/packages/label-utils/package.json
@@ -17,10 +17,9 @@
   "bugs": "https://github.com/googleapis/repo-automation-bots/issues",
   "dependencies": {
     "@google-automations/datastore-lock": "^2.0.1",
-    "gcf-utils": "^7.2.2"
+    "gcf-utils": "^8.0.1"
   },
   "devDependencies": {
-    "@octokit/rest": "^18.5.3",
     "@types/mocha": "^8.2.2",
     "@types/node": "^15.0.3",
     "@types/sinon": "^10.0.0",
@@ -32,6 +31,7 @@
     "nock": "^13.0.11",
     "sinon": "^11.0.0",
     "snap-shot-it": "^7.9.6",
+    "trim-newlines": "^3.0.1",
     "typescript": "^4.2.4"
   },
   "engines": {

--- a/packages/label-utils/src/label-utils.ts
+++ b/packages/label-utils/src/label-utils.ts
@@ -15,6 +15,7 @@
 import {createHash} from 'crypto';
 import {logger} from 'gcf-utils';
 import {DatastoreLock} from '@google-automations/datastore-lock';
+/* eslint-disable-next-line node/no-extraneous-import */
 import {Octokit} from '@octokit/rest';
 
 // We don't allow users to specify colors.

--- a/packages/label-utils/test/label-utils.ts
+++ b/packages/label-utils/test/label-utils.ts
@@ -18,6 +18,7 @@ import * as sinon from 'sinon';
 import {describe, it, beforeEach, afterEach} from 'mocha';
 
 import {DatastoreLock} from '@google-automations/datastore-lock';
+/* eslint-disable-next-line node/no-extraneous-import */
 import {Octokit} from '@octokit/rest';
 import {syncLabels, getLabelColor} from '../src/label-utils';
 


### PR DESCRIPTION
This is to address dependabot's warning.

#1954 has this fix, but some tests are failing, so I created a smaller PR for this.