### PR TITLE
build: add npm-check-updates to update-package.locks.sh

### DIFF
--- a/scripts/update-dependencies.sh
+++ b/scripts/update-dependencies.sh
@@ -241,6 +241,10 @@ for subdir in "${target_dirs[@]}"
 do
     subdir="${subdir%*/}"
     package="${subdir##*/}"
+    if [ "${package}" == "bazel-bot" ]; then
+	log_yellow "Skipping bazel-bot"
+	continue
+    fi
     pushd "${subdir}"
 
     # Skip if there's no package.json

--- a/scripts/update-dependencies.sh
+++ b/scripts/update-dependencies.sh
@@ -20,6 +20,7 @@
 # This script will first try to update package.json with major bumps
 # with npm-check-updates, then run the following:
 # - npm i
+# - npm audit fix
 # - npm run fix
 # - npm run test
 
@@ -140,24 +141,6 @@ try_update() {
     if [ "$#" == 1 ]; then
 	with_ncu="${1}"
     fi
-    log_yellow "Running 'npm update' ${with_ncu} in ${package}"
-    if [ -z "${with_ncu}" ]; then
-	logfile="${tmpdir}/${package}-npm-update.log"
-    else
-	logfile="${tmpdir}/${package}-npm-update-with-ncu.log"
-    fi
-    if ! npm update --no-color > "${logfile}"; then
-	# Failed, add it to summary and continue.
-	echo "- [ ] ${package}: 'npm update' ${with_ncu} failed" >> "${failure_summary}"
-
-	# For copy paste into the issue.
-	dump_details "${package}" "${logfile}"
-
-	# display failure
-	log_red "${package}: 'npm update' ${with_ncu} failed"
-	git restore .
-	return 1
-    fi
 
     log_yellow "Running 'npm i' ${with_ncu} in ${package}"
     if [ -z "${with_ncu}" ]; then
@@ -174,6 +157,25 @@ try_update() {
 
 	# display failure
 	log_red "${package}: 'npm i' ${with_ncu} failed"
+	git restore .
+	return 1
+    fi
+
+    log_yellow "Running 'npm audit fix' ${with_ncu} in ${package}"
+    if [ -z "${with_ncu}" ]; then
+	logfile="${tmpdir}/${package}-npm-audit-fix.log"
+    else
+	logfile="${tmpdir}/${package}-npm-audit-fix-with-ncu.log"
+    fi
+    if ! npm audit fix --no-color > "${logfile}"; then
+	# Failed, add it to summary and continue.
+	echo "- [ ] ${package}: 'npm audit fix' ${with_ncu} failed" >> "${failure_summary}"
+
+	# For copy paste into the issue.
+	dump_details "${package}" "${logfile}"
+
+	# display failure
+	log_red "${package}: 'npm audit fix' ${with_ncu} failed"
 	git restore .
 	return 1
     fi

--- a/scripts/update-dependencies.sh
+++ b/scripts/update-dependencies.sh
@@ -243,8 +243,8 @@ do
     package="${subdir##*/}"
     pushd "${subdir}"
 
-    # Skip if there's no package-lock.json
-    if [ ! -f "package-lock.json" ]; then
+    # Skip if there's no package.json
+    if [ ! -f "package.json" ]; then
 	log_red "skipping ${package}"
 	popd
 	continue
@@ -252,7 +252,7 @@ do
 
     log_yellow "Updating package-lock.json in ${package}"
 
-    rm package-lock.json
+    rm -f package-lock.json
     log_yellow "Running 'ncu -u' in ${package}"
     logfile="${tmpdir}/${package}-ncu.log"
     if ! ncu -u > "${logfile}"; then
@@ -269,7 +269,7 @@ do
 	# Succeeded, let's try updating package-lock.json too.
 	if ! try_update "with ncu"; then
 	    # Failed with ncu, try update it without ncu
-	    rm package-lock.json
+	    rm -f package-lock.json
 	    try_update
 	fi
     fi


### PR DESCRIPTION
I changed the name of the script to `update-dependencies.sh`.
You need to install npm-check-updates in order to use this script now.

```
npm i -g npm-check-updates
```

The script will try to update everything to the latest version (including major bump) with `ncu -u`, then run
`npm i`, `npm audit fix`, `npm run fix`, then `npm run test`.

When the first trial fails, it falls back to do the same thing without
updating `package.json` file.

If you give arguments to this script, it only iterates the given directories.
Example:

```
$ scripts/update-dependencies.sh packages/snippet-bot packages/bot-config-utils
```

fixes #2036 

#2040 and #2042 are example results.

This solves some problems with the current renovate solutions.

- Gives flexibility of how many packages in one single PR
- This script only preserve changes when test passes, so likely no more test failures on package update PRs
- This script also help us to track the failed update attempts (even if it's manual)

Future possible enhancements (we don't need them, but they are handy):
- automatic creation of PRs (limiting the number of packages in a single PR)
- automatic reporting the failed attempts