### PR TITLE
cleanup(gcf-utils): use Probot constructor instead of createProbot

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import {createProbot, Probot, Options} from 'probot';
+import {Probot, Options} from 'probot';
 import {ApplicationFunction} from 'probot/lib/types';
 import {createProbotAuth} from 'octokit-auth-probot';
 
@@ -162,7 +162,7 @@ export class GCFBootstrapper {
   ): Promise<Probot> {
     if (!this.probot) {
       const cfg = await this.getProbotConfig(logging);
-      this.probot = createProbot({overrides: cfg});
+      this.probot = new Probot(cfg);
     }
 
     await this.probot.load(appFn);


### PR DESCRIPTION
fixes #1148
