### PR TITLE
Revert "cleanup(gcf-utils): use Probot constructor instead of createProbot"

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import {Probot, Options} from 'probot';
+import {createProbot, Probot, Options} from 'probot';
 import {ApplicationFunction} from 'probot/lib/types';
 import {createProbotAuth} from 'octokit-auth-probot';
 
@@ -175,7 +175,7 @@ export class GCFBootstrapper {
   ): Promise<Probot> {
     if (!this.probot) {
       const cfg = await this.getProbotConfig(logging);
-      this.probot = new Probot(cfg);
+      this.probot = createProbot({overrides: cfg});
     }
 
     await this.probot.load(appFn);


### PR DESCRIPTION
Reverts googleapis/repo-automation-bots#2066

At a certain point in the past, `createProbot(options)` was marked as deprecated, but I just noticed the current form of `createProbot` is not deprecated.
I think we should stick with createProbot for populating some options from the environment variables.

Is it correctly handled by release-please?