### PR TITLE
fix!: verify payload signatures

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -232,6 +232,18 @@ export class GCFBootstrapper {
     }
   }
 
+  private static parseSignatureHeader(request: express.Request): string {
+    const sha1Signature =
+      request.get('x-hub-signature') || request.get('X-Hub-Signature');
+    if (sha1Signature) {
+      // See https://github.com/googleapis/repo-automation-bots/issues/2092
+      return sha1Signature.startsWith('sha1=')
+        ? sha1Signature
+        : `sha1=${sha1Signature}`;
+    }
+    return 'unset';
+  }
+
   /**
    * Parse the event name, delivery id, signature and task id from the request headers
    * @param request incoming trigger request
@@ -248,12 +260,7 @@ export class GCFBootstrapper {
       request.get('x-github-delivery') ||
       request.get('X-GitHub-Delivery') ||
       '';
-    // TODO: add test to validate this signature is used on the initial
-    // webhook from GitHub:
-    const signature =
-      request.get('x-github-delivery') ||
-      request.get('X-GitHub-Delivery') ||
-      '';
+    const signature = this.parseSignatureHeader(request);
     const taskId =
       request.get('X-CloudTasks-TaskName') ||
       request.get('x-cloudtasks-taskname') ||

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -62,8 +62,16 @@ interface EnqueueTaskParams {
 }
 
 export interface WrapOptions {
+  // Whether or not to enqueue direct GitHub webhooks in a Cloud Task
+  // queue which provides a retry mechanism. Defaults to `true`.
   background: boolean;
+
+  // Whether or not to automatically log Octokit requests. Defaults to
+  // `false`.
   logging: boolean;
+
+  // Whether or not to skip verification of request payloads. Defaults
+  // to `true` in test mode, otherwise `false`.
   skipVerification?: boolean;
 }
 
@@ -232,6 +240,14 @@ export class GCFBootstrapper {
     }
   }
 
+  /**
+   * Parse the signature from the request headers.
+   *
+   * If the expected header is not set, returns `unset` because the verification
+   * function throws an exception on empty string when we would rather
+   * treat the error as an invalid signature.
+   * @param request incoming trigger request
+   */
   private static parseSignatureHeader(request: express.Request): string {
     const sha1Signature =
       request.get('x-hub-signature') || request.get('X-Hub-Signature');

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -598,7 +598,6 @@ describe('GCFBootstrapper', () => {
       await handler(req, response);
 
       sinon.assert.calledOnce(enqueueTask);
-      console.log(enqueueTask.getCall(0));
     });
 
     it('binds the trigger information to the logger', async () => {
@@ -706,6 +705,7 @@ describe('GCFBootstrapper', () => {
         req.headers['x-github-event'] = 'issues';
         req.headers['x-github-delivery'] = '123';
         req.headers['x-cloudtasks-taskname'] = 'my-task';
+        // echo -n '{"installation":{"id":1}}' | openssl dgst -sha1 -hmac "foo"
         req.headers['x-hub-signature'] =
           'sha1=c012c260559a04cf285e05d67e1ecedcad71b931';
 
@@ -735,6 +735,7 @@ describe('GCFBootstrapper', () => {
         req.headers['x-github-event'] = 'issues';
         req.headers['x-github-delivery'] = '123';
         req.headers['x-cloudtasks-taskname'] = 'my-task';
+        // echo -n '{"installation":{"id":1}}' | openssl dgst -sha1 -hmac "foo"
         req.headers['x-hub-signature'] =
           'c012c260559a04cf285e05d67e1ecedcad71b931';
 

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -594,11 +594,11 @@ describe('GCFBootstrapper', () => {
       req.headers = {};
       req.headers['x-github-event'] = 'another.name';
       req.headers['x-github-delivery'] = '123';
-      req.headers['x-cloudtasks-taskname'] = '';
 
       await handler(req, response);
 
       sinon.assert.calledOnce(enqueueTask);
+      console.log(enqueueTask.getCall(0));
     });
 
     it('binds the trigger information to the logger', async () => {


### PR DESCRIPTION
* For all requests, verify the signature before taking any actions.
* When queuing a task, re-sign the request body (which is not necessarily the webhook payload)

Not really a breaking change, but forcing a major version bump.