### PR TITLE
fix: temporarily disable canary payload verification

### DIFF
--- a/packages/canary-bot/src/app.ts
+++ b/packages/canary-bot/src/app.ts
@@ -16,4 +16,8 @@ import {GCFBootstrapper} from 'gcf-utils';
 import appFn from './canary-bot';
 
 const bootstrap = new GCFBootstrapper();
-module.exports['canary_bot'] = bootstrap.gcf(appFn);
+module.exports['canary_bot'] = bootstrap.gcf(appFn, {
+  skipVerification: true,
+  logging: true,
+  background: true,
+});


### PR DESCRIPTION
I have a theory that the scheduler proxy is incorrectly signing the requests
