### PR TITLE
feat(owlbot): indicate success if OwlBot is not enabled

### DIFF
--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -140,12 +140,13 @@ describe('owlBot', () => {
       sandbox.assert.calledOnce(hasOwlBotLoopStub);
       githubMock.done();
     });
-    it('returns early and throws if postprocessor appears to be looping', async () => {
+    it('returns early and throws if post-processor appears to be looping', async () => {
       const payload = {
         installation: {
           id: 12345,
         },
         pull_request: {
+          number: 33,
           head: {
             repo: {
               full_name: 'bcoe/owl-bot-testing',
@@ -159,6 +160,19 @@ describe('owlBot', () => {
           },
         },
       };
+      const config = `docker:
+      image: node
+      digest: sha256:9205bb385656cd196f5303b03983282c95c2dfab041d275465c525b501574e5c`;
+      const githubMock = nock('https://api.github.com')
+        .get('/repos/bcoe/owl-bot-testing/pulls/33')
+        .reply(200, payload.pull_request)
+        .get(
+          '/repos/bcoe/owl-bot-testing/contents/.github%2F.OwlBot.lock.yaml?ref=abc123'
+        )
+        .reply(200, {
+          content: Buffer.from(config).toString('base64'),
+          encoding: 'base64',
+        });
       const hasOwlBotLoopStub = sandbox
         .stub(core, 'hasOwlBotLoop')
         .resolves(true);
@@ -170,6 +184,7 @@ describe('owlBot', () => {
         }),
         /too many OwlBot updates/
       );
+      githubMock.done();
       sandbox.assert.calledOnce(hasOwlBotLoopStub);
     });
   });
@@ -934,5 +949,42 @@ describe('owlBot', () => {
       id: 'abc123',
     });
     sandbox.assert.calledWith(loggerStub, sandbox.match(/.*skipping labels.*/));
+  });
+  it('returns early and adds success status if no lock file found', async () => {
+    const payload = {
+      installation: {
+        id: 12345,
+      },
+      pull_request: {
+        labels: [],
+        number: 33,
+        head: {
+          repo: {
+            full_name: 'bcoe/owl-bot-testing',
+          },
+          ref: 'abc123',
+        },
+        base: {
+          repo: {
+            full_name: 'bcoe/owl-bot-testing',
+          },
+        },
+      },
+    };
+    const githubMock = nock('https://api.github.com')
+      .get('/repos/bcoe/owl-bot-testing/pulls/33')
+      .reply(200, payload.pull_request)
+      .get(
+        '/repos/bcoe/owl-bot-testing/contents/.github%2F.OwlBot.lock.yaml?ref=abc123'
+      )
+      .reply(404);
+    const createCheckStub = sandbox.stub(core, 'createCheck');
+    await probot.receive({
+      name: 'pull_request.synchronize',
+      payload,
+      id: 'abc123',
+    });
+    sandbox.assert.calledOnce(createCheckStub);
+    githubMock.done();
   });
 });

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -984,7 +984,10 @@ describe('owlBot', () => {
       payload,
       id: 'abc123',
     });
-    sandbox.assert.calledOnce(createCheckStub);
+    sandbox.assert.calledWith(
+      createCheckStub,
+      sinon.match.has('conclusion', 'success')
+    );
     githubMock.done();
   });
 });


### PR DESCRIPTION
OwlBot will now default to a successful status check if it's not configured on a repository (as indicated by the presence of a `.OwlBot.lock`).

This will allow OwlBot to be configured as a required check mid-migration.

 Refs: #1714