### PR TITLE
fix(owlbot): add owbot:run for trusted contributors

### DIFF
--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -474,6 +474,32 @@ async function hasOwlBotLoop(
   return false;
 }
 
+/*
+ * Return whether or not the last commit was from OwlBot.
+ *
+ * @param owner owner of repo.
+ * @param repo short repo name.
+ * @param prNumber PR to check for commit.
+ * @param octokit authenticated instance of octokit.
+ * @returns Promise was the last commit from OwlBot?
+ */
+async function lastCommitFromOwlBot(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  octokit: Octokit
+): Promise<boolean> {
+  const commits = (
+    await octokit.pulls.listCommits({
+      pull_number: prNumber,
+      owner,
+      repo,
+    })
+  ).data;
+  const commit = commits[commits.length - 1];
+  return commit?.author?.login === OWLBOT_USER;
+}
+
 /**
  * After the post processor runs, we may want to close the pull request or
  * promote it to "ready for review."
@@ -560,6 +586,7 @@ export const core = {
   getGitHubShortLivedAccessToken,
   getOwlBotLock,
   hasOwlBotLoop,
+  lastCommitFromOwlBot,
   owlBotLockPath,
   triggerPostProcessBuild,
   updatePullRequestAfterPostProcessor,

--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -458,11 +458,13 @@ async function hasOwlBotLoop(
   // It's also okay to run the post-processor many more than circuitBreaker
   // times on a long lived PR, with human edits being made.
   const circuitBreaker = 3;
+  // TODO(bcoe): we should move to an async iterator for listCommits:
   const commits = (
     await octokit.pulls.listCommits({
       pull_number: prNumber,
       owner,
       repo,
+      per_page: 100,
     })
   ).data;
   let count = 0;
@@ -489,11 +491,14 @@ async function lastCommitFromOwlBot(
   prNumber: number,
   octokit: Octokit
 ): Promise<boolean> {
+  // TODO(bcoe): we should move to an async iterator for listCommits in the
+  // future, so that we can handle more than 100:
   const commits = (
     await octokit.pulls.listCommits({
       pull_number: prNumber,
       owner,
       repo,
+      per_page: 100,
     })
   ).data;
   const commit = commits[commits.length - 1];

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -699,6 +699,9 @@ describe('owlBot', () => {
       installation: {
         id: 12345,
       },
+      sender: {
+        login: 'bcoe',
+      },
       pull_request: {
         number: 33,
         labels: [
@@ -765,6 +768,9 @@ describe('owlBot', () => {
     const payload = {
       installation: {
         id: 12345,
+      },
+      sender: {
+        login: 'bcoe',
       },
       pull_request: {
         number: 33,
@@ -833,6 +839,9 @@ describe('owlBot', () => {
       installation: {
         id: 12345,
       },
+      sender: {
+        login: 'bcoe',
+      },
       pull_request: {
         number: 33,
         labels: [
@@ -900,6 +909,9 @@ describe('owlBot', () => {
       installation: {
         id: 12345,
       },
+      sender: {
+        login: 'bcoe',
+      },
       pull_request: {
         labels: [{name: 'cla:yes'}],
         head: {
@@ -928,6 +940,9 @@ describe('owlBot', () => {
       installation: {
         id: 12345,
       },
+      sender: {
+        login: 'bcoe',
+      },
       pull_request: {
         labels: [{name: 'cla:yes'}],
         head: {
@@ -949,6 +964,48 @@ describe('owlBot', () => {
       id: 'abc123',
     });
     sandbox.assert.calledWith(loggerStub, sandbox.match(/.*skipping labels.*/));
+  });
+  it('returns early when "owlbot:run" label added by bot, and last commit was from OwlBot', async () => {
+    const payload = {
+      installation: {
+        id: 12345,
+      },
+      sender: {
+        login: 'tmatsuo[bot]',
+      },
+      pull_request: {
+        number: 33,
+        labels: [
+          {
+            name: 'owlbot:run',
+          },
+        ],
+        head: {
+          repo: {
+            full_name: 'rennie/owl-bot-testing',
+          },
+          ref: 'abc123',
+        },
+        base: {
+          repo: {
+            full_name: 'rennie/owl-bot-testing',
+          },
+        },
+      },
+    };
+    const githubMock = nock('https://api.github.com')
+      .delete('/repos/rennie/owl-bot-testing/issues/33/labels/owlbot%3Arun')
+      .reply(200);
+    const lastCommitFromOwlBotStub = sandbox
+      .stub(core, 'lastCommitFromOwlBot')
+      .resolves(true);
+    await probot.receive({
+      name: 'pull_request.labeled',
+      payload,
+      id: 'abc123',
+    });
+    sandbox.assert.calledOnce(lastCommitFromOwlBotStub);
+    githubMock.done();
   });
   it('returns early and adds success status if no lock file found', async () => {
     const payload = {

--- a/packages/owl-bot/test/owl-core.ts
+++ b/packages/owl-bot/test/owl-core.ts
@@ -390,7 +390,7 @@ describe('core', () => {
         },
       ];
       const githubMock = nock('https://api.github.com')
-        .get('/repos/bcoe/foo/pulls/22/commits')
+        .get('/repos/bcoe/foo/pulls/22/commits?per_page=100')
         .reply(200, commits);
       const loop = await core.hasOwlBotLoop('bcoe', 'foo', 22, new Octokit());
       assert.strictEqual(loop, false);
@@ -421,7 +421,7 @@ describe('core', () => {
         },
       ];
       const githubMock = nock('https://api.github.com')
-        .get('/repos/bcoe/foo/pulls/22/commits')
+        .get('/repos/bcoe/foo/pulls/22/commits?per_page=100')
         .reply(200, commits);
       const loop = await core.hasOwlBotLoop('bcoe', 'foo', 22, new Octokit());
       assert.strictEqual(loop, true);

--- a/packages/trusted-contribution/src/config-schema.json
+++ b/packages/trusted-contribution/src/config-schema.json
@@ -13,8 +13,16 @@
 		"type": {
 		    "enum": ["comment", "label"]
 		},
-		"text": {
-		    "type": "string"
+		"text":{
+			"oneOf": [
+				{"type": "string"},
+				{
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			]
 		}
 	    }
 	}

--- a/packages/trusted-contribution/src/config.ts
+++ b/packages/trusted-contribution/src/config.ts
@@ -14,7 +14,7 @@
 
 export interface Annotation {
   type: 'comment' | 'label';
-  text: string;
+  text: string | Array<string>;
 }
 
 export interface ConfigurationOptions {

--- a/packages/trusted-contribution/src/trusted-contribution.ts
+++ b/packages/trusted-contribution/src/trusted-contribution.ts
@@ -41,7 +41,7 @@ const DEFAULT_TRUSTED_CONTRIBUTORS = [
 const DEFAULT_ANNOTATIONS: Annotation[] = [
   {
     type: 'label',
-    text: 'kokoro:force-run',
+    text: ['kokoro:force-run', 'owlbot:run'],
   },
 ];
 
@@ -112,7 +112,9 @@ export = (app: Probot) => {
           if (annotation.type === 'label') {
             const issuesAddLabelsParams = context.repo({
               issue_number: context.payload.pull_request.number,
-              labels: [annotation.text],
+              labels: Array.isArray(annotation.text)
+                ? annotation.text
+                : [annotation.text],
             });
             await context.octokit.issues.addLabels(issuesAddLabelsParams);
             logger.metric('trusted_contribution.labeled', {
@@ -128,7 +130,7 @@ export = (app: Probot) => {
             }
             await octokit.issues.createComment({
               issue_number: context.payload.pull_request.number,
-              body: annotation.text,
+              body: String(annotation.text),
               owner: context.repo().owner,
               repo: context.repo().repo,
             });

--- a/packages/trusted-contribution/test/trusted-contribution.ts
+++ b/packages/trusted-contribution/test/trusted-contribution.ts
@@ -256,7 +256,12 @@ describe('TrustedContributionTestRunner', () => {
         requests = requests
           .post(
             '/repos/chingor13/google-auth-library-java/issues/3/labels',
-            () => true
+            (body: object) => {
+              assert.deepStrictEqual(body, {
+                labels: ['kokoro:force-run', 'owlbot:run'],
+              });
+              return true;
+            }
           )
           .reply(200);
 


### PR DESCRIPTION
Along with running `kokoro:run` for trusted contributors, we need to make sure to run `owlbot:run`.

Refs #1714
