### PR TITLE
fix: only provide the installationId if set

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -662,11 +662,16 @@ export class GCFBootstrapper {
     wrapOptions?: WrapOptions
   ): Promise<Octokit> {
     const cfg = await this.getProbotConfig(wrapOptions?.logging);
-    const opts = {
+    let opts = {
       appId: cfg.appId,
       privateKey: cfg.privateKey,
-      installationId,
     };
+    if (installationId) {
+      opts = {
+        ...opts,
+        ...{installationId},
+      };
+    }
     if (wrapOptions?.logging) {
       const LoggingOctokit = Octokit.plugin(LoggingOctokitPlugin)
         .plugin(ConfigPlugin)

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -916,4 +916,32 @@ describe('GCFBootstrapper', () => {
       assert.strictEqual(latest, 'projects/foo/secrets/bar');
     });
   });
+
+  describe('getAuthenticatedOctokit', () => {
+    it('can return an Octokit instance given an installation id', async () => {
+      const bootstrapper = new GCFBootstrapper();
+      const configStub = sinon.stub(bootstrapper, 'getProbotConfig').resolves({
+        appId: 1234,
+        secret: 'foo',
+        webhookPath: 'bar',
+        privateKey: 'cert',
+      });
+      const octokit = await bootstrapper.getAuthenticatedOctokit(1234);
+      assert.ok(octokit);
+      sinon.assert.calledOnce(configStub);
+    });
+
+    it('can return an Octokit instance without an installation id', async () => {
+      const bootstrapper = new GCFBootstrapper();
+      const configStub = sinon.stub(bootstrapper, 'getProbotConfig').resolves({
+        appId: 1234,
+        secret: 'foo',
+        webhookPath: 'bar',
+        privateKey: 'cert',
+      });
+      const octokit = await bootstrapper.getAuthenticatedOctokit(undefined);
+      assert.ok(octokit);
+      sinon.assert.calledOnce(configStub);
+    });
+  });
 });


### PR DESCRIPTION
`@octokit/auth-app` distinguishes between unset and falsy. We need to make sure we do not set installation id if we want an installationless octokit instance.

Fixes #2107