### PR TITLE
feat: add max retries config options

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -64,16 +64,42 @@ interface EnqueueTaskParams {
 export interface WrapOptions {
   // Whether or not to enqueue direct GitHub webhooks in a Cloud Task
   // queue which provides a retry mechanism. Defaults to `true`.
-  background: boolean;
+  // Deprecated. Please use `maxRetries` and `maxCronRetries` instead.
+  background?: boolean;
 
   // Whether or not to automatically log Octokit requests. Defaults to
   // `false`.
-  logging: boolean;
+  logging?: boolean;
 
   // Whether or not to skip verification of request payloads. Defaults
   // to `true` in test mode, otherwise `false`.
   skipVerification?: boolean;
+
+  // Maximum number of attempts for webhook handlers. Defaults to `10`.
+  maxRetries?: number;
+
+  // Maximum number of attempts for cron handlers. Defaults to `0`.
+  maxCronRetries?: number;
+
+  // Maximum number of attempts for cron handlers. Defaults to `0`.
+  maxPubSubRetries?: number;
 }
+
+interface WrapConfig {
+  logging: boolean;
+  skipVerification: boolean;
+  maxCronRetries: number;
+  maxRetries: number;
+  maxPubSubRetries: number;
+}
+
+const DEFAULT_WRAP_CONFIG: WrapConfig = {
+  logging: false,
+  skipVerification: RUNNING_IN_TEST,
+  maxCronRetries: 0,
+  maxRetries: 10,
+  maxPubSubRetries: 0,
+};
 
 export const logger = new GCFLogger();
 
@@ -269,6 +295,7 @@ export class GCFBootstrapper {
     id: string;
     signature: string;
     taskId: string;
+    taskRetries: number;
   } {
     const name =
       request.get('x-github-event') || request.get('X-GitHub-Event') || '';
@@ -281,7 +308,12 @@ export class GCFBootstrapper {
       request.get('X-CloudTasks-TaskName') ||
       request.get('x-cloudtasks-taskname') ||
       '';
-    return {name, id, signature, taskId};
+    const taskRetries = parseInt(
+      request.get('X-CloudTasks-TaskRetryCount') ||
+        request.get('x-cloudtasks-taskretrycount') ||
+        '0'
+    );
+    return {name, id, signature, taskId, taskRetries};
   }
 
   /**
@@ -302,23 +334,46 @@ export class GCFBootstrapper {
     return TriggerType.UNKNOWN;
   }
 
+  private parseWrapConfig(wrapOptions: WrapOptions | undefined): WrapConfig {
+    const wrapConfig: WrapConfig = {
+      ...DEFAULT_WRAP_CONFIG,
+      ...wrapOptions,
+    };
+
+    if (wrapOptions?.background !== undefined) {
+      logger.warn(
+        '`background` option has been deprecated in favor of `maxRetries` and `maxCronRetries`'
+      );
+      if (wrapOptions.background === false) {
+        wrapConfig.maxCronRetries = 0;
+        wrapConfig.maxRetries = 0;
+        wrapConfig.maxPubSubRetries = 0;
+      }
+    }
+    return wrapConfig;
+  }
+
+  private getRetryLimit(wrapConfig: WrapConfig, eventName: string) {
+    if (eventName.startsWith('schedule.')) {
+      return wrapConfig.maxCronRetries;
+    }
+    if (eventName.startsWith('pubsub.')) {
+      return wrapConfig.maxPubSubRetries;
+    }
+    return wrapConfig.maxRetries;
+  }
+
   gcf(
     appFn: ApplicationFunction,
     wrapOptions?: WrapOptions
   ): (request: express.Request, response: express.Response) => Promise<void> {
     return async (request: express.Request, response: express.Response) => {
-      wrapOptions = wrapOptions ?? {background: true, logging: false};
-
-      // default skip verification for testing
-      // to test signatures, explicitly set skipVerification to false
-      if (wrapOptions.skipVerification === undefined) {
-        wrapOptions.skipVerification = RUNNING_IN_TEST;
-      }
+      const wrapConfig = this.parseWrapConfig(wrapOptions);
 
       this.probot =
-        this.probot || (await this.loadProbot(appFn, wrapOptions.logging));
+        this.probot || (await this.loadProbot(appFn, wrapConfig.logging));
 
-      const {name, id, signature, taskId} =
+      const {name, id, signature, taskId, taskRetries} =
         GCFBootstrapper.parseRequestHeaders(request);
 
       const triggerType: TriggerType = GCFBootstrapper.parseTriggerType(
@@ -328,7 +383,7 @@ export class GCFBootstrapper {
 
       // validate the signature
       if (
-        !wrapOptions.skipVerification &&
+        !wrapConfig.skipVerification &&
         !this.probot.webhooks.verify(request.body, signature)
       ) {
         response.send({
@@ -350,28 +405,35 @@ export class GCFBootstrapper {
           return;
         } else if (triggerType === TriggerType.SCHEDULER) {
           // Cloud scheduler tasks (cron)
-          await this.handleScheduled(id, request, wrapOptions);
-        } else if (
-          triggerType === TriggerType.TASK ||
-          triggerType === TriggerType.PUBSUB ||
-          !wrapOptions?.background
-        ) {
-          if (!wrapOptions?.background) {
-            // a bot can opt out of running through tasks, some bots do this
-            // due to large payload sizes:
-            logger.info(`${id}: skipping Cloud Tasks`);
+          await this.handleScheduled(id, request, wrapConfig);
+        } else if (triggerType === TriggerType.PUBSUB) {
+          const payload = this.parsePubSubPayload(request);
+          await this.enqueueTask({
+            id,
+            name,
+            body: JSON.stringify(payload),
+          });
+        } else if (triggerType === TriggerType.TASK) {
+          const maxRetries = this.getRetryLimit(wrapConfig, name);
+          // Abort task retries if we've hit the max number by
+          // returning "success"
+          if (taskRetries > maxRetries) {
+            logger.metric('too-many-retries');
+            logger.info(`Too many retries: ${taskRetries} > ${maxRetries}`);
+            response.send({
+              statusCode: 200,
+              body: JSON.stringify({message: 'Too many retries'}),
+            });
+            return;
           }
-          let payload = request.body;
-          if (triggerType === TriggerType.PUBSUB) {
-            payload = this.parsePubSubPayload(request);
-          }
+
           // If the payload contains `tmpUrl` this indicates that the original
           // payload has been written to Cloud Storage; download it.
-          const body = await this.maybeDownloadOriginalBody(payload);
+          const payload = await this.maybeDownloadOriginalBody(request.body);
 
           // The payload does not exist, stop retrying on this task by letting
           // this request "succeed".
-          if (!body) {
+          if (!payload) {
             logger.metric('payload-expired');
             response.send({
               statusCode: 200,
@@ -386,7 +448,7 @@ export class GCFBootstrapper {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             name: name as any,
             id,
-            payload: body,
+            payload,
           });
         } else if (triggerType === TriggerType.GITHUB) {
           await this.enqueueTask({
@@ -420,21 +482,21 @@ export class GCFBootstrapper {
    * @param body {Scheduled} Scheduler params. May contain additional request
    *   parameters besides the ones defined by the Scheduled type.
    * @param signature
-   * @param wrapOptions
+   * @param wrapConfig
    */
   private async handleScheduled(
     id: string,
     req: express.Request,
-    wrapOptions: WrapOptions
+    wrapConfig: WrapConfig
   ) {
     const body: Scheduled = this.parseRequestBody(req);
     const cronType = body.cron_type ?? DEFAULT_CRON_TYPE;
     if (cronType === 'global') {
       await this.handleScheduledGlobal(id, body);
     } else if (cronType === 'installation') {
-      await this.handleScheduledInstallation(id, body, wrapOptions);
+      await this.handleScheduledInstallation(id, body, wrapConfig);
     } else {
-      await this.handleScheduledRepository(id, body, wrapOptions);
+      await this.handleScheduledRepository(id, body, wrapConfig);
     }
   }
 
@@ -459,10 +521,10 @@ export class GCFBootstrapper {
    * Async iterator over each installation for an app.
    *
    * See https://docs.github.com/en/rest/reference/apps#list-installations-for-the-authenticated-app
-   * @param wrapOptions {WrapOptions}
+   * @param wrapConfig {WrapConfig}
    */
-  private async *eachInstallation(wrapOptions: WrapOptions) {
-    const octokit = await this.getAuthenticatedOctokit(undefined, wrapOptions);
+  private async *eachInstallation(wrapConfig: WrapConfig) {
+    const octokit = await this.getAuthenticatedOctokit(undefined, wrapConfig);
     const installationsPaginated = octokit.paginate.iterator(
       octokit.apps.listInstallations
     );
@@ -477,15 +539,15 @@ export class GCFBootstrapper {
    * Async iterator over each repository for an app installation.
    *
    * See https://docs.github.com/en/rest/reference/apps#list-repositories-accessible-to-the-app-installation
-   * @param wrapOptions {WrapOptions}
+   * @param wrapConfig {WrapConfig}
    */
   private async *eachInstalledRepository(
     installationId: number,
-    wrapOptions: WrapOptions
+    wrapConfig: WrapConfig
   ) {
     const octokit = await this.getAuthenticatedOctokit(
       installationId,
-      wrapOptions
+      wrapConfig
     );
     const installationRepositoriesPaginated = octokit.paginate.iterator(
       octokit.apps.listReposAccessibleToInstallation,
@@ -513,12 +575,12 @@ export class GCFBootstrapper {
    * @param id {string} GitHub delivery GUID
    * @param body {Scheduled} Scheduler params. May contain additional request
    *   parameters besides the ones defined by the Scheduled type.
-   * @param wrapOptions
+   * @param wrapConfig
    */
   private async handleScheduledInstallation(
     id: string,
     body: Scheduled,
-    wrapOptions: WrapOptions
+    wrapConfig: WrapConfig
   ) {
     if (body.installation) {
       await this.enqueueTask({
@@ -527,7 +589,7 @@ export class GCFBootstrapper {
         body: JSON.stringify(body),
       });
     } else {
-      const generator = this.eachInstallation(wrapOptions);
+      const generator = this.eachInstallation(wrapConfig);
       for await (const installation of generator) {
         const extraParams: Scheduled = {
           installation: {
@@ -567,12 +629,12 @@ export class GCFBootstrapper {
    * @param body {Scheduled} Scheduler params. May contain additional request
    *   parameters besides the ones defined by the Scheduled type.
    * @param signature
-   * @param wrapOptions
+   * @param wrapConfig
    */
   private async handleScheduledRepository(
     id: string,
     body: Scheduled,
-    wrapOptions: WrapOptions
+    wrapConfig: WrapConfig
   ) {
     if (body.repo) {
       // Job was scheduled for a single repository:
@@ -585,7 +647,7 @@ export class GCFBootstrapper {
     } else if (body.installation) {
       const generator = this.eachInstalledRepository(
         body.installation.id,
-        wrapOptions
+        wrapConfig
       );
       for await (const repo of generator) {
         if (repo.archived === true || repo.disabled === true) {
@@ -599,13 +661,13 @@ export class GCFBootstrapper {
         );
       }
     } else {
-      const installationGenerator = this.eachInstallation(wrapOptions);
+      const installationGenerator = this.eachInstallation(wrapConfig);
       const promises: Array<Promise<void>> = new Array<Promise<void>>();
       const batchNum = 30;
       for await (const installation of installationGenerator) {
         const generator = this.eachInstalledRepository(
           installation.id,
-          wrapOptions
+          wrapConfig
         );
         const extraParams: Scheduled = {
           installation: {
@@ -655,13 +717,13 @@ export class GCFBootstrapper {
    * @param installationId {number|undefined} The installation id to
    *   authenticate as. Required if you are trying to take action
    *   on an installed repository.
-   * @param wrapOptions
+   * @param wrapConfig
    */
   async getAuthenticatedOctokit(
     installationId?: number,
-    wrapOptions?: WrapOptions
+    wrapConfig?: WrapConfig
   ): Promise<Octokit> {
-    const cfg = await this.getProbotConfig(wrapOptions?.logging);
+    const cfg = await this.getProbotConfig(wrapConfig?.logging);
     let opts = {
       appId: cfg.appId,
       privateKey: cfg.privateKey,
@@ -672,7 +734,7 @@ export class GCFBootstrapper {
         ...{installationId},
       };
     }
-    if (wrapOptions?.logging) {
+    if (wrapConfig?.logging) {
       const LoggingOctokit = Octokit.plugin(LoggingOctokitPlugin)
         .plugin(ConfigPlugin)
         .defaults({authStrategy: createProbotAuth});

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -81,7 +81,7 @@ export interface WrapOptions {
   // Maximum number of attempts for cron handlers. Defaults to `0`.
   maxCronRetries?: number;
 
-  // Maximum number of attempts for cron handlers. Defaults to `0`.
+  // Maximum number of attempts for pubsub handlers. Defaults to `0`.
   maxPubSubRetries?: number;
 }
 


### PR DESCRIPTION
* Introduces 3 new configuration parameters:
  * `maxRetries` - max retries for GitHub webhook events. defaults to 10
  * `maxCronRetries` - max retries for cron events. defaults to 0
  * `maxPubSubRetries` - max retries for pubsub events. defaults to 0
* All handlers now go through Cloud Tasks - no requests are handled directly by the webhook source (Pub/Sub, Cron, or GitHub webhook).
* Deprecates the `background` configuration option. It now sets retries to 0 for all payload types. This option was originally there when the payload size was too large for Cloud Tasks, but that was resolved by writing the payload to the GCS.
