### PR TITLE
feat: allow configuration of GCFBootstrapper via constructor arguments

### DIFF
--- a/cloudbuild-test/Dockerfile
+++ b/cloudbuild-test/Dockerfile
@@ -19,6 +19,7 @@ USER root
 ENV PROJECT_ID=repo-automation-bots
 ENV GCF_SHORT_FUNCTION_NAME=snippet_bot
 ENV INSTALLATION_ID=9602930
+ENV GCF_LOCATION=us-central1
 
 COPY . /workspace
 RUN cd /workspace/packages/gcf-utils && \

--- a/packages/gcf-utils/package-lock.json
+++ b/packages/gcf-utils/package-lock.json
@@ -4085,6 +4085,18 @@
         }
       }
     },
+    "mocked-env": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mocked-env/-/mocked-env-1.3.4.tgz",
+      "integrity": "sha512-VGe9c1exy/pt1T+O++ovGsW7aqlRr4e/iBORc28wjvdeRuD7jJObXE9uvNrShbXYVJ8HQ0bWWmZcDrbwTywiiw==",
+      "dev": true,
+      "requires": {
+        "check-more-types": "2.24.0",
+        "debug": "4.3.1",
+        "lazy-ass": "1.6.0",
+        "ramda": "0.27.1"
+      }
+    },
     "mri": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",

--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -61,6 +61,7 @@
     "google-auth-library": "^7.0.0",
     "gts": "^3.0.0",
     "mocha": "^8.0.0",
+    "mocked-env": "^1.3.4",
     "nock": "^13.0.0",
     "sinon": "^11.0.0",
     "snap-shot-it": "^7.8.0",

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -196,7 +196,7 @@ export const addOrUpdateIssueComment = async (
   }
 };
 
-interface BootStrapperOptions {
+interface BootstrapperOptions {
   secretsClient?: SecretManagerV1.SecretManagerServiceClient;
   tasksClient?: CloudTasksV2.CloudTasksClient;
   projectId?: string;
@@ -216,7 +216,7 @@ export class GCFBootstrapper {
   location: string;
   payloadBucket: string | undefined;
 
-  constructor(options?: BootStrapperOptions) {
+  constructor(options?: BootstrapperOptions) {
     options = {
       ...{
         projectId: process.env.PROJECT_ID,

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -234,15 +234,21 @@ export class GCFBootstrapper {
       options?.tasksClient || new CloudTasksV2.CloudTasksClient();
     this.storage = new Storage({autoRetry: !RUNNING_IN_TEST});
     if (!options.projectId) {
-      throw new Error('Missing required `projectId`');
+      throw new Error(
+        'Missing required `projectId`. Please provide as a constructor argument or set the PROJECT_ID env variable.'
+      );
     }
     this.projectId = options.projectId;
     if (!options.functionName) {
-      throw new Error('Missing required `functionName`');
+      throw new Error(
+        'Missing required `functionName`. Please provide as a constructor argument or set the GCF_SHORT_FUNCTION_NAME env variable.'
+      );
     }
     this.functionName = options.functionName;
     if (!options.location) {
-      throw new Error('Missing required `location`');
+      throw new Error(
+        'Missing required `location`. Please provide as a constructor argument or set the GCF_LOCATION env variable.'
+      );
     }
     this.location = options.location;
     this.payloadBucket = options.payloadBucket;

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -197,18 +197,12 @@ export const addOrUpdateIssueComment = async (
 };
 
 interface BootStrapperOptions {
-  secretsClient?: SecretManagerV1.SecretManagerServiceClient,
-  tasksClient?: CloudTasksV2.CloudTasksClient,
+  secretsClient?: SecretManagerV1.SecretManagerServiceClient;
+  tasksClient?: CloudTasksV2.CloudTasksClient;
   projectId?: string;
   functionName?: string;
   location?: string;
   payloadBucket?: string;
-}
-const DEFAULT_BOOTSTRAPPER_OPTIONS = {
-  projectId: process.env.PROJECT_ID,
-  functionName: process.env.GCF_SHORT_FUNCTION_NAME,
-  location: process.env.GCF_LOCATION,
-  payloadBucket: process.env.WEBHOOK_TMP,
 }
 
 export class GCFBootstrapper {
@@ -224,11 +218,20 @@ export class GCFBootstrapper {
 
   constructor(options?: BootStrapperOptions) {
     options = {
-      ...DEFAULT_BOOTSTRAPPER_OPTIONS,
-      ...options
+      ...{
+        projectId: process.env.PROJECT_ID,
+        functionName: process.env.GCF_SHORT_FUNCTION_NAME,
+        location: process.env.GCF_LOCATION,
+        payloadBucket: process.env.WEBHOOK_TMP,
+      },
+      ...options,
     };
-    this.secretsClient = options?.secretsClient || new SecretManagerV1.SecretManagerServiceClient();
-    this.cloudTasksClient = options?.tasksClient || new CloudTasksV2.CloudTasksClient();
+
+    this.secretsClient =
+      options?.secretsClient ||
+      new SecretManagerV1.SecretManagerServiceClient();
+    this.cloudTasksClient =
+      options?.tasksClient || new CloudTasksV2.CloudTasksClient();
     this.storage = new Storage({autoRetry: !RUNNING_IN_TEST});
     if (!options.projectId) {
       throw new Error('Missing required `projectId`');
@@ -237,10 +240,10 @@ export class GCFBootstrapper {
     if (!options.functionName) {
       throw new Error('Missing required `functionName`');
     }
-    this.functionName = options.functionName
+    this.functionName = options.functionName;
     if (!options.location) {
       throw new Error('Missing required `location`');
-    };
+    }
     this.location = options.location;
     this.payloadBucket = options.payloadBucket;
   }
@@ -884,10 +887,7 @@ export class GCFBootstrapper {
     logger.info('scheduling cloud task');
     // Make a task here and return 200 as this is coming from GitHub
     // queue name can contain only letters ([A-Za-z]), numbers ([0-9]), or hyphens (-):
-    const queueName = this.functionName.replace(
-      /_/g,
-      '-'
-    );
+    const queueName = this.functionName.replace(/_/g, '-');
     const queuePath = this.cloudTasksClient.queuePath(
       this.projectId,
       this.location,

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -59,6 +59,67 @@ describe('GCFBootstrapper', () => {
     process.env = {...storedEnv};
   });
 
+  describe('configuration', () => {
+    it('requires a projectId to be set', () => {
+      assert.throws(
+        () => {
+          new GCFBootstrapper({
+            functionName: 'my-function',
+            location: 'my-location',
+          });
+        },
+        {
+          message: /Missing required `projectId`/,
+        }
+      );
+    });
+    it('requires a functionName to be set', () => {
+      assert.throws(
+        () => {
+          new GCFBootstrapper({
+            projectId: 'my-project',
+            location: 'my-location',
+          });
+        },
+        {
+          message: /Missing required `functionName`/,
+        }
+      );
+    });
+    it('requires a location to be set', () => {
+      assert.throws(
+        () => {
+          new GCFBootstrapper({
+            projectId: 'my-project',
+            functionName: 'my-function',
+          });
+        },
+        {
+          message: /Missing required `location`/,
+        }
+      );
+    });
+    it('can be configured via constructor args', () => {
+      const bootstrapper = new GCFBootstrapper({
+        projectId: 'my-project',
+        functionName: 'my-function',
+        location: 'my-location',
+      });
+      assert.strictEqual(bootstrapper.projectId, 'my-project');
+      assert.strictEqual(bootstrapper.functionName, 'my-function');
+      assert.strictEqual(bootstrapper.location, 'my-location');
+    });
+    it('can be configured via environment variables', () => {
+      process.env.GCF_SHORT_FUNCTION_NAME = 'fake-function';
+      process.env.GCF_LOCATION = 'canada1-fake';
+      process.env.PROJECT_ID = 'fake-project';
+      const bootstrapper = new GCFBootstrapper();
+      assert.strictEqual(bootstrapper.projectId, 'fake-project');
+      assert.strictEqual(bootstrapper.functionName, 'fake-function');
+      assert.strictEqual(bootstrapper.location, 'canada1-fake');
+    });
+  });
+
   describe('gcf', () => {
     let handler: HandlerFunction;
     let response: express.Response;

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -973,7 +973,7 @@ describe('GCFBootstrapper', () => {
 
     beforeEach(() => {
       secretClientStub = new v1.SecretManagerServiceClient();
-      bootstrapper = new GCFBootstrapper(secretClientStub);
+      bootstrapper = new GCFBootstrapper({secretsClient: secretClientStub});
 
       secretVersionNameStub = sandbox
         .stub(bootstrapper, 'getLatestSecretVersionName')
@@ -1067,12 +1067,7 @@ describe('GCFBootstrapper', () => {
   });
 
   describe('getSecretName', () => {
-    let bootstrapper: GCFBootstrapper;
     const storedEnv = process.env;
-
-    beforeEach(() => {
-      bootstrapper = new GCFBootstrapper();
-    });
 
     afterEach(() => {
       process.env = storedEnv;
@@ -1081,6 +1076,7 @@ describe('GCFBootstrapper', () => {
     it('formats from env even with nothing', async () => {
       delete process.env.PROJECT_ID;
       delete process.env.GCF_SHORT_FUNCTION_NAME;
+      const bootstrapper = new GCFBootstrapper();
       const latest = bootstrapper.getSecretName();
       assert.strictEqual(latest, 'projects//secrets/');
     });
@@ -1088,6 +1084,7 @@ describe('GCFBootstrapper', () => {
     it('formats from env', async () => {
       process.env.PROJECT_ID = 'foo';
       process.env.GCF_SHORT_FUNCTION_NAME = 'bar';
+      const bootstrapper = new GCFBootstrapper();
       const latest = bootstrapper.getSecretName();
       assert.strictEqual(latest, 'projects/foo/secrets/bar');
     });

--- a/packages/gcf-utils/test/server.ts
+++ b/packages/gcf-utils/test/server.ts
@@ -32,7 +32,11 @@ describe('GCFBootstrapper', () => {
   describe('server', () => {
     const sandbox = sinon.createSandbox();
     let server: http.Server;
-    const bootstrapper = new GCFBootstrapper();
+    const bootstrapper = new GCFBootstrapper({
+      projectId: 'test-project',
+      functionName: 'test-bot',
+      location: 'some-location',
+    });
     const issueSpy = sandbox.stub();
     const repositoryCronSpy = sandbox.stub();
     const installationCronSpy = sandbox.stub();


### PR DESCRIPTION
* Changes the constructor argument from positional args to an options object (technically breaking, but the only usage is in our tests).
* Default options to reading from the environment variables
* Throws errors early if required options are not set (rather than crashing later or having unexpected behavior)
* Refactors the tests to only set env variables for the duration of a single test.

Fixes #2139