### PR TITLE
build: add index.yaml for datastore indexes

### DIFF
--- a/packages/merge-on-green/index.yaml
+++ b/packages/merge-on-green/index.yaml
@@ -1,0 +1,7 @@
+# to update, run:
+# gcloud --project=repo-automation-bots datastore indexes create index.yaml --quiet
+indexes:
+- kind: mog-prs
+  properties:
+    - name: installationId
+    - name: created


### PR DESCRIPTION
We added a filter in the datastore query for PRs. This is the index.yaml used to configure the now necessary index.