### PR TITLE
fix(cron-utils): correctly set attemptDeadline at top level

### DIFF
--- a/packages/cron-utils/src/cron-utils.ts
+++ b/packages/cron-utils/src/cron-utils.ts
@@ -116,6 +116,7 @@ export async function createOrUpdateCron(
   const jobParams = {
     schedule: cronEntry.schedule,
     description: cronEntry.description,
+    attemptDeadline: {seconds: '540'}, // The max request time for the Cloud Function.
     httpTarget: {
       uri: targetUrl,
       httpMethod: protos.google.cloud.scheduler.v1.HttpMethod.POST,
@@ -127,7 +128,6 @@ export async function createOrUpdateCron(
         'Content-Type': 'application/json',
       },
       body: Buffer.from(JSON.stringify(bodyContent), 'utf-8'),
-      attemptDeadline: '540s', // The max request time for the Cloud Function.
     },
     timeZone: 'America/Los_Angeles',
   };


### PR DESCRIPTION
fix #2163

Sorry I thought I tested the last change locally, but I didn't test it
properly. This time I started from 180s scheduler job and updated it to
540s deadline with the updated code.
