### PR TITLE
fix(gcf-utils): use raw body for signature verification

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -333,10 +333,7 @@ export class GCFBootstrapper {
     const sha1Signature =
       request.get('x-hub-signature') || request.get('X-Hub-Signature');
     if (sha1Signature) {
-      // See https://github.com/googleapis/repo-automation-bots/issues/2092
-      return sha1Signature.startsWith('sha1=')
-        ? sha1Signature
-        : `sha1=${sha1Signature}`;
+      return sha1Signature;
     }
     return 'unset';
   }

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -32,7 +32,7 @@ import {GCFLogger} from './logging/gcf-logger';
 import {v4} from 'uuid';
 import {getServer} from './server/server';
 
-// On Cloud Functions, rawBody is automatially added.
+// On Cloud Functions, rawBody is automatically added.
 // It's not guaranteed on other platform.
 export interface RequestWithRawBody extends express.Request {
   rawBody?: Buffer;
@@ -365,8 +365,8 @@ export class GCFBootstrapper {
       '';
     const taskRetries = parseInt(
       request.get('X-CloudTasks-TaskRetryCount') ||
-        request.get('x-cloudtasks-taskretrycount') ||
-        '0'
+      request.get('x-cloudtasks-taskretrycount') ||
+      '0'
     );
     return {name, id, signature, taskId, taskRetries};
   }

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -365,8 +365,8 @@ export class GCFBootstrapper {
       '';
     const taskRetries = parseInt(
       request.get('X-CloudTasks-TaskRetryCount') ||
-      request.get('x-cloudtasks-taskretrycount') ||
-      '0'
+        request.get('x-cloudtasks-taskretrycount') ||
+        '0'
     );
     return {name, id, signature, taskId, taskRetries};
   }

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -32,11 +32,17 @@ import {GCFLogger} from './logging/gcf-logger';
 import {v4} from 'uuid';
 import {getServer} from './server/server';
 
+// On Cloud Functions, rawBody is automatially added.
+// It's not guaranteed on other platform.
+export interface RequestWithRawBody extends express.Request {
+  rawBody?: Buffer;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const LoggingOctokitPlugin = require('../src/logging/logging-octokit-plugin.js');
 
 export type HandlerFunction = (
-  request: express.Request,
+  request: RequestWithRawBody,
   response: express.Response
 ) => Promise<void>;
 
@@ -429,7 +435,7 @@ export class GCFBootstrapper {
    * @param wrapOptions {WrapOptions} Bot handler options
    */
   gcf(appFn: ApplicationFunction, wrapOptions?: WrapOptions): HandlerFunction {
-    return async (request: express.Request, response: express.Response) => {
+    return async (request: RequestWithRawBody, response: express.Response) => {
       const wrapConfig = this.parseWrapConfig(wrapOptions);
 
       this.probot =
@@ -448,7 +454,10 @@ export class GCFBootstrapper {
       // validate the signature
       if (
         !wrapConfig.skipVerification &&
-        !this.probot.webhooks.verify(request.body, signature)
+        !this.probot.webhooks.verify(
+          request.rawBody ? request.rawBody.toString() : request.body,
+          signature
+        )
       ) {
         response.send({
           statusCode: 400,

--- a/packages/gcf-utils/test/fixtures/payload.json
+++ b/packages/gcf-utils/test/fixtures/payload.json
@@ -1,0 +1,3 @@
+{
+  installation: {id: 1},
+}

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -1007,39 +1007,6 @@ describe('GCFBootstrapper', () => {
         sinon.assert.notCalled(installationCronSpy);
         sinon.assert.notCalled(globalCronSpy);
       });
-
-      // Remove this test after https://github.com/googleapis/repo-automation-bots/issues/2092
-      // is fixed.
-      it('handles valid task request signatures without leading sha1', async () => {
-        await mockBootstrapper({
-          logging: false,
-          background: true,
-          skipVerification: false,
-        });
-        // req.body is a parsed json object.
-        req.body = {
-          installation: {id: 1},
-        };
-        // while req.rawBody is a raw buffer
-        req.rawBody = fs.readFileSync('test/fixtures/payload.json');
-        req.headers = {};
-        req.headers['x-github-event'] = 'issues';
-        req.headers['x-github-delivery'] = '123';
-        req.headers['x-cloudtasks-taskname'] = 'my-task';
-        // cat fixtures/payload.json | openssl dgst -sha1 -hmac "foo"
-        req.headers['x-hub-signature'] =
-          'fd28a625d68ef18fe9b532fd972514774fed9653';
-
-        await handler(req, response);
-
-        sinon.assert.calledOnce(configStub);
-        sinon.assert.notCalled(sendStatusStub);
-        sinon.assert.calledOnceWithMatch(sendStub, {statusCode: 200});
-        sinon.assert.calledOnce(issueSpy);
-        sinon.assert.notCalled(repositoryCronSpy);
-        sinon.assert.notCalled(installationCronSpy);
-        sinon.assert.notCalled(globalCronSpy);
-      });
     });
   });
 

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -17,11 +17,13 @@ import {
   WrapOptions,
   logger,
   HandlerFunction,
+  RequestWithRawBody,
 } from '../src/gcf-utils';
 import {describe, beforeEach, afterEach, it} from 'mocha';
 import {Octokit} from '@octokit/rest';
 import {Options} from 'probot';
 import * as express from 'express';
+import fs from 'fs';
 import sinon from 'sinon';
 import nock from 'nock';
 import assert from 'assert';
@@ -130,7 +132,7 @@ describe('GCFBootstrapper', () => {
   describe('gcf', () => {
     let handler: HandlerFunction;
     let response: express.Response;
-    let req: express.Request;
+    let req: RequestWithRawBody;
     let sendStub: sinon.SinonStub;
     let sendStatusStub: sinon.SinonStub;
     let issueSpy: sinon.SinonStub;
@@ -157,6 +159,7 @@ describe('GCFBootstrapper', () => {
         Object.getPrototypeOf(express.request),
         Object.getOwnPropertyDescriptors(express.request)
       );
+      req.rawBody = Buffer.from('');
       response = Object.create(
         Object.getPrototypeOf(express.response),
         Object.getOwnPropertyDescriptors(express.response)
@@ -923,9 +926,12 @@ describe('GCFBootstrapper', () => {
           background: true,
           skipVerification: false,
         });
+        // req.body is a parsed json object.
         req.body = {
           installation: {id: 1},
         };
+        // while req.rawBody is a raw buffer
+        req.rawBody = fs.readFileSync('test/fixtures/payload.json');
         req.headers = {};
         req.headers['x-github-event'] = 'another.name';
         req.headers['x-github-delivery'] = '123';
@@ -948,9 +954,12 @@ describe('GCFBootstrapper', () => {
           background: true,
           skipVerification: false,
         });
+        // req.body is a parsed json object.
         req.body = {
           installation: {id: 1},
         };
+        // while req.rawBody is a raw buffer
+        req.rawBody = fs.readFileSync('test/fixtures/payload.json');
         req.headers = {};
         req.headers['x-github-event'] = 'another.name';
         req.headers['x-github-delivery'] = '123';
@@ -974,16 +983,19 @@ describe('GCFBootstrapper', () => {
           background: true,
           skipVerification: false,
         });
+        // req.body is a parsed json object.
         req.body = {
           installation: {id: 1},
         };
+        // while req.rawBody is a raw buffer
+        req.rawBody = fs.readFileSync('test/fixtures/payload.json');
         req.headers = {};
         req.headers['x-github-event'] = 'issues';
         req.headers['x-github-delivery'] = '123';
         req.headers['x-cloudtasks-taskname'] = 'my-task';
-        // echo -n '{"installation":{"id":1}}' | openssl dgst -sha1 -hmac "foo"
+        // cat fixtures/payload.json | openssl dgst -sha1 -hmac "foo"
         req.headers['x-hub-signature'] =
-          'sha1=c012c260559a04cf285e05d67e1ecedcad71b931';
+          'sha1=fd28a625d68ef18fe9b532fd972514774fed9653';
 
         await handler(req, response);
 
@@ -1004,16 +1016,19 @@ describe('GCFBootstrapper', () => {
           background: true,
           skipVerification: false,
         });
+        // req.body is a parsed json object.
         req.body = {
           installation: {id: 1},
         };
+        // while req.rawBody is a raw buffer
+        req.rawBody = fs.readFileSync('test/fixtures/payload.json');
         req.headers = {};
         req.headers['x-github-event'] = 'issues';
         req.headers['x-github-delivery'] = '123';
         req.headers['x-cloudtasks-taskname'] = 'my-task';
-        // echo -n '{"installation":{"id":1}}' | openssl dgst -sha1 -hmac "foo"
+        // cat fixtures/payload.json | openssl dgst -sha1 -hmac "foo"
         req.headers['x-hub-signature'] =
-          'c012c260559a04cf285e05d67e1ecedcad71b931';
+          'fd28a625d68ef18fe9b532fd972514774fed9653';
 
         await handler(req, response);
 


### PR DESCRIPTION
The `req.body` is a parsed json object. We should use the raw body
for signature verification.