### PR TITLE
chore(canary-bot): update to gcf-utils@11.3.1

### DIFF
--- a/packages/canary-bot/package-lock.json
+++ b/packages/canary-bot/package-lock.json
@@ -161,9 +161,9 @@
       "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
     },
     "@google-cloud/secret-manager": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.7.1.tgz",
-      "integrity": "sha512-QXFNBQai0/6VW7m8u5GobyqnHOyn4xt/9RlflWvQKzgzetkOasZr7YbG5umhon/Gp70nTiDySLUV0NjCDQcY2g==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.7.2.tgz",
+      "integrity": "sha512-c06OquLy4o9P4PqA5V/IFFtkk2h15U0xImIIBRQD5sEYRXoXyROXhIB8najUD1Z4ywpxWoB6nePjxQ2B4uYY6A==",
       "requires": {
         "google-gax": "^2.12.0"
       }
@@ -205,17 +205,17 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.2.tgz",
-      "integrity": "sha512-UXepkOKCATJrhHGsxt+CGfpZy9zUn1q9mop5kfcXq1fBkTePxVNPOdnISlCbJFlCtld+pSLGyZCzr9/zVprFKA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.3.tgz",
+      "integrity": "sha512-KkKZrX3fVTBYCtUk8I+Y4xWaauEEOIR1mIGoPFUK8C+a9TTub5dmjowJpFGz0dqYj//wJcgVR9fqpoNhSYFfHQ==",
       "requires": {
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.2.tgz",
-      "integrity": "sha512-q2Qle60Ht2OQBCp9S5hv1JbI4uBBq6/mqSevFNK3ZEgRDBCAkWqZPUhD/K9gXOHrHKluliHiVq2L9sw1mVyAIg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.3.tgz",
+      "integrity": "sha512-AtMWwb7kY8DdtwIQh2hC4YFM1MzZ22lMA+gjbnCYDgICt14vX2tCa59bDrEjFyOI4LvORjpvT/UhHUdKvsX8og==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -262,9 +262,9 @@
       }
     },
     "@octokit/auth-app": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-3.5.0.tgz",
-      "integrity": "sha512-U62Ys2qeViLcLRjbwEjfo2wk7bDA5IcRuUJKbhtSDNhZheV227zRPfeCcazbfArY5XDDFvTFZppV3eXLQotMzQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-3.5.2.tgz",
+      "integrity": "sha512-IVgh3UmnJlLRmt5vAhhWqdzlnPo7wKBXXA5NRNyXPpa5bokY29Us6Qt/D33K7umH3xJ6QZLB5USByaMIHTmgOA==",
       "requires": {
         "@octokit/auth-oauth-app": "^4.3.0",
         "@octokit/auth-oauth-user": "^1.2.3",
@@ -304,9 +304,9 @@
       }
     },
     "@octokit/auth-oauth-user": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-1.2.4.tgz",
-      "integrity": "sha512-efOajupCZBP1veqx5w59Qey0lIud1rDUgxTRjjkQDU3eOBmkAasY1pXemDsQwW0I85jb1P/gn2dMejedVxf9kw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-1.3.0.tgz",
+      "integrity": "sha512-3QC/TAdk7onnxfyZ24BnJRfZv8TRzQK7SEFUS9vLng4Vv6Hv6I64ujdk/CUkREec8lhrwU764SZ/d+yrjjqhaQ==",
       "requires": {
         "@octokit/auth-oauth-device": "^3.1.1",
         "@octokit/oauth-methods": "^1.1.0",
@@ -385,9 +385,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.2.tgz",
-      "integrity": "sha512-oJhK/yhl9Gt430OrZOzAl2wJqR0No9445vmZ9Ey8GjUZUpwuu/vmEFP0TDhDXdpGDoxD6/EIFHJEcY8nHXpDTA=="
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.4.tgz",
+      "integrity": "sha512-binmLrMQWBG0CvUE/jS3/XXrZbX3oN/6gF7ocSsb/ZJ0xfox2isJN4ZhGeL91SDJVzFK7XuUYBm2mlIDedkxsg=="
     },
     "@octokit/plugin-enterprise-compatibility": {
       "version": "1.3.0",
@@ -412,18 +412,18 @@
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.1.tgz",
-      "integrity": "sha512-3B2iguGmkh6bQQaVOtCsS0gixrz8Lg0v4JuXPqBcFqLKuJtxAUf3K88RxMEf/naDOI73spD+goJ/o7Ie7Cvdjg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.3.tgz",
+      "integrity": "sha512-xHlZK9gxVFP2YQYXOmR1ItCwl9k+0Z3cA40oGMQfpPbWIYY32FTM15Qj+V0V6oLJZr0E26Sz3VX6qYlM/ytfig==",
       "requires": {
-        "@octokit/types": "^6.16.2",
+        "@octokit/types": "^6.16.6",
         "deprecation": "^2.3.1"
       }
     },
     "@octokit/plugin-retry": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.8.tgz",
-      "integrity": "sha512-Pv1At5Wm6ywA2QbB1IElpyrfXVPzdTIbdeXjKRh9sJ/7fT+cZVSHTiQwm+YzoFZsoNBHhYSdS3JKNZzKsH0KdA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz",
+      "integrity": "sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==",
       "requires": {
         "@octokit/types": "^6.0.3",
         "bottleneck": "^2.15.3"
@@ -462,22 +462,22 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.6.0.tgz",
-      "integrity": "sha512-MdHuXHDJM7e5sUBe3K9tt7th0cs4csKU5Bb52LRi2oHAeIMrMZ4XqaTrEv660HoUPoM1iDlnj27Ab/Nh3MtwlA==",
+      "version": "18.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.6.2.tgz",
+      "integrity": "sha512-q6nrxhM+oXzPmbZlykNaBP1vG0+mU6URLBy9cl4XXrWcD0k0ShYiaXDaPewbllTxoMevqv+OABb+Q7ycUWkE2A==",
       "requires": {
         "@octokit/core": "^3.5.0",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.3.1"
+        "@octokit/plugin-rest-endpoint-methods": "5.3.3"
       }
     },
     "@octokit/types": {
-      "version": "6.16.4",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.4.tgz",
-      "integrity": "sha512-UxhWCdSzloULfUyamfOg4dJxV9B+XjgrIZscI0VCbp4eNrjmorGEw+4qdwcpTsu6DIrm9tQsFQS2pK5QkqQ04A==",
+      "version": "6.16.6",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.6.tgz",
+      "integrity": "sha512-PrEGjMnEhLlNttsuLadEWqXdMYJX3icHHaRs/ChJebRT79VDh/cNkk8bURx05BEEwr7QvaLsRzjt3hNxUJZfXA==",
       "requires": {
-        "@octokit/openapi-types": "^7.3.2"
+        "@octokit/openapi-types": "^7.3.4"
       }
     },
     "@octokit/webhooks": {
@@ -2724,9 +2724,9 @@
       }
     },
     "gcf-utils": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-11.1.0.tgz",
-      "integrity": "sha512-bj0GAfAoVpous4t+wNPXe+e1MvZlnXV3CKMuXS3rw8vdbn4jJK2JjGQ1TiF/PJQYILmqgdjStMYAAQoqSP3vnw==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-11.3.1.tgz",
+      "integrity": "sha512-lFq3k3oG1g6sXORs4V9msNQ28JxIyhj7f6+5hNcOQ2Q4+aTSBoDxNWRzbl8LCNGyzGc04iTV+gXUQkp7iOjNdg==",
       "requires": {
         "@google-cloud/kms": "^2.0.0",
         "@google-cloud/secret-manager": "^3.0.0",
@@ -2744,6 +2744,7 @@
         "@types/lru-cache": "^5.1.0",
         "@types/sonic-boom": "^0.7.0",
         "@types/uuid": "^8.3.0",
+        "body-parser": "^1.19.0",
         "express": "^4.17.1",
         "gaxios": "^4.0.0",
         "get-stream": "^6.0.0",
@@ -2878,9 +2879,9 @@
       }
     },
     "google-gax": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.15.1.tgz",
-      "integrity": "sha512-I5j4JRxx1HfZZBXnQs7gUvRHaTqT8XZ6U/QQWI/mDbf05dXP/vLni+ZkDzUh/XHDtIo/MPVkuEUhkwWwi+vwTg==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.17.0.tgz",
+      "integrity": "sha512-Ze/Oq0atVNKyKvDzQFU8B82V9w36GELQruXGsiY1jnySbieZ9vS75v98V/Z10PktmSVqis4sQ+FwK2gkgwIiiw==",
       "requires": {
         "@grpc/grpc-js": "~1.3.0",
         "@grpc/proto-loader": "^0.6.1",
@@ -3396,9 +3397,9 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "joycon": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
-      "integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.0.1.tgz",
+      "integrity": "sha512-SJcJNBg32dGgxhPtM0wQqxqV0ax9k/9TaUskGDSJkSFSQOEWWvQ3zzWdGQRIUry2j1zA5+ReH13t0Mf3StuVZA=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4379,9 +4380,9 @@
       }
     },
     "pino-pretty": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-5.0.2.tgz",
-      "integrity": "sha512-nOoRoQXYZgURqtSwsM+FLFHBTrZRjuMKfQhELMeewjHnM8xdNhlkqLEGxBpcSCkFlfjHX3jdav9TQzQljjSL9w==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-5.1.0.tgz",
+      "integrity": "sha512-fpDU80MKP59XOWxqV8crTDjRegC2fbDsA56zTr5s1guiv6QuYHILc9x1a4+o9SNPtfmF2kQdpAZS+bIExtbELQ==",
       "requires": {
         "@hapi/bourne": "^2.0.0",
         "@types/node": "^15.3.0",
@@ -4390,7 +4391,7 @@
         "dateformat": "^4.5.1",
         "fast-safe-stringify": "^2.0.7",
         "jmespath": "^0.15.0",
-        "joycon": "^2.2.5",
+        "joycon": "^3.0.0",
         "pump": "^3.0.0",
         "readable-stream": "^3.6.0",
         "rfdc": "^1.3.0",
@@ -4896,9 +4897,9 @@
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "retry-request": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.3.tgz",
-      "integrity": "sha512-QnRZUpuPNgX0+D1xVxul6DbJ9slvo4Rm6iV/dn63e048MvGbUZiKySVt6Tenp04JqmchxjiLltGerOJys7kJYQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.0.tgz",
+      "integrity": "sha512-rIwHm2pipUX7MFTpscNr9CNfOsW3gzcosqUOvS7MbuURgdDeIzNVjA/sNgs4BTt0g3L748hB7Q/Yt6StRFHD4w==",
       "requires": {
         "debug": "^4.1.1"
       }

--- a/packages/canary-bot/package.json
+++ b/packages/canary-bot/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "dayjs": "^1.10.5",
-    "gcf-utils": "^11.1.0"
+    "gcf-utils": "^11.3.1"
   },
   "devDependencies": {
     "@types/mocha": "^8.2.2",


### PR DESCRIPTION
This version of gcf-utils started to use rawBody for signature
verification.

We want to make sure this change works.
