### PR TITLE
fix: canary comments on issue instead of updating issue body

### DIFF
--- a/packages/canary-bot/src/canary-bot.ts
+++ b/packages/canary-bot/src/canary-bot.ts
@@ -72,12 +72,14 @@ export = (app: Probot) => {
 
     // Issue found
     if (issue) {
-      await context.octokit.issues.update({
-        owner: owner,
-        repo: repo,
-        issue_number: issue.number,
-        body: body,
-      });
+      await addOrUpdateIssueComment(
+        context.octokit,
+        owner,
+        repo,
+        issue.number,
+        context.payload.installation!.id,
+        body
+      );
     } else {
       await context.octokit.issues.create({
         owner: owner,

--- a/packages/canary-bot/test/test.ts
+++ b/packages/canary-bot/test/test.ts
@@ -98,6 +98,9 @@ describe('canary-bot', () => {
           organization: {
             login: 'googleapis',
           },
+          installation: {
+            id: 234,
+          },
         },
         id: 'abc123',
       });
@@ -105,21 +108,15 @@ describe('canary-bot', () => {
       for (const scope of scopes) {
         scope.done();
       }
+      sinon.assert.notCalled(addOrUpdateIssueCommentStub);
     });
-    it('updates a correct issue', async () => {
+
+    it('comments on a correct issue', async () => {
       const scopes = [
         listIssues('googleapis', 'repo-automation-bots', [
           {title: 'A canary is not chirping', number: 6},
           {title: 'A canary is chirping', number: 5},
         ]),
-        nock('https://api.github.com')
-          .patch('/repos/googleapis/repo-automation-bots/issues/5', body => {
-            assert(
-              body.body.includes('The dependencies and their versions are')
-            );
-            return true;
-          })
-          .reply(200),
       ];
       await probot.receive({
         name: 'schedule.repository' as '*',
@@ -133,6 +130,9 @@ describe('canary-bot', () => {
           organization: {
             login: 'googleapis',
           },
+          installation: {
+            id: 234,
+          },
         },
         id: 'abc123',
       });
@@ -140,6 +140,15 @@ describe('canary-bot', () => {
       for (const scope of scopes) {
         scope.done();
       }
+      sinon.assert.calledOnceWithMatch(
+        addOrUpdateIssueCommentStub,
+        sinon.match.object,
+        'googleapis',
+        'repo-automation-bots',
+        5,
+        234,
+        sinon.match.string
+      );
     });
   });
 


### PR DESCRIPTION
This will allow us to run multiple copies of canary bot (GCF & Cloud Run). Since they will have different installation ids, both bots can comment on the same repository issue.

The cron behavior is now:
* if the specially named issue is found, find or update the comment with diagnostics
* otherwise, open the issue with diagnostics