### PR TITLE
fix: use gcloud beta run

### DIFF
--- a/packages/owl-bot/cloudbuild.yaml
+++ b/packages/owl-bot/cloudbuild.yaml
@@ -81,7 +81,7 @@ steps:
       - "$_FUNCTION_REGION"
       - "owl-bot"
       - "3600"
-      - "1"
+      - "1" # We want to serve Github webhook quickly.
 
   # Build the CLI container whenever we merge changes to the owl-bot folder.
   # this container is used to run helpers from OwlBot in a Cloud Build

--- a/scripts/publish-cloud-run.sh
+++ b/scripts/publish-cloud-run.sh
@@ -50,7 +50,7 @@ functionName=${botName//-/_}
 queueName=${botName//_/-}
 
 echo "About to cloud run app ${serviceName}"
-gcloud run deploy \
+gcloud beta run deploy \
   --image "gcr.io/${project}/${botName}" \
   --set-env-vars "DRIFT_PRO_BUCKET=${bucket}" \
   --set-env-vars "KEY_LOCATION=${keyLocation}" \


### PR DESCRIPTION
for deploying Cloud Run

gcloud complains with longer timeout:

```
Timeout duration must be less than 15m. Timeouts above 15m are in Beta.
Use "gcloud beta run ..." to set timeouts above 15m.
```