### PR TITLE
fix(owl-bot): bump the maxRetries to 30

### DIFF
--- a/packages/owl-bot/src/app.ts
+++ b/packages/owl-bot/src/app.ts
@@ -25,5 +25,10 @@ module.exports.owl_bot = bootstrap.gcf(
     const config = await bootstrap.getProbotConfig(false);
     OwlBot(config.privateKey, app);
   },
-  {maxPubSubRetries: 3}
+  // owl-bot typically waits for a Cloud Build build to finish.
+  // Cloud Build has a limit for number of concurrent builds, so
+  // owl-bot tends to hit the 540s (9 mins) timeout.
+  // We bump the maxRetries to 30 so that the bot will likely finish
+  // the jobs even there are bunch of Cloud Build builds.
+  {maxRetries: 30, maxPubSubRetries: 3}
 );


### PR DESCRIPTION
We performed a real world stress tests with 80 PRs labeled with
`owlbot:run`. While owl-bot finished all the jobs, some tasks are
retried 4 or 5 times already.

Since we made the owl-bot check a mandatory check, we should minimize
the posibility of discarding the job. Maybe we should change to pull
model, but it needs some design changes.