### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request: null
 name: ci
 jobs:
   changeFinder:
@@ -16,9 +16,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 12
+          cache: npm
       - id: interrogate
         run: node ./.github/workflows/interrogate.js
         env:
@@ -32,9 +33,10 @@ jobs:
         package: ${{fromJson(needs.changeFinder.outputs.nodePaths)}}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - run: echo ./packages/${{ matrix.package }}
       - run: cd ./packages/${{ matrix.package }}
       - run: npm install
@@ -52,23 +54,23 @@ jobs:
       matrix:
         module: ${{fromJson(needs.changeFinder.outputs.goPaths)}}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '^1.16'
-    - name: Install goimports
-      run: go get golang.org/x/tools/cmd/goimports
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: goimports
-      run: |
-        test -z "$($(go env GOPATH)/bin/goimports -l .)"
-      working-directory: ./${{ matrix.module }}
-    - name: Instructions to fix goimports (if necessary)
-      run: echo Run goimports -w .
-      if: failure()
-    - run: go test ./...
-      working-directory: ./${{ matrix.module }}
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "^1.16"
+      - name: Install goimports
+        run: go get golang.org/x/tools/cmd/goimports
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: goimports
+        run: |
+          test -z "$($(go env GOPATH)/bin/goimports -l .)"
+        working-directory: ./${{ matrix.module }}
+      - name: Instructions to fix goimports (if necessary)
+        run: echo Run goimports -w .
+        if: failure()
+      - run: go test ./...
+        working-directory: ./${{ matrix.module }}
   bash-test:
     runs-on: ubuntu-latest
     needs: changeFinder
@@ -88,17 +90,21 @@ jobs:
     needs: changeFinder
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 12
+          cache: npm
       - run: npm install
-      - run: node ./.github/workflows/finale.js '${{needs.changeFinder.outputs.requiredJobs}}' ${{secrets.GITHUB_TOKEN}}
+      - run: node ./.github/workflows/finale.js
+          '${{needs.changeFinder.outputs.requiredJobs}}'
+          ${{secrets.GITHUB_TOKEN}}
   docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: JustinBeckwith/linkinator-action@v1
         with:
-          paths: '**/*.md'
-          verbosity: 'ERROR'
-          skip: 'node_modules/ http://devrel/products http://localhost:3000 https://www.github.com/googleapis/repo-automation-bots/compare/*'
+          paths: "**/*.md"
+          verbosity: "ERROR"
+          skip: "node_modules/ http://devrel/products http://localhost:3000
+            https://www.github.com/googleapis/repo-automation-bots/compare/*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.16"
+          go-version: '^1.16'
       - name: Install goimports
         run: go get golang.org/x/tools/cmd/goimports
       - name: Checkout code
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: JustinBeckwith/linkinator-action@v1
         with:
-          paths: "**/*.md"
-          verbosity: "ERROR"
-          skip: "node_modules/ http://devrel/products http://localhost:3000
-            https://www.github.com/googleapis/repo-automation-bots/compare/*"
+          paths: '**/*.md'
+          verbosity: 'ERROR'
+          skip: 'node_modules/ http://devrel/products http://localhost:3000
+            https://www.github.com/googleapis/repo-automation-bots/compare/*'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - master
-  pull_request: null
+  pull_request:
 name: ci
 jobs:
   changeFinder:


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

Fix #2243

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
