### PR TITLE
fix(snippet-bot): skip errors when fetching renamed files

### DIFF
--- a/packages/snippet-bot/src/region-tag-parser.ts
+++ b/packages/snippet-bot/src/region-tag-parser.ts
@@ -162,7 +162,8 @@ export async function parseRegionTagsInPullRequest(
       } catch (err) {
         // See: https://github.com/googleapis/repo-automation-bots/issues/2246
         // TODO: Migrate to Git Data API.
-        err.message = `Skipping the diff entry because it failed to read the` +
+        err.message =
+          'Skipping the diff entry because it failed to read the' +
           ` file: ${err.message}`;
         logger.error(err);
         continue;

--- a/packages/snippet-bot/test/region-tag-parser.ts
+++ b/packages/snippet-bot/test/region-tag-parser.ts
@@ -155,7 +155,7 @@ describe('region-tag-parser', () => {
           .get(
             '/repos/headOwner/headRepo/contents/storage%2Fs3-sdk%2Fsrc%2Fmain%2Fjava%2Fstorage%2Fs3sdk%2FListGcsBuckets.java?ref=headSha'
           )
-          .reply(400, "File too big"),
+          .reply(400, 'File too big'),
       ];
 
       const result = await parseRegionTagsInPullRequest(


### PR DESCRIPTION
part of #2246

This is not a complete solution, but pragmatically it will work well.
The bot used to die when there is a file larger than 1MB.

With this PR, the bot ignores such an error. Most of the cases, those
large files are data files and they normally don't include region tags.