### PR TITLE
fix: log label names rather than objects

### DIFF
--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -344,9 +344,11 @@ export = (app: Probot) => {
       )
     ) {
       logger.info(
-        `ignoring non-force label action (${context.payload.pull_request.labels.join(
-          ', '
-        )})`
+        `ignoring non-force label action (${context.payload.pull_request.labels
+          .map(label => {
+            return label.name;
+          })
+          .join(', ')})`
       );
       return;
     }


### PR DESCRIPTION
We are logging the full label objects as strings which makes the logs appear like `[object], [object]`. We actually want to log the label names.
