### PR TITLE
fix(owl-bot): Set minInstances to 3, concurrency to 40.

### DIFF
--- a/packages/owl-bot/cloudbuild.yaml
+++ b/packages/owl-bot/cloudbuild.yaml
@@ -79,9 +79,15 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
+      # botName
       - "owl-bot"
+      # timeout
       - "3600"
-      - "1" # We want to serve Github webhook quickly.
+      # minInstances: We want to serve Github webhook quickly.
+      - "3"
+      # concurrency: We saw some errors in gRPC stack (#2265) with the default
+      # 80 concurrency.
+      - "40"
 
   # Build the CLI container whenever we merge changes to the owl-bot folder.
   # this container is used to run helpers from OwlBot in a Cloud Build

--- a/scripts/publish-cloud-run.sh
+++ b/scripts/publish-cloud-run.sh
@@ -45,7 +45,7 @@ else
 fi
 
 if [ $# -ge 10 ]; then
-  concurrency=$10
+  concurrency=${10}
 else
   concurrency="80"
 fi

--- a/scripts/publish-cloud-run.sh
+++ b/scripts/publish-cloud-run.sh
@@ -16,7 +16,7 @@
 set -eo pipefail
 
 if [ $# -lt 6 ]; then
-  echo "Usage: $0 <botDirectory> <projectId> <bucket> <keyLocation> <keyRing> <region> [botName] [timeout] [min-instance]"
+  echo "Usage: $0 <botDirectory> <projectId> <bucket> <keyLocation> <keyRing> <region> [botName] [timeout] [min-instance] [concurrency]"
   exit 1
 fi
 
@@ -42,6 +42,12 @@ if [ $# -ge 9 ]; then
   minInstances=$9
 else
   minInstances="0"
+fi
+
+if [ $# -ge 10 ]; then
+  concurrency=$10
+else
+  concurrency="80"
 fi
 
 if [ "${project}" == "repo-automation-bots" ]; then
@@ -87,6 +93,8 @@ deployArgs=(
   "${timeout}"
   "--min-instances"
   "${minInstances}"
+  "--concurrency"
+  "${concurrency}"
   "--quiet"
 )
 if [ -n "${SERVICE_ACCOUNT}" ]; then


### PR DESCRIPTION
I recommend that we set minInstances to 3 for not dropping webhook
requests and set concurrency to 40 because we have seen some errors in
gRPC stack (#2265) with the default 80 concurrency.
