### PR TITLE
Revert "deps(release-please): release please with fix for pre-releases"

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -5476,9 +5476,9 @@
       }
     },
     "release-please": {
-      "version": "11.20.1",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-11.20.1.tgz",
-      "integrity": "sha512-1gtbHOelKmUXR9Q0FSsBpzTbSlaJylRhksLVEa7ty/Dru5ENpLJwzQ8EieBTDHyKaZSawGT+hxqF8eBMIZnpvA==",
+      "version": "11.19.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-11.19.0.tgz",
+      "integrity": "sha512-H0IoS8jfWo9u2W9O1LowgbZ1KF97SAwyNg8rvyX26yj0YLtXwnXu7fIhTJik2xnPX9c1X9amR6fxcjOHqgMFZg==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",
@@ -5516,9 +5516,9 @@
           }
         },
         "type-fest": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.3.0.tgz",
-          "integrity": "sha512-mYUYkAy6fPatVWtUeCV/qGeGL3IVucmdJOzeAEfwgCJDx8gP0JaW8jn6KQ5xDfPec31e0KXWn5EUOZMhquR1zA=="
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.3.tgz",
+          "integrity": "sha512-w81kTuuq5V8j7aZamYO9TJ+LYqhw11mkHyMISJIRl2+uMYmgOj3yhSLk2qH6lznyTicBOdMrudxrrVvCQzK1tQ=="
         },
         "typescript": {
           "version": "3.9.10",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -32,7 +32,7 @@
     "@google-automations/label-utils": "^1.1.0",
     "@octokit/webhooks": "^9.11.0",
     "gcf-utils": "^12.0.0",
-    "release-please": "^11.20.1"
+    "release-please": "^11.19.0"
   },
   "devDependencies": {
     "@octokit/rest": "^18.7.2",


### PR DESCRIPTION
We're seeing a ton of exceptions `PathNotFoundError: Could not find requested path: google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java` starting 18 hours ago which matches up with this release

See #2335