### PR TITLE
fix(build): run OwlBot from main

### DIFF
--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -115,7 +115,7 @@ export async function triggerPostProcessBuild(
     triggerId: args.trigger,
     source: {
       projectId: project,
-      branchName: 'master', // TODO: It might fail if we change the default branch.
+      branchName: 'main', // TODO: It might fail if we change the default branch.
       substitutions: {
         _GITHUB_TOKEN: token.token,
         _PR: args.pr.toString(),


### PR DESCRIPTION
Once we've swapped branch over we should invoke job against `main`.