### PR TITLE
fix: used wrong branch name in pull request

### DIFF
--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -525,6 +525,6 @@ export function userCheckedRegenerateBox(
     prBody: newBody,
     gcpProjectId: project,
     buildTriggerId: trigger,
-    branch: payload.pull_request.base.ref,
+    branch: payload.pull_request.head.ref,
   };
 }

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -1364,6 +1364,12 @@ function pullRequestEditedEventFrom(
         repo: {
           full_name: 'googleapis/nodejs-dlp',
         },
+        ref: 'main',
+      },
+      head: {
+        repo: {
+          full_name: 'googleapis/nodejs-dlp',
+        },
         ref: 'owl-bot-update-branch',
       },
       number: 48,


### PR DESCRIPTION
When updating an existing pull request, Owl Bot should be pushing changes to the pull request's branch, not the main branch.

Error as seen in the wild:
```
Cloning into '/tmp/tmp-1-nvrfgINIetD7/dest'...
git checkout -b master
fatal: A branch named 'master' already exists.
```
