### PR TITLE
fix: git commit failed with "please tell me who you are"

### DIFF
--- a/packages/owl-bot/cloud-build/copy-code-again.yaml
+++ b/packages/owl-bot/cloud-build/copy-code-again.yaml
@@ -70,6 +70,9 @@ steps:
       - ${_PR_BRANCH}
       - --github-token
       - ${_GITHUB_TOKEN}
+    env:
+      - 'HOME=/workspace'
+
 
 # The github token only lives 10 minutes.
 timeout: '600s'


### PR DESCRIPTION
Earlier steps properly call `git config --global user.name 'Owl Bot'`, with the environment variable `HOME=/workspace`.  I think git couldn't find it those credentials in the final step because `HOME` was not set.
