### PR TITLE
feat: allow copy-code to use non-repo dirs as sources

### DIFF
--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -330,8 +330,10 @@ export async function copyCode(
     // sourceRepo is not a repo.  It's a bazel-bin directory, so there's
     // no corresponding commit hash, and that's ok.
   } else if (sourceCommitHash) {
+    // User provided us a commithash.  Checkout that version.
     cmd(`git checkout ${sourceCommitHash}`, {cwd: sourceDir});
   } else {
+    // User wants to use the latest commit in the repo.  Get its commit hash.
     sourceCommitHash = cmd('git log -1 --format=%H', {cwd: sourceDir})
       .toString('utf8')
       .trim();

--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -325,7 +325,11 @@ export async function copyCode(
   const cmd = newCmd(logger);
   const sourceDir = toLocalRepo(sourceRepo, workDir, logger);
   // Check out the specific hash we want to copy from.
-  if (sourceCommitHash) {
+  if ('none' === sourceCommitHash) {
+    // User is running copy-code from command line.  The path specified by
+    // sourceRepo is not a repo.  It's a bazel-bin directory, so there's
+    // no corresponding commit hash, and that's ok.
+  } else if (sourceCommitHash) {
     cmd(`git checkout ${sourceCommitHash}`, {cwd: sourceDir});
   } else {
     sourceCommitHash = cmd('git log -1 --format=%H', {cwd: sourceDir})


### PR DESCRIPTION
The need for this feature arose while discussing: https://github.com/googleapis/java-spanner/pull/1356.

The spanner library maintainers want to play with proto changes and see how they would affect the library.  They'll need to invoke copy-code on a bazel-bin output directory which has no commithash.

