### PR TITLE
build(release-trigger): use custom service account

### DIFF
--- a/packages/release-trigger/cloudbuild.yaml
+++ b/packages/release-trigger/cloudbuild.yaml
@@ -33,7 +33,7 @@ steps:
     waitFor: ["push-docker"]
     entrypoint: bash
     env:
-      - "SERVICE_ACCOUNT=autorelease@repo-automation-bots.iam.gserviceaccount.com"
+      - "SERVICE_ACCOUNT=autorelease@cloud-devrel-kokoro-resources.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-cloud-run.sh"

--- a/packages/release-trigger/cloudbuild.yaml
+++ b/packages/release-trigger/cloudbuild.yaml
@@ -32,6 +32,8 @@ steps:
     id: "deploy-cloud-run"
     waitFor: ["push-docker"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=autorelease@cloud-devrel-kokoro-resources.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-cloud-run.sh"

--- a/packages/release-trigger/cloudbuild.yaml
+++ b/packages/release-trigger/cloudbuild.yaml
@@ -33,7 +33,7 @@ steps:
     waitFor: ["push-docker"]
     entrypoint: bash
     env:
-      - "SERVICE_ACCOUNT=autorelease@cloud-devrel-kokoro-resources.iam.gserviceaccount.com"
+      - "SERVICE_ACCOUNT=autorelease@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-cloud-run.sh"

--- a/scripts/publish-cloud-run.sh
+++ b/scripts/publish-cloud-run.sh
@@ -101,7 +101,7 @@ if [ -n "${SERVICE_ACCOUNT}" ]; then
   deployArgs+=( "--service-account" "${SERVICE_ACCOUNT}" )
 fi
 echo "About to cloud run app ${serviceName}"
-gcloud beta run deploy "${serviceName}" "${deployArgs[@]}"
+gcloud run deploy "${serviceName}" "${deployArgs[@]}"
 
 echo "Adding ability for allUsers to execute the Function"
 gcloud run services add-iam-policy-binding "${serviceName}" \


### PR DESCRIPTION
Deploys the release-trigger bot as the `autorelease@repo-automation-bots.iam.gserviceaccount.com` service account