### PR TITLE
feat: copy-bazel-bin command

### DIFF
--- a/packages/owl-bot/Dockerfile
+++ b/packages/owl-bot/Dockerfile
@@ -31,7 +31,9 @@ RUN apk update && apk upgrade && \
 # RUN npm ci --only=production
 RUN npm install
 RUN npm run compile
-RUN chmod 755 /usr/src/app/build/src/bin/owl-bot.js
+
+# Make sure users besides root can run the app.
+RUN chmod a+rx -R .
 
 # Run the web service on container startup.
 ENTRYPOINT ["/usr/src/app/build/src/bin/owl-bot.js"]

--- a/packages/owl-bot/src/bazel-bin.ts
+++ b/packages/owl-bot/src/bazel-bin.ts
@@ -1,0 +1,87 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import glob from 'glob';
+import {newCmd} from './cmd';
+import path from 'path';
+import * as fs from 'fs';
+
+/**
+ * Run `Bazel build ...` in googleapis/googleapis to build tar balls of source
+ * code.  This function unpacks those tarballs into the same directory structure
+ * as googleapis-gen.
+ */
+export function unpackTarBalls(
+  bazelBinDir: string,
+  outDir: string,
+  buildTargetStem = '',
+  logger = console
+) {
+  const cmd = newCmd(logger);
+  const pattern = makeTarBallPattern(buildTargetStem);
+  const tarBalls = glob.sync(pattern, {cwd: bazelBinDir});
+  for (const tarBall of tarBalls) {
+    const parentDir = path.dirname(tarBall);
+    const tarBallFullPath = path.join(bazelBinDir, tarBall);
+    const targetDir = path.join(outDir, parentDir);
+    fs.mkdirSync(targetDir, {recursive: true});
+    cmd(`tar xf ${tarBallFullPath} -C ${targetDir}`);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////
+// Unpacking *all* the tarballs would take a while and annoy users.
+// The following functions select just the relevant tarballs.
+
+// Exported for testing purposes only.
+export function makeTarBallPattern(buildTargetStem: string): string {
+  // Strip leading / if present.
+  const stem = buildTargetStem.replace(/^\/+/, '');
+  // Construct the glob pattern.
+  // a/bc => a/bc*/**/*.tar.gz
+  // a/bc/ => a/bc/**/*.tar.gz
+  const lastStemChar = stem.length ? stem[stem.length - 1] : '/';
+  return lastStemChar === '/' ? stem + '**/*.tar.gz' : stem + '*/**/*.tar.gz';
+}
+
+/**
+ * Finds the common directory stem across a range of regular expressions.
+ */
+export function getCommonStem(regexps: string[]): string {
+  if (regexps.length < 1) {
+    return '';
+  }
+  let stem = regexps[0];
+  for (const regexp of regexps.slice(1)) {
+    stem = getCommonPrefix(regexp, stem);
+  }
+  // Cut any regular expression characters off the stem.
+  const controlCharIndex = stem.search(/[-[\]{}()*+?.,\\^$|#\s]/g);
+  return controlCharIndex < 0 ? stem : stem.slice(0, controlCharIndex);
+}
+
+function getCommonPrefix(a: string, b: string): string {
+  // eslint-disable-next-line
+  for (let i = 0; true; ++i) {
+    if (i >= a.length) {
+      return a;
+    }
+    if (i >= b.length) {
+      return b;
+    }
+    if (a[i] !== b[i]) {
+      return a.slice(0, i);
+    }
+  }
+}

--- a/packages/owl-bot/src/bazel-bin.ts
+++ b/packages/owl-bot/src/bazel-bin.ts
@@ -21,6 +21,11 @@ import * as fs from 'fs';
  * Run `Bazel build ...` in googleapis/googleapis to build tar balls of source
  * code.  This function unpacks those tarballs into the same directory structure
  * as googleapis-gen.
+ * @param bazelBinDir path to build output directory; should always end with bazel-bin.
+ * @param outDir directory where tarballs will be unpacked; corresponds to
+ *               googleapis/googleapis-gen.
+ * @param buildTargetStem only unpack tarballs whose paths have a common stem;
+ *                        empty means unpack all the tarballs.
  */
 export function unpackTarBalls(
   bazelBinDir: string,

--- a/packages/owl-bot/src/bin/commands/copy-bazel-bin.ts
+++ b/packages/owl-bot/src/bin/commands/copy-bazel-bin.ts
@@ -1,0 +1,56 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// To Run: node ./build/src/bin/owl-bot.js copy-code <args>
+
+import yargs = require('yargs');
+import tmp from 'tmp';
+import {copyDirs, loadOwlBotYaml} from '../../copy-code';
+import {getCommonStem, unpackTarBalls} from '../../bazel-bin';
+
+interface Args {
+  'source-dir': string;
+  dest: string | undefined;
+}
+
+export const copyBazelBin: yargs.CommandModule<{}, Args> = {
+  command: 'copy-bazel-bin',
+  describe: 'copies source code from bazel output into a local repo',
+  builder(yargs) {
+    return yargs
+      .option('source-dir', {
+        describe:
+          'The source directory.  Example: ~/my-repos/googleapis/bazel-bin',
+        type: 'string',
+        demand: true,
+        default: '',
+      })
+      .option('dest', {
+        describe:
+          'The directory containing a local repo.  Example: nodejs/vision.' +
+          '  Defaults to the current working directory.',
+        type: 'string',
+        demand: false,
+      });
+  },
+  async handler(argv) {
+    const destDir = argv.dest ?? process.cwd();
+    const tempDir = tmp.dirSync().name;
+    const yaml = await loadOwlBotYaml(destDir);
+    const sourceRegexps = (yaml['deep-copy-regex'] ?? []).map(x => x.source);
+    const regexpStem = getCommonStem(sourceRegexps);
+    unpackTarBalls(argv['source-dir'], tempDir, regexpStem);
+    copyDirs(tempDir, destDir, yaml);
+  },
+};

--- a/packages/owl-bot/src/bin/owl-bot.ts
+++ b/packages/owl-bot/src/bin/owl-bot.ts
@@ -27,6 +27,7 @@ import {writeLock} from './commands/write-lock';
 import {maybeCreatePullRequestForLockUpdateCommand} from './commands/maybe-create-pull-request-for-lock-update';
 import {testWebhook} from './commands/test-webhook';
 import {copyCodeIntoPullRequestCommand} from './commands/copy-code-into-pull-request';
+import {copyBazelBin} from './commands/copy-bazel-bin';
 
 yargs(process.argv.slice(2))
   .command(triggerBuildCommand)
@@ -36,6 +37,7 @@ yargs(process.argv.slice(2))
   .command(enqueueCopyTasks)
   .command(copyExists)
   .command(copyCodeCommand)
+  .command(copyBazelBin)
   .command(scanGoogleapisGenAndCreatePullRequestsCommand)
   .command(copyCodeAndCreatePullRequestCommand)
   .command(writeLock)

--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -389,14 +389,14 @@ export function copyDirs(
 
   // Wipe out the existing contents of the dest directory.
   const deadPaths: string[] = [];
+  const allDestPaths = glob.sync('**', {
+    cwd: destDir,
+    dot: true,
+    ignore: ['.git', '.git/**'],
+  });
   for (const rmDest of yaml['deep-remove-regex'] ?? []) {
     if (rmDest && stat(destDir)) {
       const rmRegExp = toFrontMatchRegExp(rmDest);
-      const allDestPaths = glob.sync('**', {
-        cwd: destDir,
-        dot: true,
-        ignore: ['.git', '.git/**'],
-      });
       const matchingDestPaths = allDestPaths.filter(path =>
         rmRegExp.test('/' + path)
       );
@@ -428,13 +428,13 @@ export function copyDirs(
   }
 
   // Copy the files from source to dest.
+  const allSourcePaths = glob.sync('**', {
+    cwd: sourceDir,
+    dot: true,
+    ignore: ['.git', '.git/**'],
+  });
   for (const deepCopy of yaml['deep-copy-regex'] ?? []) {
     const regExp = toFrontMatchRegExp(deepCopy.source);
-    const allSourcePaths = glob.sync('**', {
-      cwd: sourceDir,
-      dot: true,
-      ignore: ['.git', '.git/**'],
-    });
     const sourcePathsToCopy = allSourcePaths.filter(path =>
       regExp.test('/' + path)
     );

--- a/packages/owl-bot/test/bazel-bin.ts
+++ b/packages/owl-bot/test/bazel-bin.ts
@@ -1,0 +1,59 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as assert from 'assert';
+import {getCommonStem, makeTarBallPattern} from '../src/bazel-bin';
+
+describe('makeTarBallPattern', () => {
+  it('stripsLeadingSlashes', () => {
+    assert.strictEqual(makeTarBallPattern('///sheep'), 'sheep*/**/*.tar.gz');
+  });
+
+  it("doesn't append star when ends with slash", () => {
+    assert.strictEqual(makeTarBallPattern('a/b/'), 'a/b/**/*.tar.gz');
+  });
+});
+
+describe('getCommonStem', () => {
+  it('real-world', () => {
+    const sources = [
+      '/google/spanner/(v.*)/.*-java/proto-google-.*/src',
+      '/google/spanner/(v.*)/.*-java/grpc-google-.*/src',
+      '/google/spanner/(v.*)/.*-java/gapic-google-.*/src',
+      '/google/spanner/admin/database/(v.*)/.*-java/proto-google-.*/src',
+      '/google/spanner/admin/database/(v.*)/.*-java/grpc-google-.*/src',
+      '/google/spanner/admin/database/(v.*)/.*-java/gapic-google-.*/src',
+      '/google/spanner/admin/instance/(v.*)/.*-java/proto-google-.*/src',
+      '/google/spanner/admin/instance/(v.*)/.*-java/grpc-google-.*/src',
+      '/google/spanner/admin/instance/(v.*)/.*-java/gapic-google-.*/src',
+    ];
+    assert.strictEqual(getCommonStem(sources), '/google/spanner/');
+  });
+
+  it('stops at first regexp control character', () => {
+    const sources = [
+      '/google/spanner/(v.*)/.*-java/proto-google-.*/src',
+      '/google/spanner/(v.*)/.*-java/grpc-google-.*/src',
+    ];
+    assert.strictEqual(getCommonStem(sources), '/google/spanner/');
+  });
+
+  it('one string is full stem', () => {
+    const sources = [
+      '/google/spanner/(v.*)/.*-java/proto-google-.*/src',
+      '/google/span',
+    ];
+    assert.strictEqual(getCommonStem(sources), '/google/span');
+    assert.strictEqual(getCommonStem(sources.reverse()), '/google/span');
+  });
+});


### PR DESCRIPTION
googleapis/java-spanner maintainers like to make manual changes to
protos and see how they get rendered in the library.

This tool allows them to run owl bot's copy function directly on
bazel build output.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/repo-automation-bots/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
