### PR TITLE
fix: check for config file presence, then merge in defaults

### DIFF
--- a/packages/release-trigger/src/bot.ts
+++ b/packages/release-trigger/src/bot.ts
@@ -99,7 +99,7 @@ export = (app: Probot) => {
       context.octokit,
       {owner: repository.owner.login, repo: repository.name}
     );
-    const {token} = (await context.octokit.auth({type: 'event-octokit'})) as {
+    const {token} = (await context.octokit.auth({type: 'installation'})) as {
       token: string;
     };
     for (const pullRequest of releasePullRequests) {
@@ -146,7 +146,7 @@ export = (app: Probot) => {
       return;
     }
 
-    const {token} = (await context.octokit.auth({type: 'event-octokit'})) as {
+    const {token} = (await context.octokit.auth({type: 'installation'})) as {
       token: string;
     };
     await doTrigger(context.octokit, context.payload.pull_request, token);

--- a/packages/release-trigger/src/bot.ts
+++ b/packages/release-trigger/src/bot.ts
@@ -41,12 +41,14 @@ async function doTrigger(octokit: Octokit, pullRequest: PullRequest) {
     return;
   }
   try {
-    await triggerKokoroJob(pullRequest.html_url);
-    await markTriggered(octokit, {
-      owner,
-      repo: pullRequest.base.repo.name,
-      number: pullRequest.number,
-    });
+    await Promise.all([
+      triggerKokoroJob(pullRequest.html_url),
+      markTriggered(octokit, {
+        owner,
+        repo: pullRequest.base.repo.name,
+        number: pullRequest.number,
+      }),
+    ]);
   } catch (e) {
     await markFailed(octokit, {
       owner,

--- a/packages/release-trigger/src/bot.ts
+++ b/packages/release-trigger/src/bot.ts
@@ -17,10 +17,7 @@ import {Probot} from 'probot';
 // eslint-disable-next-line node/no-extraneous-import
 import {Octokit} from '@octokit/rest';
 import {logger} from 'gcf-utils';
-import {
-  ConfigChecker,
-  getConfigWithDefault,
-} from '@google-automations/bot-config-utils';
+import {ConfigChecker, getConfig} from '@google-automations/bot-config-utils';
 import schema from './config-schema.json';
 import {
   ConfigurationOptions,
@@ -72,20 +69,22 @@ export = (app: Probot) => {
       return;
     }
 
-    const remoteConfiguration =
-      await getConfigWithDefault<ConfigurationOptions>(
-        context.octokit,
-        owner,
-        repo,
-        WELL_KNOWN_CONFIGURATION_FILE,
-        DEFAULT_CONFIGURATION,
-        {schema: schema}
-      );
+    const remoteConfiguration = await getConfig<ConfigurationOptions>(
+      context.octokit,
+      owner,
+      repo,
+      WELL_KNOWN_CONFIGURATION_FILE,
+      {schema: schema}
+    );
     if (!remoteConfiguration) {
       logger.info(`release-trigger not configured for ${repoUrl}`);
       return;
     }
-    if (!remoteConfiguration.enabled) {
+    const configuration = {
+      ...DEFAULT_CONFIGURATION,
+      ...remoteConfiguration,
+    };
+    if (!configuration.enabled) {
       logger.info(`release-trigger not enabled for ${repoUrl}`);
       return;
     }
@@ -112,20 +111,22 @@ export = (app: Probot) => {
       return;
     }
 
-    const remoteConfiguration =
-      await getConfigWithDefault<ConfigurationOptions>(
-        context.octokit,
-        owner,
-        repo,
-        WELL_KNOWN_CONFIGURATION_FILE,
-        DEFAULT_CONFIGURATION,
-        {schema: schema}
-      );
+    const remoteConfiguration = await getConfig<ConfigurationOptions>(
+      context.octokit,
+      owner,
+      repo,
+      WELL_KNOWN_CONFIGURATION_FILE,
+      {schema: schema}
+    );
     if (!remoteConfiguration) {
       logger.info(`release-trigger not configured for ${repoUrl}`);
       return;
     }
-    if (!remoteConfiguration.enabled) {
+    const configuration = {
+      ...DEFAULT_CONFIGURATION,
+      ...remoteConfiguration,
+    };
+    if (!configuration.enabled) {
       logger.info(`release-trigger not enabled for ${repoUrl}`);
       return;
     }

--- a/packages/release-trigger/src/bot.ts
+++ b/packages/release-trigger/src/bot.ts
@@ -45,14 +45,12 @@ async function doTrigger(
     return;
   }
   try {
-    await Promise.all([
-      triggerKokoroJob(pullRequest.html_url, token),
-      markTriggered(octokit, {
-        owner,
-        repo: pullRequest.base.repo.name,
-        number: pullRequest.number,
-      }),
-    ]);
+    await triggerKokoroJob(pullRequest.html_url, token);
+    await markTriggered(octokit, {
+      owner,
+      repo: pullRequest.base.repo.name,
+      number: pullRequest.number,
+    });
   } catch (e) {
     await markFailed(octokit, {
       owner,

--- a/packages/release-trigger/src/bot.ts
+++ b/packages/release-trigger/src/bot.ts
@@ -34,7 +34,11 @@ import {
   PullRequest,
 } from './release-trigger';
 
-async function doTrigger(octokit: Octokit, pullRequest: PullRequest, token: string) {
+async function doTrigger(
+  octokit: Octokit,
+  pullRequest: PullRequest,
+  token: string
+) {
   const owner = pullRequest.base.repo.owner?.login;
   if (!owner) {
     logger.error(`no owner for ${pullRequest.number}`);
@@ -95,7 +99,9 @@ export = (app: Probot) => {
       context.octokit,
       {owner: repository.owner.login, repo: repository.name}
     );
-    const {token} = await context.octokit.auth() as {token: string};
+    const {token} = (await context.octokit.auth({type: 'event-octokit'})) as {
+      token: string;
+    };
     for (const pullRequest of releasePullRequests) {
       await doTrigger(context.octokit, pullRequest, token);
     }
@@ -140,7 +146,9 @@ export = (app: Probot) => {
       return;
     }
 
-    const {token} = await context.octokit.auth() as {token: string};
+    const {token} = (await context.octokit.auth({type: 'event-octokit'})) as {
+      token: string;
+    };
     await doTrigger(context.octokit, context.payload.pull_request, token);
   });
 

--- a/packages/release-trigger/src/bot.ts
+++ b/packages/release-trigger/src/bot.ts
@@ -46,13 +46,14 @@ async function doTrigger(
   }
   try {
     await triggerKokoroJob(pullRequest.html_url, token);
-    await markTriggered(octokit, {
+  } catch (e) {
+    await markFailed(octokit, {
       owner,
       repo: pullRequest.base.repo.name,
       number: pullRequest.number,
     });
-  } catch (e) {
-    await markFailed(octokit, {
+  } finally {
+    await markTriggered(octokit, {
       owner,
       repo: pullRequest.base.repo.name,
       number: pullRequest.number,

--- a/packages/release-trigger/src/release-trigger.ts
+++ b/packages/release-trigger/src/release-trigger.ts
@@ -19,10 +19,13 @@ import {logger} from 'gcf-utils';
 import * as child_process from 'child_process';
 
 export const exec = function (
-  command: string
+  command: string,
+  token: string,
 ): Promise<{stdout: string; stderr: string}> {
   return new Promise((resolve, reject) => {
-    child_process.exec(command, (error, stdout, stderr) => {
+    child_process.exec(command, {env: {
+      'GITHUB_TOKEN': token,
+    }}, (error, stdout, stderr) => {
       if (stdout) {
         logger.info(stdout);
       }
@@ -120,14 +123,15 @@ export async function findPendingReleasePullRequests(
 }
 
 export async function triggerKokoroJob(
-  pullRequestUrl: string
+  pullRequestUrl: string,
+  token: string,
 ): Promise<{stdout: string; stderr: string}> {
   logger.info(`triggering job for ${pullRequestUrl}`);
 
   const command = `python3 -m autorelease trigger-single --pull=${pullRequestUrl}`;
   logger.debug(`command: ${command}`);
   try {
-    return await exec(command);
+    return await exec(command, token);
   } catch (e) {
     logger.error(`error executing command: ${command}`, e);
     throw e;

--- a/packages/release-trigger/src/release-trigger.ts
+++ b/packages/release-trigger/src/release-trigger.ts
@@ -138,7 +138,14 @@ export async function triggerKokoroJob(
   const command = `python3 -m autorelease trigger-single --pull=${pullRequestUrl}`;
   logger.debug(`command: ${command}`);
   try {
-    return await exec(command, token);
+    const {stdout, stderr} = await exec(command, token);
+    if (stdout) {
+      logger.info(stdout);
+    }
+    if (stderr) {
+      logger.warn(stderr);
+    }
+    return {stdout, stderr};
   } catch (e) {
     logger.error(`error executing command: ${command}`, e);
     throw e;

--- a/packages/release-trigger/src/release-trigger.ts
+++ b/packages/release-trigger/src/release-trigger.ts
@@ -27,6 +27,7 @@ export const exec = function (
       command,
       {
         env: {
+          ...process.env,
           GITHUB_TOKEN: token,
         },
       },

--- a/packages/release-trigger/src/release-trigger.ts
+++ b/packages/release-trigger/src/release-trigger.ts
@@ -20,24 +20,30 @@ import * as child_process from 'child_process';
 
 export const exec = function (
   command: string,
-  token: string,
+  token: string
 ): Promise<{stdout: string; stderr: string}> {
   return new Promise((resolve, reject) => {
-    child_process.exec(command, {env: {
-      'GITHUB_TOKEN': token,
-    }}, (error, stdout, stderr) => {
-      if (stdout) {
-        logger.info(stdout);
+    child_process.exec(
+      command,
+      {
+        env: {
+          GITHUB_TOKEN: token,
+        },
+      },
+      (error, stdout, stderr) => {
+        if (stdout) {
+          logger.info(stdout);
+        }
+        if (stderr) {
+          logger.warn(stderr);
+        }
+        if (error) {
+          reject(error);
+        } else {
+          resolve({stdout, stderr});
+        }
       }
-      if (stderr) {
-        logger.warn(stderr);
-      }
-      if (error) {
-        reject(error);
-      } else {
-        resolve({stdout, stderr});
-      }
-    });
+    );
   });
 };
 
@@ -124,7 +130,7 @@ export async function findPendingReleasePullRequests(
 
 export async function triggerKokoroJob(
   pullRequestUrl: string,
-  token: string,
+  token: string
 ): Promise<{stdout: string; stderr: string}> {
   logger.info(`triggering job for ${pullRequestUrl}`);
 

--- a/packages/release-trigger/test/bot.ts
+++ b/packages/release-trigger/test/bot.ts
@@ -64,7 +64,7 @@ describe('bot', () => {
       },
     });
     probot.load(myProbotApp);
-    getConfigStub = sandbox.stub(botConfigModule, 'getConfigWithDefault');
+    getConfigStub = sandbox.stub(botConfigModule, 'getConfig');
     sandbox.replace(releaseTriggerModule, 'ALLOWED_ORGANIZATIONS', [
       'Codertocat',
     ]);

--- a/packages/release-trigger/test/release-trigger.ts
+++ b/packages/release-trigger/test/release-trigger.ts
@@ -175,16 +175,12 @@ describe('release-trigger', () => {
       const execStub = sandbox
         .stub(releaseTriggerModule, 'exec')
         .resolves({stdout: 'some output', stderr: 'some error output'});
-      const infoStub = sandbox.stub(logger, 'info');
-      const warnStub = sandbox.stub(logger, 'warn');
       const {stdout, stderr} = await triggerKokoroJob(
         'https://github.com/testOwner/testRepo/pull/1234'
       );
       assert.strictEqual(stdout, 'some output');
       assert.strictEqual(stderr, 'some error output');
       sinon.assert.calledOnce(execStub);
-      sinon.assert.calledWithMatch(infoStub, sinon.match('some output'));
-      sinon.assert.calledWithMatch(warnStub, sinon.match('some error output'));
     });
 
     it('should catch and log an exception', async () => {

--- a/packages/release-trigger/test/release-trigger.ts
+++ b/packages/release-trigger/test/release-trigger.ts
@@ -176,7 +176,8 @@ describe('release-trigger', () => {
         .stub(releaseTriggerModule, 'exec')
         .resolves({stdout: 'some output', stderr: 'some error output'});
       const {stdout, stderr} = await triggerKokoroJob(
-        'https://github.com/testOwner/testRepo/pull/1234'
+        'https://github.com/testOwner/testRepo/pull/1234',
+        'fake-token'
       );
       assert.strictEqual(stdout, 'some output');
       assert.strictEqual(stderr, 'some error output');
@@ -189,7 +190,10 @@ describe('release-trigger', () => {
         .rejects(new Error('Command failed: /bin/false'));
       const errorStub = sandbox.stub(logger, 'error');
       await assert.rejects(
-        triggerKokoroJob('https://github.com/testOwner/testRepo/pull/1234'),
+        triggerKokoroJob(
+          'https://github.com/testOwner/testRepo/pull/1234',
+          'fake-token'
+        ),
         err => {
           if (err instanceof Error) {
             return err.message.startsWith('Command failed: /bin/false');


### PR DESCRIPTION
When installed org-wide, this was incorrectly triggering for all repositories rather than making sure a config file existed

fix: provide auth token to releasetool