### PR TITLE
fix: limit release PRs to releases tagged after a start date

### DIFF
--- a/packages/release-trigger/src/release-trigger.ts
+++ b/packages/release-trigger/src/release-trigger.ts
@@ -84,8 +84,10 @@ export interface PullRequest {
       name: string;
     };
   };
+  closed_at: string | null;
 }
 
+const LAUNCH_DATE = new Date('2021-08-01');
 function isReleasePullRequest(pullRequest: PullRequest): boolean {
   return (
     pullRequest.state === 'closed' &&
@@ -95,7 +97,9 @@ function isReleasePullRequest(pullRequest: PullRequest): boolean {
     }) &&
     !pullRequest.labels.some(label => {
       return label.name === TRIGGERED_LABEL;
-    })
+    }) &&
+    !!pullRequest.closed_at &&
+    new Date(pullRequest.closed_at) > LAUNCH_DATE
   );
 }
 

--- a/packages/release-trigger/test/bot.ts
+++ b/packages/release-trigger/test/bot.ts
@@ -46,6 +46,7 @@ function buildFakePullRequest(
         name: repo,
       },
     },
+    closed_at: '2021-08-15T19:01:12Z',
   };
 }
 


### PR DESCRIPTION
The release trigger bot can find older "tagged" release PRs. We should limit to newly tagged releases.
