### PR TITLE
build: force-push to dependency update branches

### DIFF
--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -45,4 +45,5 @@ jobs:
           message: 'deps: update ${{ matrix.package }} deps'
           branch: update-deps-${{ matrix.package }}
           primary: main
+          force: true
           git_dir: '.'


### PR DESCRIPTION
The code-suggester action failed for branches that already exist
