### PR TITLE
fix: loadOwlBotYaml should use path to .OwlBot.yaml file

### DIFF
--- a/packages/owl-bot/src/bin/commands/copy-bazel-bin.ts
+++ b/packages/owl-bot/src/bin/commands/copy-bazel-bin.ts
@@ -16,12 +16,14 @@
 
 import yargs = require('yargs');
 import tmp from 'tmp';
+import path = require('path');
 import {copyDirs, loadOwlBotYaml} from '../../copy-code';
 import {getCommonStem, unpackTarBalls} from '../../bazel-bin';
 
 interface Args {
   'source-dir': string;
   dest: string | undefined;
+  'config-file': string;
 }
 
 export const copyBazelBin: yargs.CommandModule<{}, Args> = {
@@ -42,12 +44,17 @@ export const copyBazelBin: yargs.CommandModule<{}, Args> = {
           '  Defaults to the current working directory.',
         type: 'string',
         demand: false,
+      })
+      .option('config-file', {
+        describe: 'Path in the directory to the .OwlBot.yaml config.',
+        type: 'string',
+        default: '.github/.OwlBot.yaml',
       });
   },
   async handler(argv) {
     const destDir = argv.dest ?? process.cwd();
     const tempDir = tmp.dirSync().name;
-    const yaml = await loadOwlBotYaml(destDir);
+    const yaml = await loadOwlBotYaml(path.join(destDir, argv['config-file']));
     const sourceRegexps = (yaml['deep-copy-regex'] ?? []).map(x => x.source);
     const regexpStem = getCommonStem(sourceRegexps);
     unpackTarBalls(argv['source-dir'], tempDir, regexpStem);

--- a/packages/owl-bot/src/bin/commands/copy-code.ts
+++ b/packages/owl-bot/src/bin/commands/copy-code.ts
@@ -16,6 +16,7 @@
 
 import tmp from 'tmp';
 import yargs = require('yargs');
+import path = require('path');
 import {copyCode, loadOwlBotYaml} from '../../copy-code';
 
 interface Args {
@@ -56,7 +57,7 @@ export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
       argv['source-repo-commit-hash'],
       destDir,
       tmp.dirSync().name,
-      await loadOwlBotYaml(destDir)
+      await loadOwlBotYaml(path.join(destDir, '.github', '.OwlBot.yaml'))
     );
   },
 };

--- a/packages/owl-bot/src/bin/commands/copy-code.ts
+++ b/packages/owl-bot/src/bin/commands/copy-code.ts
@@ -23,6 +23,7 @@ interface Args {
   'source-repo': string;
   'source-repo-commit-hash': string;
   dest: string | undefined;
+  'config-file': string;
 }
 
 export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
@@ -48,6 +49,11 @@ export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
           'The directory containing a local repo.  Example: nodejs/vision.',
         type: 'string',
         demand: false,
+      })
+      .option('config-file', {
+        describe: 'Path in the directory to the .OwlBot.yaml config.',
+        type: 'string',
+        default: '.github/.OwlBot.yaml',
       });
   },
   async handler(argv) {
@@ -57,7 +63,7 @@ export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
       argv['source-repo-commit-hash'],
       destDir,
       tmp.dirSync().name,
-      await loadOwlBotYaml(path.join(destDir, '.github', '.OwlBot.yaml'))
+      await loadOwlBotYaml(path.join(destDir, argv['config-file']))
     );
   },
 };


### PR DESCRIPTION
Fixes #2472
