### PR TITLE
Revert "fix(owl-bot): Determine loop by the last few commits"

### DIFF
--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -506,24 +506,13 @@ async function hasOwlBotLoop(
       per_page: 100,
     })
   ).data;
-
-  // get the most recent commits (limit by circuit breaker)
-  const lastFewCommits = commits
-    .sort((a, b) => {
-      const aDate = new Date(a.commit.author?.date || 0);
-      const bDate = new Date(b.commit.author?.date || 0);
-
-      // sort desc
-      return bDate.valueOf() - aDate.valueOf();
-    })
-    .slice(0, circuitBreaker);
-
-  for (const commit of lastFewCommits) {
-    if (commit?.author?.login !== OWLBOT_USER) return false;
+  let count = 0;
+  for (const commit of commits) {
+    if (commit?.author?.login === OWLBOT_USER) count++;
+    else count = 0;
+    if (count >= circuitBreaker) return true;
   }
-
-  // all of the recent commits were from owl-bot
-  return true;
+  return false;
 }
 
 /*

--- a/packages/owl-bot/test/owl-core.ts
+++ b/packages/owl-bot/test/owl-core.ts
@@ -406,40 +406,20 @@ describe('core', () => {
           author: {
             login: 'gcf-owl-bot[bot]',
           },
-          commit: {
-            author: {
-              date: new Date(0).toISOString(),
-            },
-          },
         },
         {
           author: {
             login: 'gcf-owl-bot[bot]',
-          },
-          commit: {
-            author: {
-              date: new Date(1).toISOString(),
-            },
           },
         },
         {
           author: {
             login: 'bcoe',
           },
-          commit: {
-            author: {
-              date: new Date(2).toISOString(),
-            },
-          },
         },
         {
           author: {
             login: 'gcf-owl-bot[bot]',
-          },
-          commit: {
-            author: {
-              date: new Date(3).toISOString(),
-            },
           },
         },
       ];
@@ -450,48 +430,27 @@ describe('core', () => {
       assert.strictEqual(loop, false);
       githubMock.done();
     });
-
     it('returns true if post processor looping', async () => {
       const commits = [
         // Three commits from OwlBot in a row should not happen:
         {
           author: {
+            login: 'gcf-owl-bot[bot]',
+          },
+        },
+        {
+          author: {
+            login: 'gcf-owl-bot[bot]',
+          },
+        },
+        {
+          author: {
+            login: 'gcf-owl-bot[bot]',
+          },
+        },
+        {
+          author: {
             login: 'bcoe',
-          },
-          commit: {
-            author: {
-              date: new Date(0).toISOString(),
-            },
-          },
-        },
-        {
-          author: {
-            login: 'gcf-owl-bot[bot]',
-          },
-          commit: {
-            author: {
-              date: new Date(1).toISOString(),
-            },
-          },
-        },
-        {
-          author: {
-            login: 'gcf-owl-bot[bot]',
-          },
-          commit: {
-            author: {
-              date: new Date(2).toISOString(),
-            },
-          },
-        },
-        {
-          author: {
-            login: 'gcf-owl-bot[bot]',
-          },
-          commit: {
-            author: {
-              date: new Date(3).toISOString(),
-            },
           },
         },
       ];
@@ -500,58 +459,6 @@ describe('core', () => {
         .reply(200, commits);
       const loop = await core.hasOwlBotLoop('bcoe', 'foo', 22, new Octokit());
       assert.strictEqual(loop, true);
-      githubMock.done();
-    });
-
-    it('returns false if there was a loop in the past, but not within the last few commits', async () => {
-      const commits = [
-        // Three commits from OwlBot in a row should not happen:
-        {
-          author: {
-            login: 'gcf-owl-bot[bot]',
-          },
-          commit: {
-            author: {
-              date: new Date(0).toISOString(),
-            },
-          },
-        },
-        {
-          author: {
-            login: 'gcf-owl-bot[bot]',
-          },
-          commit: {
-            author: {
-              date: new Date(1).toISOString(),
-            },
-          },
-        },
-        {
-          author: {
-            login: 'gcf-owl-bot[bot]',
-          },
-          commit: {
-            author: {
-              date: new Date(2).toISOString(),
-            },
-          },
-        },
-        {
-          author: {
-            login: 'bcoe',
-          },
-          commit: {
-            author: {
-              date: new Date(3).toISOString(),
-            },
-          },
-        },
-      ];
-      const githubMock = nock('https://api.github.com')
-        .get('/repos/bcoe/foo/pulls/22/commits?per_page=100')
-        .reply(200, commits);
-      const loop = await core.hasOwlBotLoop('bcoe', 'foo', 22, new Octokit());
-      assert.strictEqual(loop, false);
       githubMock.done();
     });
   });


### PR DESCRIPTION
Reverts googleapis/repo-automation-bots#2482

I think the logic gives us false positive when there's only one commit from owlbot.