### PR TITLE
revert: "chore(deps): update dependency gcp-releasetool to v1.8.1"

### DIFF
--- a/packages/release-trigger/requirements.txt
+++ b/packages/release-trigger/requirements.txt
@@ -1,2 +1,2 @@
-gcp-releasetool==1.8.1
+gcp-releasetool==1.8.0
 keyrings.alt


### PR DESCRIPTION
Reverts googleapis/repo-automation-bots#2515

There's a bug in the explicit triggering of a PR where it should not use the language allowlist.