### PR TITLE
feat(policy): add a check for default branch name

### DIFF
--- a/packages/policy/policy-bigquery-schema.json
+++ b/packages/policy/policy-bigquery-schema.json
@@ -55,6 +55,11 @@
     "type": "BOOLEAN"
   },
   {
+    "mode": "REQUIRED",
+    "name": "hasMainDefault",
+    "type": "BOOLEAN"
+  },
+  {
     "mode": "REPEATED",
     "name": "topics",
     "type": "STRING"

--- a/packages/policy/src/policy.ts
+++ b/packages/policy/src/policy.ts
@@ -84,6 +84,10 @@ export interface PolicyResult {
    */
   hasSecurityPolicy: boolean;
   /**
+   * Is the default branch set to `main`, and not `master`?
+   */
+  hasMainDefault: boolean;
+  /**
    * Date when the scan was run for this repository
    */
   timestamp: Date;
@@ -256,6 +260,13 @@ export class Policy {
   }
 
   /**
+   * Ensure `main` is the default branch name.
+   */
+  async hasMainDefault(repo: GitHubRepo) {
+    return repo.default_branch === 'main';
+  }
+
+  /**
    * Merge Commits are disabled
    */
   async hasMergeCommitsDisabled(repo: GitHubRepo) {
@@ -306,6 +317,7 @@ export class Policy {
       hasBranchProtection,
       hasMergeCommitsDisabled,
       hasSecurityPolicy,
+      hasMainDefault,
     ] = await Promise.all([
       this.hasRenovate(repo),
       this.hasLicense(repo),
@@ -315,6 +327,7 @@ export class Policy {
       this.hasBranchProtection(repo),
       this.hasMergeCommitsDisabled(repo),
       this.hasSecurityPolicy(repo),
+      this.hasMainDefault(repo),
     ]);
     const [org, name] = repo.full_name.split('/');
     const results: PolicyResult = {
@@ -328,6 +341,7 @@ export class Policy {
       hasContributing,
       hasCodeowners,
       hasBranchProtection,
+      hasMainDefault,
       hasMergeCommitsDisabled,
       hasSecurityPolicy,
       timestamp: new Date(),

--- a/packages/policy/test/test.changer.ts
+++ b/packages/policy/test/test.changer.ts
@@ -39,6 +39,7 @@ describe('changer', () => {
     hasRenovateConfig: true,
     hasSecurityPolicy: true,
     hasValidLicense: true,
+    hasMainDefault: true,
     timestamp: new Date(),
   };
 

--- a/packages/policy/test/test.policy.ts
+++ b/packages/policy/test/test.policy.ts
@@ -297,6 +297,15 @@ describe('policy', () => {
     assert.ok(!isValid);
   });
 
+  it('should check for main as the default branch', async () => {
+    const repo = {
+      full_name: 'googleapis/nodejs-storage',
+      default_branch: 'master',
+    } as GitHubRepo;
+    const isValid = await policy.hasMainDefault(repo);
+    assert.ok(!isValid);
+  });
+
   it('should check for all policy checks', async () => {
     const repo = {
       full_name: 'googleapis/nodejs-storage',
@@ -317,6 +326,7 @@ describe('policy', () => {
       sinon.stub(policy, 'hasBranchProtection').resolves(true),
       sinon.stub(policy, 'hasMergeCommitsDisabled').resolves(true),
       sinon.stub(policy, 'hasSecurityPolicy').resolves(true),
+      sinon.stub(policy, 'hasMainDefault').resolves(true),
     ];
     const result = await policy.checkRepoPolicy(repo);
     const [org, name] = repo.full_name.split('/');
@@ -333,6 +343,7 @@ describe('policy', () => {
       hasBranchProtection: true,
       hasMergeCommitsDisabled: true,
       hasSecurityPolicy: true,
+      hasMainDefault: true,
       timestamp: result.timestamp,
     };
     assert.deepStrictEqual(result, expected);


### PR DESCRIPTION
This adds a new policy check, `hasDefaultMain` which checks if `main` is the name of the default branch.  