### PR TITLE
build: fix deployment script for secret rotator

### DIFF
--- a/scripts/publish-cloud-run-secret-rotator.sh
+++ b/scripts/publish-cloud-run-secret-rotator.sh
@@ -24,7 +24,7 @@ serviceNameForInvoker='scheduler-service-agent@secret-rotator-prod.iam.gservicea
 timeout=3600
 concurrency=80
 
-pushd "${directoryName}"
+pushd "packages/${directoryName}"
 serviceName=${botName//_/-}
 
 deployArgs=(


### PR DESCRIPTION
Fixes:
```
Already have image (with digest): gcr.io/cloud-builders/gcloud
./scripts/publish-cloud-run-secret-rotator.sh: line 27: pushd: secret-rotator: No such file or directory
```