### PR TITLE
fix(owlbot): always run post-processor if "owlbot:run" label added

### DIFF
--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -289,7 +289,8 @@ export async function handlePullRequestLabeled(
       repo,
       defaultBranch: payload?.repository?.default_branch,
     },
-    octokit
+    octokit,
+    false
   );
   logger.metric('owlbot.run_post_processor');
 }
@@ -352,7 +353,8 @@ const runPostProcessor = async (
   project: string,
   trigger: string,
   opts: RunPostProcessorOpts,
-  octokit: Octokit
+  octokit: Octokit,
+  breakLoop = true
 ) => {
   // Fetch the .Owlbot.lock.yaml from head of PR:
   let lock: OwlBotLock | undefined = undefined;
@@ -404,7 +406,10 @@ const runPostProcessor = async (
     return;
   }
   // Detect looping OwlBot behavior and break the cycle:
-  if (await core.hasOwlBotLoop(opts.owner, opts.repo, opts.prNumber, octokit)) {
+  if (
+    breakLoop &&
+    (await core.hasOwlBotLoop(opts.owner, opts.repo, opts.prNumber, octokit))
+  ) {
     const message = `Too many OwlBot updates created in a row for ${opts.owner}/${opts.repo}`;
     logger.warn(message);
 

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -970,7 +970,7 @@ describe('owlBot', () => {
     });
     sandbox.assert.calledOnce(triggerBuildStub);
     sandbox.assert.calledOnce(createCheckStub);
-    sandbox.assert.calledOnce(hasOwlBotLoopStub);
+    sandbox.assert.notCalled(hasOwlBotLoopStub);
     sandbox.assert.calledOnce(updatePullRequestStub);
     githubMock.done();
   });
@@ -1042,7 +1042,7 @@ describe('owlBot', () => {
     });
     sandbox.assert.calledOnce(triggerBuildStub);
     sandbox.assert.calledOnce(createCheckStub);
-    sandbox.assert.calledOnce(hasOwlBotLoopStub);
+    sandbox.assert.notCalled(hasOwlBotLoopStub);
     sandbox.assert.calledOnce(updatePullRequestStub);
     githubMock.done();
   });
@@ -1114,7 +1114,7 @@ describe('owlBot', () => {
     });
     sandbox.assert.calledOnce(triggerBuildStub);
     sandbox.assert.calledOnce(createCheckStub);
-    sandbox.assert.calledOnce(hasOwlBotLoopStub);
+    sandbox.assert.notCalled(hasOwlBotLoopStub);
     sandbox.assert.calledOnce(updatePullRequestStub);
     githubMock.done();
   });


### PR DESCRIPTION
We have logic in place that attempts to detect too many updates from OwlBot in a row and break loops (_this was because we've had bad releases of post processors in the past that created infinite commits_).

This PR updates the logic so that this safety is skipped if an `owlbot:run` label has explicitly been added.