### PR TITLE
fix(owlbot): break loop if bot account added label

### DIFF
--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -290,7 +290,7 @@ export async function handlePullRequestLabeled(
       defaultBranch: payload?.repository?.default_branch,
     },
     octokit,
-    false
+    isBotAccount(payload.sender.login) ? true : false
   );
   logger.metric('owlbot.run_post_processor');
 }

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -290,7 +290,7 @@ export async function handlePullRequestLabeled(
       defaultBranch: payload?.repository?.default_branch,
     },
     octokit,
-    isBotAccount(payload.sender.login) ? true : false
+    isBotAccount(payload.sender.login)
   );
   logger.metric('owlbot.run_post_processor');
 }


### PR DESCRIPTION
I worry that we still might end up with infinite loop if trusted contributor bot keeps adding `owlbot:run` and we're in a looping update situation.