### PR TITLE
fix(release-brancher): provide default branch name for PRs

### DIFF
--- a/packages/release-brancher/__snapshots__/release-brancher.js
+++ b/packages/release-brancher/__snapshots__/release-brancher.js
@@ -204,7 +204,8 @@ exports['pr-options'] = {
   "description": "enable releases",
   "branch": "release-brancher/1.x",
   "force": true,
-  "fork": false
+  "fork": false,
+  "primary": "master"
 }
 
 exports['workflows-pr-changes'] = [

--- a/packages/release-brancher/src/release-brancher.ts
+++ b/packages/release-brancher/src/release-brancher.ts
@@ -245,6 +245,7 @@ export class Runner {
       }
     }
 
+    const defaultBranch = await this.getDefaultBranch();
     const message = `build: configure branch ${this.branchName} as a release branch`;
     return await createPullRequest(this.octokit, changes, {
       upstreamRepo: this.upstreamRepo,
@@ -252,6 +253,7 @@ export class Runner {
       message,
       title: message,
       description: 'enable releases',
+      primary: defaultBranch,
       branch: `release-brancher/${this.branchName}`,
       force: true,
       fork: false,

--- a/packages/release-brancher/test/release-brancher.ts
+++ b/packages/release-brancher/test/release-brancher.ts
@@ -331,6 +331,12 @@ describe('Runner', () => {
           content: Buffer.from(
             loadFixture('sync-repo-settings/basic.yaml')
           ).toString('base64'),
+        })
+        .get('/repos/testOwner/testRepo')
+        .reply(200, {
+          name: 'testRepo',
+          full_name: 'testOwner/testRepo',
+          default_branch: 'master',
         });
       sandbox.replace(
         suggester,
@@ -377,6 +383,12 @@ describe('Runner', () => {
           content: Buffer.from(
             loadFixture('sync-repo-settings/with-extra-branches.yaml')
           ).toString('base64'),
+        })
+        .get('/repos/testOwner/testRepo')
+        .reply(200, {
+          name: 'testRepo',
+          full_name: 'testOwner/testRepo',
+          default_branch: 'master',
         });
       sandbox.replace(
         suggester,
@@ -410,7 +422,13 @@ describe('Runner', () => {
         .get(
           '/repos/testOwner/testRepo/contents/.github%2Fsync-repo-settings.yaml'
         )
-        .reply(404);
+        .reply(404)
+        .get('/repos/testOwner/testRepo')
+        .reply(200, {
+          name: 'testRepo',
+          full_name: 'testOwner/testRepo',
+          default_branch: 'master',
+        });
       sandbox.replace(
         suggester,
         'createPullRequest',


### PR DESCRIPTION
Before this fix, the release-brancher command-line tool was not working. See #2617. I think this is the recent change in https://github.com/googleapis/code-suggester/pull/262/files.

After this fix, the tool works to create pull requests:

<img width="1425" alt="Screen Shot 2021-09-28 at 09 52 56" src="https://user-images.githubusercontent.com/28604/135101163-b39b686e-1b47-45b5-8520-0d8151322235.png">



Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/repo-automation-bots/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2617 🦕
