### PR TITLE
fix(release-brancher): use "ci:" (non-releasable) in init

### DIFF
--- a/packages/release-brancher/__snapshots__/release-brancher.js
+++ b/packages/release-brancher/__snapshots__/release-brancher.js
@@ -184,7 +184,7 @@ exports['pr-changes'] = [
     ".github/release-please.yml",
     {
       "mode": "100644",
-      "content": "releaseType: java-yoshi\nbumpMinorPreMajor: true\nbranches:\n  - releaseType: java-yoshi\n    bumpMinorPreMajor: true\n    branch: 1.x\n"
+      "content": "releaseType: java-yoshi\nbumpMinorPreMajor: true\nbranches:\n  - releaseType: java-lts\n    bumpMinorPreMajor: true\n    branch: 1.x\n"
     }
   ],
   [
@@ -201,7 +201,7 @@ exports['pr-changes-with-title-override'] = [
     ".github/release-please.yml",
     {
       "mode": "100644",
-      "content": "releaseType: java-yoshi\nbumpMinorPreMajor: true\nbranches:\n  - releaseType: java-yoshi\n    bumpMinorPreMajor: true\n    branch: 1.3.x\n"
+      "content": "releaseType: java-yoshi\nbumpMinorPreMajor: true\nbranches:\n  - releaseType: java-backport\n    bumpMinorPreMajor: true\n    branch: 1.3.x\n"
     }
   ],
   [
@@ -247,6 +247,16 @@ exports['workflows-pr-changes'] = [
   ]
 ]
 
+exports['workflows-pr-changes-java-backport'] = [
+  [
+    ".github/workflows/ci.yaml",
+    {
+      "mode": "100644",
+      "content": "'on':\n  push:\n    branches:\n      - 1.x\n      - other\n  pull_request: null\n"
+    }
+  ]
+]
+
 exports['workflows-pr-no-changes'] = []
 
 exports['workflows-pr-no-options'] = {
@@ -266,6 +276,18 @@ exports['workflows-pr-options'] = {
   "upstreamOwner": "testOwner",
   "message": "feat: configure the protected branch",
   "title": "feat: configure the protected branch",
+  "description": "Configures CI for branch",
+  "branch": "release-brancher/ci/1.x",
+  "primary": "1.x",
+  "force": true,
+  "fork": false
+}
+
+exports['workflows-pr-options-java-backport'] = {
+  "upstreamRepo": "testRepo",
+  "upstreamOwner": "testOwner",
+  "message": "ci: configure the protected branch",
+  "title": "ci: configure the protected branch",
   "description": "Configures CI for branch",
   "branch": "release-brancher/ci/1.x",
   "primary": "1.x",

--- a/packages/release-brancher/src/release-brancher.ts
+++ b/packages/release-brancher/src/release-brancher.ts
@@ -336,7 +336,12 @@ export class Runner {
         }
       }
     }
-    const message = 'feat: configure the protected branch';
+
+    // For java-lts type, we want a release through a releasable commit ('feat: ') immediately
+    // after creating the protected branch.
+    const message =
+      (this.releaseType === 'java-lts' ? 'feat' : 'ci') +
+      ': configure the protected branch';
     return await createPullRequest(this.octokit, changes, {
       upstreamRepo: this.upstreamRepo,
       upstreamOwner: this.upstreamOwner,

--- a/packages/release-brancher/test/release-brancher.ts
+++ b/packages/release-brancher/test/release-brancher.ts
@@ -315,6 +315,7 @@ describe('Runner', () => {
         gitHubToken: 'sometoken',
         upstreamOwner: 'testOwner',
         upstreamRepo: 'testRepo',
+        releaseType: 'java-lts',
       });
       const requests = nock('https://api.github.com')
         .get('/repos/testOwner/testRepo/contents/.github%2Frelease-please.yml')
@@ -368,6 +369,7 @@ describe('Runner', () => {
         upstreamOwner: 'testOwner',
         upstreamRepo: 'testRepo',
         pullRequestTitle: 'feat: next release from default branch is 1.4.0',
+        releaseType: 'java-backport',
       });
       const requests = nock('https://api.github.com')
         .get('/repos/testOwner/testRepo/contents/.github%2Frelease-please.yml')
@@ -512,6 +514,7 @@ describe('Runner', () => {
         gitHubToken: 'sometoken',
         upstreamOwner: 'testOwner',
         upstreamRepo: 'testRepo',
+        releaseType: 'java-lts',
       });
       const requests = nock('https://api.github.com')
         .get('/repos/testOwner/testRepo/git/matching-refs/tags%2Fv1.3.0')
@@ -571,6 +574,76 @@ describe('Runner', () => {
       requests.done();
     });
 
+    it('opens or creates a new pull request with java-backport type', async () => {
+      runner = new Runner({
+        branchName: '1.x',
+        targetTag: 'v1.3.0',
+        gitHubToken: 'sometoken',
+        upstreamOwner: 'testOwner',
+        upstreamRepo: 'testRepo',
+        releaseType: 'java-backport',
+      });
+      const requests = nock('https://api.github.com')
+        .get('/repos/testOwner/testRepo/git/matching-refs/tags%2Fv1.3.0')
+        .reply(200, [{ref: 'refs/tags/v1.3.0', object: {sha: 'abcd1234'}}])
+        .get('/repos/testOwner/testRepo/git/trees/abcd1234?recursive=true')
+        .reply(200, {
+          sha: 'abcd1234',
+          tree: [
+            {
+              path: '.github/workflows/ci.yaml',
+            },
+            {
+              path: '.github/workflows/approve.yaml',
+            },
+          ],
+        })
+        .get('/repos/testOwner/testRepo')
+        .reply(200, {
+          name: 'testRepo',
+          full_name: 'testOwner/testRepo',
+          default_branch: 'main',
+        })
+        .get('/repos/testOwner/testRepo/contents/.github%2Fworkflows%2Fci.yaml')
+        .reply(200, {
+          content: Buffer.from(
+            loadFixture('workflows/only-push.yaml'),
+            'utf8'
+          ).toString('base64'),
+        })
+        .get(
+          '/repos/testOwner/testRepo/contents/.github%2Fworkflows%2Fapprove.yaml'
+        )
+        .reply(200, {
+          content: Buffer.from(
+            loadFixture('workflows/empty-objects.yaml')
+          ).toString('base64'),
+        });
+      sandbox.replace(
+        suggester,
+        'createPullRequest',
+        (
+          _octokit: Octokit,
+          changes: suggester.Changes | null | undefined,
+          options: CreatePullRequestUserOptions
+        ): Promise<number> => {
+          assert.ok(changes);
+
+          // Map does not work well with snapshot
+          snapshot(
+            'workflows-pr-changes-java-backport',
+            Array.from(changes.entries())
+          );
+          snapshot('workflows-pr-options-java-backport', options);
+          return Promise.resolve(2345);
+        }
+      );
+      const pullNumber = await runner.createWorkflowPullRequest();
+      assert.equal(pullNumber, 2345);
+
+      requests.done();
+    });
+
     it('ignores non-matching branches a new pull request', async () => {
       runner = new Runner({
         branchName: '1.x',
@@ -578,6 +651,7 @@ describe('Runner', () => {
         gitHubToken: 'sometoken',
         upstreamOwner: 'testOwner',
         upstreamRepo: 'testRepo',
+        releaseType: 'java-lts',
       });
       const requests = nock('https://api.github.com')
         .get('/repos/testOwner/testRepo/git/matching-refs/tags%2Fv1.3.0')


### PR DESCRIPTION
Use "ci: " suffix in the commit message when it creates a workflow pull request for initializing the protected branch. This addresses @chingor13 's comment in https://github.com/googleapis/repo-automation-bots/pull/2615#discussion_r717957080

Fixes #2568 🦕
