### PR TITLE
fix: prevent post processor running infinite times

### DIFF
--- a/packages/owl-bot/src/bin/commands/commit-post-processor-update.ts
+++ b/packages/owl-bot/src/bin/commands/commit-post-processor-update.ts
@@ -45,6 +45,12 @@ export async function commitPostProcessorUpdate(repoDir = ''): Promise<void> {
   }
   // Add all pending changes to the commit.
   cmd('git add -A .', {cwd: repoDir});
+  const status = cmd('git status --porcelain', {cwd: repoDir}).toString(
+    'utf-8'
+  );
+  if (!status) {
+    return; // No changes made.  Nothing to do.
+  }
   // Unpack the Copy-Tag.
   const body = cmd('git log -1 --format=%B', {cwd: repoDir}).toString('utf-8');
   const copyTagText = findCopyTag(body);


### PR DESCRIPTION
The problem is that "git commit --amend --no-edit" always replaces
the most recent commit even when no changes are pending.

