### PR TITLE
test: add example of removing owlbot:run label from labels added by trusted contributor

### DIFF
--- a/packages/trusted-contribution/test/fixtures/labels.yml
+++ b/packages/trusted-contribution/test/fixtures/labels.yml
@@ -1,0 +1,4 @@
+annotations:
+  - type: 'label'
+    text:
+      'kokoro:force-run'

--- a/packages/trusted-contribution/test/trusted-contribution.ts
+++ b/packages/trusted-contribution/test/trusted-contribution.ts
@@ -702,4 +702,48 @@ describe('TrustedContributionTestRunner', () => {
     assert.ok(errorStub.calledOnce);
     requests.done();
   });
+
+  describe('with alternate labels configured', () => {
+    beforeEach(() => {
+      getConfigStub.resolves(loadConfig('labels.yml'));
+    });
+
+    it('sets alternate labels on PR, if PR author is a trusted contributor', async () => {
+      requests = requests
+        .post(
+          '/repos/chingor13/google-auth-library-java/issues/3/labels',
+          (body: object) => {
+            assert.deepStrictEqual(body, {
+              labels: ['kokoro:force-run'],
+            });
+            return true;
+          }
+        )
+        .reply(200);
+
+      await probot.receive({
+        name: 'pull_request',
+        payload: {
+          action: 'opened',
+          pull_request: {
+            number: 3,
+            head: {
+              sha: 'testsha',
+            },
+            user: {
+              login: 'renovate-bot',
+            },
+          },
+          repository: {
+            name: 'google-auth-library-java',
+            owner: {
+              login: 'chingor13',
+            },
+          },
+        } as PullRequestOpenedEvent,
+        id: 'abc123',
+      });
+      requests.done();
+    });
+  });
 });


### PR DESCRIPTION
Adds a demonstration of how a repository can opt out of the owlbot: run label the configuration can be added to `.github/trusted-contribution.yml` in a repository, and provide an alternate set of labels.

Fixes #2247




