### PR TITLE
chore: write logs to a dedicated bucket

### DIFF
--- a/packages/owl-bot/cloud-build/update-pr.yaml
+++ b/packages/owl-bot/cloud-build/update-pr.yaml
@@ -86,3 +86,4 @@ steps:
 
 # allow 20 minutes for the post-processor image to run
 timeout: '1200s'
+logsBucket: 'gs://repo-automation-bots-post-processor-logs'


### PR DESCRIPTION
First step in using a cloud build account with very few permissions
for post processor.
