### PR TITLE
fix: owl bot endlessly retried failed owl-bot-lock builds

### DIFF
--- a/packages/owl-bot/src/scan-and-retry-failed-lock-updates.ts
+++ b/packages/owl-bot/src/scan-and-retry-failed-lock-updates.ts
@@ -20,6 +20,8 @@ const twentyFourHours =
   60 * // minutes
   24; // hours.
 
+const seventyTwoHours = 3 * twentyFourHours;
+
 /**
  * Scans all the cloud builds for the past 24 hours, and retries builds
  * that never succeeded.
@@ -85,11 +87,9 @@ export async function filterBuildsToRetry(
     if (!newestCreateTime) {
       newestCreateTime = build.createTime!;
     }
-    if (
-      build.createTime &&
-      Number(newestCreateTime.seconds) - Number(build.createTime.seconds) >
-        twentyFourHours
-    ) {
+    const secondsElapsedSinceCreateTime =
+      Number(newestCreateTime.seconds) - Number(build.createTime!.seconds);
+    if (secondsElapsedSinceCreateTime > seventyTwoHours) {
       logger.info('Finished scanning recent builds.');
       break;
     }
@@ -110,6 +110,9 @@ export async function filterBuildsToRetry(
     if (counts) {
       counts.failureCount += failed;
       counts.successCount += succeeded;
+    } else if (secondsElapsedSinceCreateTime > twentyFourHours) {
+      // A build that happened more than 24 hours ago is not one we should
+      // retry.
     } else {
       countsMap.set(key, {
         build,

--- a/packages/owl-bot/test/scan-and-retry-failed-lock-updates.ts
+++ b/packages/owl-bot/test/scan-and-retry-failed-lock-updates.ts
@@ -134,4 +134,29 @@ describe('filterBuildsToRetry', () => {
     );
     assert.deepStrictEqual([], rebuilds);
   });
+
+  it('ignores build that exceeds max-failures over 48 hours', async () => {
+    const builds: google.devtools.cloudbuild.v1.IBuild[] = [
+      {
+        name: 'iFailedAgain',
+        createTime: {seconds: 1632347329, nanos: 10},
+        buildTriggerId: 'a2',
+        status: 'FAILURE',
+        substitutions: {_A: 'b', _C: 'd'},
+      },
+      {
+        name: 'iFailed',
+        createTime: {seconds: 1632260628, nanos: 10},
+        buildTriggerId: 'a2',
+        status: 'FAILURE',
+        substitutions: {_C: 'd', _A: 'b'},
+      },
+    ];
+    const rebuilds = await filterBuildsToRetry(
+      'a2',
+      2,
+      asyncIteratorFrom(builds)
+    );
+    assert.deepStrictEqual([], rebuilds);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/googleapis/repo-automation-bots/issues/2796
