### PR TITLE
feat(bot-config-utils): getConfigWithDefault now returns default on permission errors

### DIFF
--- a/packages/bot-config-utils/README.md
+++ b/packages/bot-config-utils/README.md
@@ -35,6 +35,8 @@ const config = await getConfig<Config>(
 
 You can use a similar method that supports default value.
 
+> Note: on permission errors `getConfigWithDefault` will return the default configuration.
+
 ```typescript
 import {
   getConfigWithDefault,

--- a/packages/bot-config-utils/src/bot-config-utils.ts
+++ b/packages/bot-config-utils/src/bot-config-utils.ts
@@ -447,8 +447,11 @@ export async function getConfigWithDefault<ConfigType>(
       throw new Error('could not handle getContent result.');
     }
   } catch (e) {
+    console.info(e);
     const err = e as RequestError;
-    if (err.status !== 404) {
+    // For 4xx codes return default config.
+    if (![401, 403, 404].includes(err.status)) {
+      logger.warn(`received ${err.status} reading ${path} for ${owner}/${repo}`);
       throw err;
     }
     if (repo === '.github' || !options.fallbackToOrgConfig || options.branch) {
@@ -488,7 +491,8 @@ export async function getConfigWithDefault<ConfigType>(
       }
     } catch (e) {
       const err = e as RequestError;
-      if (err.status !== 404) {
+      if (![401, 403, 404].includes(err.status)) {
+        logger.warn(`received ${err.status} reading ${path} for ${owner}/${repo}`);
         throw err;
       }
       return defaultConfig;

--- a/packages/bot-config-utils/src/bot-config-utils.ts
+++ b/packages/bot-config-utils/src/bot-config-utils.ts
@@ -451,7 +451,9 @@ export async function getConfigWithDefault<ConfigType>(
     const err = e as RequestError;
     // For 4xx codes return default config.
     if (![401, 403, 404].includes(err.status)) {
-      logger.warn(`received ${err.status} reading ${path} for ${owner}/${repo}`);
+      logger.warn(
+        `received ${err.status} reading ${path} for ${owner}/${repo}`
+      );
       throw err;
     }
     if (repo === '.github' || !options.fallbackToOrgConfig || options.branch) {
@@ -492,7 +494,9 @@ export async function getConfigWithDefault<ConfigType>(
     } catch (e) {
       const err = e as RequestError;
       if (![401, 403, 404].includes(err.status)) {
-        logger.warn(`received ${err.status} reading ${path} for ${owner}/${repo}`);
+        logger.warn(
+          `received ${err.status} reading ${path} for ${owner}/${repo}`
+        );
         throw err;
       }
       return defaultConfig;

--- a/packages/bot-config-utils/src/bot-config-utils.ts
+++ b/packages/bot-config-utils/src/bot-config-utils.ts
@@ -447,7 +447,6 @@ export async function getConfigWithDefault<ConfigType>(
       throw new Error('could not handle getContent result.');
     }
   } catch (e) {
-    console.info(e);
     const err = e as RequestError;
     // For 4xx codes return default config.
     if (![401, 403, 404].includes(err.status)) {

--- a/packages/bot-config-utils/test/bot-config-utils.ts
+++ b/packages/bot-config-utils/test/bot-config-utils.ts
@@ -625,14 +625,14 @@ describe('config', () => {
         scope.done();
       }
     });
-    it('throws an error upon non 404 errors for the org config', async () => {
+    it('throws an error upon non 401/403/404 errors for the org config', async () => {
       const owner = 'googleapis';
       const repo = 'repo-automation-bots';
       const filename = 'flakybot.yaml';
 
       const scopes = [
         getConfigFile('flakybot.yaml', owner, repo, 404),
-        getConfigFile('flakybot.yaml', owner, '.github', 403),
+        getConfigFile('flakybot.yaml', owner, '.github', 502),
       ];
 
       await assert.rejects(
@@ -876,14 +876,14 @@ describe('config', () => {
         scope.done();
       }
     });
-    it('throws an error upon non 404 errors for the org config', async () => {
+    it('throws an error upon non 401/403/404 errors for the org config', async () => {
       const owner = 'googleapis';
       const repo = 'repo-automation-bots';
       const filename = 'flakybot.yaml';
 
       const scopes = [
-        getConfigFile('flakybot.yaml', owner, repo, 404),
-        getConfigFile('flakybot.yaml', owner, '.github', 403),
+        getConfigFile('flakybot.yaml', owner, repo, 403),
+        getConfigFile('flakybot.yaml', owner, '.github', 502),
       ];
 
       await assert.rejects(


### PR DESCRIPTION
I believe what might be causing #2739 is a lack of repository level config,
which causes the automation to check the org level .github repository, which
the integration does not have permission to access.

Fixes #2739