### PR TITLE
fix(do-not-merge): ignore failures loading config

### DIFF
--- a/packages/do-not-merge/src/do-not-merge.ts
+++ b/packages/do-not-merge/src/do-not-merge.ts
@@ -64,13 +64,18 @@ export = (app: Probot) => {
         l => l.name === DO_NOT_MERGE || l.name === DO_NOT_MERGE_2
       );
 
-      const config = await getConfigWithDefault<ConfigurationOptions>(
-        context.octokit,
-        owner,
-        repo,
-        CONFIGURATION_FILE_PATH,
-        DEFAULT_CONFIGURATION
-      );
+      let config = DEFAULT_CONFIGURATION;
+      try {
+        config = await getConfigWithDefault<ConfigurationOptions>(
+          context.octokit,
+          owner,
+          repo,
+          CONFIGURATION_FILE_PATH,
+          DEFAULT_CONFIGURATION
+        );
+      } catch (err) {
+        logger.error(err as Error);
+      }
 
       const existingCheck = await findCheck(context, owner, repo, sha);
 


### PR DESCRIPTION
For do-not-merge it's safe to default to defaultConfig if we fail to load
remote configuration

Fixes #2739