### PR TITLE
feat(bazel-bot): allow Bazel Bot to push to non-default branches

### DIFF
--- a/packages/bazel-bot/cloudbuild.yaml
+++ b/packages/bazel-bot/cloudbuild.yaml
@@ -28,6 +28,11 @@ steps:
     # is defined in the Cloud Build UI, with the intention that it is only
     # used for exceptional circumstances.
     - "BROKEN_SHAS=$_BROKEN_SHAS"
+    # Use source/target branch variables to override the default git
+    # branch which is cloned. This is primarily used for preview
+    # branch support.
+    - "SOURCE_BRANCH=$_SOURCE_BRANCH"
+    - "TARGET_BRANCH=$_TARGET_BRANCH"
 
 timeout: '7200s'
 

--- a/packages/bazel-bot/docker-image/docker-main.sh
+++ b/packages/bazel-bot/docker-image/docker-main.sh
@@ -18,10 +18,21 @@ set -e
 git config --global user.email "bazel-bot-development[bot]@users.noreply.github.com"
 git config --global user.name "Bazel Bot"
 
-git clone https://github.com/googleapis/googleapis.git
-git clone https://github.com/googleapis/googleapis-gen.git
+SOURCE_CLONE_ARGS=
+if [[ $SOURCE_BRANCH != "" ]]
+then
+  SOURCE_CLONE_ARGS="-b $SOURCE_BRANCH"
+fi
+
+TARGET_CLONE_ARGS=
+if [[ $TARGET_BRANCH != "" ]]
+then
+  TARGET_CLONE_ARGS="-b $TARGET_BRANCH"
+fi
+
+git clone https://github.com/googleapis/googleapis.git ${SOURCE_CLONE_ARGS}
+git clone https://github.com/googleapis/googleapis-gen.git ${TARGET_CLONE_ARGS}
 
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 bash -x "$mydir/generate-googleapis-gen.sh"
-

--- a/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
+++ b/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
@@ -31,11 +31,11 @@
 set -e
 
 # path to clone of https://github.com/googleapis/googleapis with
-#   master branch checked out.
+#   with the correct source branch checked out.
 export GOOGLEAPIS=${GOOGLEAPIS:=`realpath googleapis`}
 
 # path to clone of https://github.com/googleapis/googleapis-gen
-#   with master branch checked out.
+#   with the correct target branch checked out.
 export GOOGLEAPIS_GEN=${GOOGLEAPIS_GEN:=`realpath googleapis-gen`}
 
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -141,12 +141,15 @@ for (( idx=${#ungenerated_shas[@]}-1 ; idx>=0 ; idx-- )) ; do
         git -C "$GOOGLEAPIS_GEN" tag "googleapis-$sha"
         git -C "$GOOGLEAPIS_GEN" push origin "googleapis-$sha"
     else
+        # Determine the current branch so we can explicitly push to it
+        declare -r googleapis_gen_branch=$(git -C "$GOOGLEAPIS_GEN" branch --show-current)
+
         # Copy the commit message from the commit in googleapis.
         git -C "$GOOGLEAPIS" log -1 --format=%s%n%n%b > commit-msg.txt
         echo "Source-Link: https://github.com/googleapis/googleapis/commit/$sha" >> commit-msg.txt
         # Commit changes and push them.
         git -C "$GOOGLEAPIS_GEN" commit -F "$(realpath commit-msg.txt)"
         git -C "$GOOGLEAPIS_GEN" tag "googleapis-$sha"
-        git -C "$GOOGLEAPIS_GEN" push origin master "googleapis-$sha"
+        git -C "$GOOGLEAPIS_GEN" push origin "$googleapis_gen_branch" "googleapis-$sha"
     fi
 done


### PR DESCRIPTION
We assume that both googleapis and googleapis-gen have been checked
out on the desired branches, and then push to the same branch after
generation.

Note that this won't automatically start synching preview branches - it just allows us to create a new trigger that *will* do so.

(Discussed internally prior to coding. I can create an issue specifically to be fixed by this if that's desirable.)
