### PR TITLE
fix(policy): bubble error when fetching files

### DIFF
--- a/packages/policy/src/policy.ts
+++ b/packages/policy/src/policy.ts
@@ -178,7 +178,11 @@ export class Policy {
         });
       })
     );
-    const good = results.filter(x => x.status === 200);
+    const good = results.filter(x => {
+      if (x.status >= 500)
+        throw Error(`received ${x.status} fetching ${file} in ${repo}`);
+      return x.status === 200;
+    });
     return good.length > 0;
   }
 

--- a/packages/policy/test/test.bot.ts
+++ b/packages/policy/test/test.bot.ts
@@ -164,6 +164,89 @@ describe('bot', () => {
     assert.ok(submitFixesStub.calledOnce);
   });
 
+  it('should run the check and saves the result', async () => {
+    const repo = 'nodejs-storage';
+    const org = 'googleapis';
+    const fakeRepo = {
+      full_name: 'googleapis/nodejs-storage',
+    } as policy.GitHubRepo;
+    const fakeResult = {} as policy.PolicyResult;
+    const p = new policy.Policy(new Octokit(), console);
+    const c = new changer.Changer(new Octokit(), fakeRepo);
+    const getPolicyStub = sinon.stub(policy, 'getPolicy').returns(p);
+    const getChangerStub = sinon.stub(changer, 'getChanger').returns(c);
+    const getRepoStub = sinon.stub(p, 'getRepo').resolves(fakeRepo);
+    const checkPolicyStub = sinon
+      .stub(p, 'checkRepoPolicy')
+      .resolves(fakeResult);
+    const exportStub = sinon.stub(bq, 'exportToBigQuery').resolves();
+    const submitFixesStub = sinon.stub(c, 'submitFixes').resolves();
+
+    await probot.receive({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      name: 'schedule.repository' as any,
+      payload: {
+        repository: {
+          name: repo,
+          owner: {
+            login: org,
+          },
+        },
+        organization: {
+          login: org,
+        },
+        cron_org: org,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      id: 'abc123',
+    });
+    assert.ok(getPolicyStub.calledOnce);
+    assert.ok(getChangerStub.calledOnce);
+    assert.ok(getRepoStub.calledOnce);
+    assert.ok(checkPolicyStub.calledOnce);
+    assert.ok(exportStub.calledOnce);
+    assert.ok(submitFixesStub.calledOnce);
+  });
+
+  it('should raise error if checkRepoPolicy throws', async () => {
+    const repo = 'nodejs-docs-samples';
+    const org = 'GoogleCloudPlatform';
+    const fakeRepo = {
+      topics: ['samples'],
+      full_name: 'googleapis/nodejs-storage',
+    } as policy.GitHubRepo;
+    const p = new policy.Policy(new Octokit(), console);
+    const getPolicyStub = sinon.stub(policy, 'getPolicy').returns(p);
+    const getRepoStub = sinon.stub(p, 'getRepo').resolves(fakeRepo);
+    const checkPolicyStub = sinon
+      .stub(p, 'checkRepoPolicy')
+      .throws(Error('reading file failed'));
+    await assert.rejects(
+      probot.receive({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        name: 'schedule.repository' as any,
+        payload: {
+          repository: {
+            name: repo,
+            owner: {
+              login: org,
+            },
+          },
+          organization: {
+            login: org,
+          },
+          cron_org: org,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        id: 'abc123',
+      }),
+      /reading file failed/
+    );
+    assert.ok(getPolicyStub.calledOnce);
+    assert.ok(getRepoStub.calledOnce);
+    assert.ok(checkPolicyStub.calledOnce);
+  });
+
   it('should skip archived repos', async () => {
     const repo = 'nodejs-storage';
     const org = 'googleapis';

--- a/packages/policy/test/test.bot.ts
+++ b/packages/policy/test/test.bot.ts
@@ -164,50 +164,6 @@ describe('bot', () => {
     assert.ok(submitFixesStub.calledOnce);
   });
 
-  it('should run the check and saves the result', async () => {
-    const repo = 'nodejs-storage';
-    const org = 'googleapis';
-    const fakeRepo = {
-      full_name: 'googleapis/nodejs-storage',
-    } as policy.GitHubRepo;
-    const fakeResult = {} as policy.PolicyResult;
-    const p = new policy.Policy(new Octokit(), console);
-    const c = new changer.Changer(new Octokit(), fakeRepo);
-    const getPolicyStub = sinon.stub(policy, 'getPolicy').returns(p);
-    const getChangerStub = sinon.stub(changer, 'getChanger').returns(c);
-    const getRepoStub = sinon.stub(p, 'getRepo').resolves(fakeRepo);
-    const checkPolicyStub = sinon
-      .stub(p, 'checkRepoPolicy')
-      .resolves(fakeResult);
-    const exportStub = sinon.stub(bq, 'exportToBigQuery').resolves();
-    const submitFixesStub = sinon.stub(c, 'submitFixes').resolves();
-
-    await probot.receive({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      name: 'schedule.repository' as any,
-      payload: {
-        repository: {
-          name: repo,
-          owner: {
-            login: org,
-          },
-        },
-        organization: {
-          login: org,
-        },
-        cron_org: org,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any,
-      id: 'abc123',
-    });
-    assert.ok(getPolicyStub.calledOnce);
-    assert.ok(getChangerStub.calledOnce);
-    assert.ok(getRepoStub.calledOnce);
-    assert.ok(checkPolicyStub.calledOnce);
-    assert.ok(exportStub.calledOnce);
-    assert.ok(submitFixesStub.calledOnce);
-  });
-
   it('should raise error if checkRepoPolicy throws', async () => {
     const repo = 'nodejs-docs-samples';
     const org = 'GoogleCloudPlatform';


### PR DESCRIPTION
If there's an intermittent error loading config files, prior to this change this
was treated as a 404. Rather than doing this, bubble the error. This will allow
us to investigate how common of an occurrence this is.

Fixes #1924