### PR TITLE
fix(auto-label): add staleness to config schema

### DIFF
--- a/packages/auto-label/src/config-schema.json
+++ b/packages/auto-label/src/config-schema.json
@@ -62,6 +62,21 @@
 		},
 		"paths": {"$ref": "#/definitions/path"}
 	    }
+	},
+	"staleness": {
+	    "type": "object",
+	    "additionalProperties": false,
+	    "properties": {
+		"pullrequest": {
+		    "type": "boolean"
+		},
+		"old": {
+		    "type": "number"
+		},
+		"critical": {
+		    "type": "number"
+		}
+	    }
 	}
     }
 }


### PR DESCRIPTION
Fix the schema for staleness configuration

Fixes #[2751](https://github.com/googleapis/repo-automation-bots/issues/2751) 🦕
