### PR TITLE
build(bazel-bot): build with --allow-releaseinfo-change

### DIFF
--- a/packages/bazel-bot/docker-image/Dockerfile
+++ b/packages/bazel-bot/docker-image/Dockerfile
@@ -29,6 +29,7 @@ FROM gcr.io/gapic-images/googleapis:prod
 COPY --from=0 /jwt-cli/target/release/jwt /bin/jwt
 
 # Install the github command line tool, and jq to parse json responses.
+RUN apt-get --allow-releaseinfo-change update
 RUN apt-get install -y software-properties-common
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
 RUN apt-add-repository https://cli.github.com/packages


### PR DESCRIPTION
Allow the update command to continue downloading data from a repository which changed its information of the release contained in the repository indicating e.g a new major release.

We should be mindful rolling out this update to bazel-bot, due to above warning. The actual tag that changed was stable to oldstable, which makes me think it's not actually a breaking change just one of our dependencies moving locatoins.