### PR TITLE
fix: Revert "feat(owl-bot): Acknowledge Ignore label Before Updating PRs (…

### DIFF
--- a/packages/owl-bot/README.md
+++ b/packages/owl-bot/README.md
@@ -46,13 +46,10 @@ The following sections are internal details for Yosh Team members.
 injecting the following substitutions:
 
 * `_REPOSITORY`: The name of the forked repository (_may differ from base_).
-* `_PR`: The pull request number
 * `_PR_BRANCH`: The branch that a PR has been created from.
-* `_PR_OWNER`: The owner of the PR's repo (e.g. 'googleapis' in https://github.com/googleapis/synthtool)
 * `_PR_USER`: The user creating the PR.
 * `_GITHUB_TOKEN`: [a short-lived GitHub JWT](https://docs.github.com/en/free-pro-team@latest/developers/apps/authenticating-with-github-apps).
 * `_CONTAINER`: The docker container to run (loaded from `.github/OwlBot.yaml`).
-* `_DEFAULT_BRANCH`: The default branch of the repository
 
 2. The appropriate repository and branch are cloned to a working directory.
 3. Any changes made relative to the working directory are pushed back to

--- a/packages/owl-bot/cloud-build/update-pr.yaml
+++ b/packages/owl-bot/cloud-build/update-pr.yaml
@@ -80,17 +80,11 @@ steps:
     env:
       - 'GITHUB_TOKEN=$_GITHUB_TOKEN'
       - 'HOME=/workspace'
-
+  
   # Commit any changes back to the pull request.
   - name: 'gcr.io/cloud-devrel-public-resources/owlbot-cli'
     args:
       - commit-post-processor-update
-      - --dest-repo
-      - ${_PR_OWNER}/${_REPOSITORY}
-      - --pr
-      - ${_PR}
-      - --github-token
-      - ${_GITHUB_TOKEN}
     dir: ${_REPOSITORY}
     env:
       - 'HOME=/workspace'

--- a/packages/owl-bot/src/bin/commands/commit-post-processor-update.ts
+++ b/packages/owl-bot/src/bin/commands/commit-post-processor-update.ts
@@ -24,20 +24,10 @@ import {cwd} from 'process';
 import yargs = require('yargs');
 import {newCmd} from '../../cmd';
 import {findCopyTag, loadOwlBotYaml, unpackCopyTag} from '../../copy-code';
-import {OWL_BOT_IGNORE} from '../../labels';
-import {octokitFactoryFromToken} from '../../octokit-util';
 import * as proc from 'child_process';
 import path = require('path');
-import {githubRepoFromOwnerSlashName} from '../../github-repo';
 
-interface Args {
-  'dest-repo': string;
-  pr: number;
-  'github-token': string;
-  'repo-path': string;
-}
-
-export const commitPostProcessorUpdateCommand: yargs.CommandModule<{}, Args> = {
+export const commitPostProcessorUpdateCommand: yargs.CommandModule<{}, {}> = {
   command: 'commit-post-processor-update',
   describe:
     'Runs either `git commit -m "Updates from OwlBot"` or ' +
@@ -45,39 +35,11 @@ export const commitPostProcessorUpdateCommand: yargs.CommandModule<{}, Args> = {
     'depending on the squash flag in .OwlBot.yaml.\n\n' +
     'Run this command in the root directory of a client library repository ' +
     'after running the post processor.',
-  builder(yargs) {
-    return yargs
-      .option('dest-repo', {
-        describe: "The PR's destination repo (e.g., googleapis/foo)",
-        type: 'string',
-        demand: true,
-      })
-      .option('pr', {
-        describe: 'The pull request number',
-        type: 'number',
-        demand: true,
-      })
-      .option('github-token', {
-        describe: 'Short-lived GitHub token.',
-        type: 'string',
-        demand: true,
-      })
-      .option('repo-path', {
-        describe: 'Local path to the repository',
-        type: 'string',
-        default: cwd(),
-      });
-  },
-  handler: argv => commitPostProcessorUpdate(argv),
+  handler: () => commitPostProcessorUpdate(),
 };
 
-export async function commitPostProcessorUpdate(args: Args): Promise<void> {
-  const octokitFactory = octokitFactoryFromToken(args['github-token']);
-  const octokit = await octokitFactory.getShortLivedOctokit();
-  const repo = githubRepoFromOwnerSlashName(args['dest-repo']);
-
+export async function commitPostProcessorUpdate(repoDir = ''): Promise<void> {
   const cmd = newCmd(console);
-  let repoDir = args['repo-path'];
   if (['', '.'].includes(repoDir)) {
     repoDir = cwd();
   }
@@ -90,22 +52,6 @@ export async function commitPostProcessorUpdate(args: Args): Promise<void> {
   if (!status) {
     return; // No changes made.  Nothing to do.
   }
-
-  // Check if the ignore label has been added during the post-processing.
-  // If so, do not push changes.
-  const {data: prData} = await octokit.pulls.get({
-    owner: repo.owner,
-    repo: repo.repo,
-    pull_number: args.pr,
-  });
-
-  if (prData.labels.find(label => label.name === OWL_BOT_IGNORE)) {
-    console.log(
-      `Not making any changes to ${repo}#${args.pr} because it's labeled with ${OWL_BOT_IGNORE}.`
-    );
-    return;
-  }
-
   // Unpack the Copy-Tag.
   const body = cmd('git log -1 --format=%B', {cwd: repoDir}).toString('utf-8');
   const copyTagText = findCopyTag(body);

--- a/packages/owl-bot/src/fetch-configs.ts
+++ b/packages/owl-bot/src/fetch-configs.ts
@@ -41,6 +41,6 @@ export async function fetchConfigs(
     return collectConfigs(repoDir);
   } finally {
     // When running in cloud functions, space is limited, so clean up.
-    fs.rmSync(tmpDir, {recursive: true});
+    fs.rmdirSync(tmpDir, {recursive: true});
   }
 }

--- a/packages/owl-bot/test/commit-post-processor-update.ts
+++ b/packages/owl-bot/test/commit-post-processor-update.ts
@@ -19,9 +19,6 @@ import {makeDirTree} from './dir-tree';
 import {newCmd} from '../src/cmd';
 import {commitPostProcessorUpdate} from '../src/bin/commands/commit-post-processor-update';
 import {copyTagFrom} from '../src/copy-code';
-import sinon from 'sinon';
-import nock from 'nock';
-import {OWL_BOT_IGNORE, OWLBOT_RUN_LABEL} from '../src/labels';
 
 export function makeOrigin(logger = console): string {
   const cmd = newCmd(logger);
@@ -60,67 +57,12 @@ export function cloneRepo(dir: string, logger = console): string {
 describe('commitPostProcessorUpdate', () => {
   const cmd = newCmd();
   const yamlPath = '.github/.OwlBot.yaml';
-  const destRepo = 'test-org/test-repo';
-  const gitHubToken = 'test-github-token';
-  let sandbox: sinon.SinonSandbox;
-  let pr = 0;
-  let labels: {name: string}[] = [];
-
-  function prepareGitHubEndpoint() {
-    const payload = {
-      pull_request: {
-        labels,
-        number: pr,
-        head: {
-          repo: {
-            full_name: destRepo,
-          },
-          ref: 'abc123',
-        },
-        base: {
-          ref: 'main',
-          repo: {
-            full_name: destRepo,
-          },
-        },
-      },
-    };
-
-    nock.cleanAll();
-    nock('https://api.github.com')
-      .get(`/repos/${destRepo}/pulls/${pr}`)
-      .reply(200, payload.pull_request);
-  }
-
-  function prepareArgs(
-    repoPath: string
-  ): Parameters<typeof commitPostProcessorUpdate>[0] {
-    return {
-      'dest-repo': destRepo,
-      pr,
-      'github-token': gitHubToken,
-      'repo-path': repoPath,
-    };
-  }
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    pr++;
-    labels = [];
-
-    prepareGitHubEndpoint();
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
-    sandbox.restore();
-  });
 
   it("adds commit when there's no Copy-Tag", async () => {
     const origin = makeOrigin();
     const clone = cloneRepo(origin);
     makeDirTree(clone, ['a.txt:The post processor ran.']);
-    await commitPostProcessorUpdate(prepareArgs(clone));
+    await commitPostProcessorUpdate(clone);
     const log = cmd('git log --format=%B main', {cwd: origin}).toString(
       'utf-8'
     );
@@ -134,7 +76,7 @@ describe('commitPostProcessorUpdate', () => {
     cmd('git add c.txt', {cwd: clone});
     cmd('git commit -m "Copy-Tag: abc123"', {cwd: clone});
     makeDirTree(clone, ['a.txt:The post processor ran.']);
-    await commitPostProcessorUpdate(prepareArgs(clone));
+    await commitPostProcessorUpdate(clone);
     const log = cmd('git log --format=%B main', {cwd: origin}).toString(
       'utf-8'
     );
@@ -149,7 +91,7 @@ describe('commitPostProcessorUpdate', () => {
     const copyTag = copyTagFrom(yamlPath, 'abc123');
     cmd(`git commit -m "Copy-Tag: ${copyTag}"`, {cwd: clone});
     makeDirTree(clone, ['a.txt:The post processor ran.']);
-    await commitPostProcessorUpdate(prepareArgs(clone));
+    await commitPostProcessorUpdate(clone);
     const log = cmd('git log --format=%B main', {cwd: origin}).toString(
       'utf-8'
     );
@@ -164,7 +106,7 @@ describe('commitPostProcessorUpdate', () => {
     const copyTag = copyTagFrom(yamlPath, 'abc123');
     cmd(`git commit -m "Copy-Tag: ${copyTag}"`, {cwd: clone});
     makeDirTree(clone, ['a.txt:The post processor ran.']);
-    await commitPostProcessorUpdate(prepareArgs(clone));
+    await commitPostProcessorUpdate(clone);
     const log = cmd('git log --format=%B main', {cwd: origin}).toString(
       'utf-8'
     );
@@ -179,7 +121,7 @@ describe('commitPostProcessorUpdate', () => {
     const copyTag = copyTagFrom(yamlPath, 'abc123');
     cmd(`git commit -m "Copy-Tag: ${copyTag}"`, {cwd: clone});
     makeDirTree(clone, ['a.txt:The post processor ran.']);
-    await commitPostProcessorUpdate(prepareArgs(clone));
+    await commitPostProcessorUpdate(clone);
     const log = cmd('git log --format=%B main', {cwd: origin}).toString(
       'utf-8'
     );
@@ -194,7 +136,7 @@ describe('commitPostProcessorUpdate', () => {
     const copyTag = copyTagFrom(yamlPath, 'abc123');
     cmd(`git commit -m "Copy-Tag: ${copyTag}"`, {cwd: clone});
     makeDirTree(clone, ['a.txt:The post processor ran.']);
-    await commitPostProcessorUpdate(prepareArgs(clone));
+    await commitPostProcessorUpdate(clone);
     const log = cmd('git log --format=%B main', {cwd: origin}).toString(
       'utf-8'
     );
@@ -212,7 +154,7 @@ describe('commitPostProcessorUpdate', () => {
       'utf-8'
     );
     const clone = cloneRepo(origin);
-    await commitPostProcessorUpdate(prepareArgs(clone));
+    await commitPostProcessorUpdate(clone);
     const log = cmd('git log --format=%B main', {cwd: origin}).toString(
       'utf-8'
     );
@@ -223,43 +165,5 @@ describe('commitPostProcessorUpdate', () => {
       head,
       cmd('git log -1 --format=%H main', {cwd: origin}).toString('utf-8')
     );
-  });
-
-  it("Doesn't create a commit if the 'ignore' label is present", async () => {
-    const origin = makeOrigin();
-    const clone = cloneRepo(origin);
-    makeDirTree(clone, ['a.txt:The post processor ran.']);
-    const head = cmd('git log -1 --format=%H main', {cwd: origin}).toString(
-      'utf-8'
-    );
-
-    labels.push({name: OWL_BOT_IGNORE});
-    prepareGitHubEndpoint();
-
-    await commitPostProcessorUpdate(prepareArgs(clone));
-    const log = cmd('git log --format=%B main', {cwd: origin}).toString(
-      'utf-8'
-    );
-    assert.doesNotMatch(log, /Updates from OwlBot/);
-    // No commits should have been pushed.
-    assert.strictEqual(
-      head,
-      cmd('git log -1 --format=%H main', {cwd: origin}).toString('utf-8')
-    );
-  });
-
-  it('Creates a commit if labels other than ignore are present', async () => {
-    const origin = makeOrigin();
-    const clone = cloneRepo(origin);
-    makeDirTree(clone, ['a.txt:The post processor ran.']);
-
-    labels.push({name: OWLBOT_RUN_LABEL});
-    prepareGitHubEndpoint();
-
-    await commitPostProcessorUpdate(prepareArgs(clone));
-    const log = cmd('git log --format=%B main', {cwd: origin}).toString(
-      'utf-8'
-    );
-    assert.match(log, /Updates from OwlBot/);
   });
 });


### PR DESCRIPTION
…#2983)"

This reverts commit dc1edad393d29be133fc56541ea336e647899156.

Saw error:
```
TypeError
fs.rmSync is not a function
TypeError: fs.rmSync is not a function at fetchConfigs (/workspace/build/src/fetch-configs.js:63:12) at refreshConfigs (/workspace/build/src/handlers.js:213:80) at runMicrotasks () at async /workspace/build/src/owl-bot.js:155:9 at async Promise.all (index 0) at async /workspace/node_modules/gcf-utils/build/src/gcf-utils.js:370:21
Service
owl_bot
```
