### PR TITLE
build(owl-bot): Upgrade `owl-bot` Cloud Function to Node v14

### DIFF
--- a/packages/owl-bot/cloudbuild.yaml
+++ b/packages/owl-bot/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs12"
+      - "nodejs14"
       - "540s"
       - "68a5145e-8907-4301-a4b6-b7e37892a510"
 

--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -8,7 +8,7 @@
     "build/src"
   ],
   "engines": {
-    "node": ">=12.10.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "start": "node ./build/src/server.js",

--- a/packages/owl-bot/src/fetch-configs.ts
+++ b/packages/owl-bot/src/fetch-configs.ts
@@ -41,6 +41,6 @@ export async function fetchConfigs(
     return collectConfigs(repoDir);
   } finally {
     // When running in cloud functions, space is limited, so clean up.
-    fs.rmdirSync(tmpDir, {recursive: true});
+    fs.rmSync(tmpDir, {recursive: true});
   }
 }


### PR DESCRIPTION
Upgrading owl-bot's cloud function to v14. The Dockerfiles were already running on v14.