### PR TITLE
build(repo-metadata-lint): use alternate key

### DIFF
--- a/packages/repo-metadata-lint/cloudbuild.yaml
+++ b/packages/repo-metadata-lint/cloudbuild.yaml
@@ -26,6 +26,8 @@ steps:
     id: "publish-function"
     waitFor: ["build"]
     entrypoint: bash
+    env:
+      - SERVICE_ACCOUNT: repo-metadata-lint@repo-automation-bots.iam.gserviceaccount.com
     args:
       - "-e"
       - "./scripts/publish-function.sh"

--- a/packages/repo-metadata-lint/cloudbuild.yaml
+++ b/packages/repo-metadata-lint/cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
     waitFor: ["build"]
     entrypoint: bash
     env:
-      - SERVICE_ACCOUNT: repo-metadata-lint@repo-automation-bots.iam.gserviceaccount.com
+      - 'SERVICE_ACCOUNT=repo-metadata-lint@repo-automation-bots.iam.gserviceaccount.com'
     args:
       - "-e"
       - "./scripts/publish-function.sh"


### PR DESCRIPTION
Use an alternate service account key for repo-metadata-lint.