### PR TITLE
docs(auto-label): add spacing to README.md

### DIFF
--- a/packages/auto-label/README.md
+++ b/packages/auto-label/README.md
@@ -125,6 +125,7 @@ path:
 Bot runs on all pull requests and labels them with staleness indicator based on configured values. Currently there are two staleness labels available: `stale: old` and `stale: extraold`.
 
 Staleness labeling is turned off by default. To turn on staleness labeling:
+
 ```yaml
 # In .github/auto-label.yaml
 staleness:
@@ -140,15 +141,24 @@ staleness:
 ## Size Label
 
 Bot runs on a pull request when it changes and labels them with T-shirt size indicator if feature is enabled. 
+
 Currently there are following labels available:
+
   `size: xs` for pull request with less than 50 changes.
+  
   `size: s` for pull request with less than 250 changes.
+  
   `size: m` for pull request with less than 1000 changes.
+  
   `size: l` for pull request with less than 1250 changes.
+  
   `size: xl` for pull request with less than 1500 changes.
+  
   `size: xxl` for pull request with more than 1500 changes.
+  
 
 Size labeling is turned off by default. To turn on size labeling:
+
 ```yaml
 # In .github/auto-label.yaml
 requestsize:


### PR DESCRIPTION
Add spacing to packages/auto-label/README.md to improve readability
