### PR TITLE
feat(owl-bot): Include the API name in the title of pull requests.

### DIFF
--- a/packages/owl-bot/src/config-files.ts
+++ b/packages/owl-bot/src/config-files.ts
@@ -62,6 +62,7 @@ export interface OwlBotYaml {
   'deep-remove-regex'?: string[];
   'deep-preserve-regex'?: string[];
   'begin-after-commit-hash'?: string;
+  'insert-folder-names-into-pull-request-titles'?: boolean;
 }
 
 // The default path where .OwlBot.yaml is expected to be found.

--- a/packages/owl-bot/src/config-files.ts
+++ b/packages/owl-bot/src/config-files.ts
@@ -62,7 +62,8 @@ export interface OwlBotYaml {
   'deep-remove-regex'?: string[];
   'deep-preserve-regex'?: string[];
   'begin-after-commit-hash'?: string;
-  'insert-folder-names-into-pull-request-titles'?: boolean;
+  // Gets inserted into pull request titles.
+  'api-name'?: string;
 }
 
 // The default path where .OwlBot.yaml is expected to be found.

--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -71,6 +71,7 @@ interface LocalCopy {
   kind: 'LocalCopy';
   dir: string; // The local directory of the github repo.
   sourceCommitHash: string; // The commit hash from which the code was copied.
+  yaml: OwlBotYaml;
 }
 
 /**
@@ -238,6 +239,7 @@ ${copyTagLine}`,
     kind: 'LocalCopy',
     dir: destDir,
     sourceCommitHash,
+    yaml,
   };
 }
 
@@ -290,6 +292,7 @@ export async function copyCodeAndCreatePullRequest(
     [OWL_BOT_COPY],
     octokit,
     prBody,
+    dest.yaml['api-name'] ?? '',
     logger
   );
 }

--- a/packages/owl-bot/src/create-pr.ts
+++ b/packages/owl-bot/src/create-pr.ts
@@ -51,9 +51,37 @@ export function getLastCommitBody(
     .trim();
 }
 
+// Exported for testing only.
+/**
+ * Inserts an API name into a pr title after the first colon.
+ * Ex:
+ *   chore(bazel): Update gapic-generator-php to v1.2.1
+ * bocomes
+ *   chore(bazel): [Billing] Update gapic-generator-php to v1.2.1
+ */
+export function insertApiName(prTitle: string, apiName: string): string {
+  if (!apiName) {
+    return prTitle;
+  }
+  // Only search for the colon in the first 40 characters of the title,
+  // and stop at new lines.  A conventional commit message shouldn't
+  // exceed 40 characters.
+  const match = /^[^\r\n]{1,40}/.exec(prTitle);
+  const firstForty = match ? match[0] : '';
+  const firstColon = firstForty.indexOf(':');
+  if (firstColon < 0) {
+    return `[${apiName}] ${prTitle}`;
+  } else {
+    const left = prTitle.substring(0, firstColon + 1);
+    const right = prTitle.substring(firstColon + 1);
+    return `${left} [${apiName}]${right}`;
+  }
+}
+
 /**
  * Creates a pull request using the title and commit message from the most
  * recent commit.
+ * @argument apiName Name of the API to optionally include in the PR title.
  */
 export async function createPullRequestFromLastCommit(
   owner: string,
@@ -64,6 +92,7 @@ export async function createPullRequestFromLastCommit(
   labels: string[],
   octokit: OctokitType,
   prBody = '',
+  //  apiName = '',
   logger = console
 ): Promise<void> {
   const cmd = newCmd(logger);

--- a/packages/owl-bot/src/create-pr.ts
+++ b/packages/owl-bot/src/create-pr.ts
@@ -92,9 +92,10 @@ export async function createPullRequestFromLastCommit(
   labels: string[],
   octokit: OctokitType,
   prBody = '',
-  //  apiName = '',
+  // apiName = '',
   logger = console
 ): Promise<void> {
+  const apiName = '';
   const cmd = newCmd(logger);
   const githubRepo = await octokit.repos.get({owner, repo});
 
@@ -109,7 +110,10 @@ export async function createPullRequestFromLastCommit(
     .trim();
   const commitBody = prBody ?? getLastCommitBody(localRepoDir, logger);
 
-  const {title, body} = resplit(commitSubject, commitBody);
+  const {title, body} = resplit(
+    insertApiName(commitSubject, apiName),
+    commitBody
+  );
 
   // Create a pull request.
   const pull = await octokit.pulls.create({

--- a/packages/owl-bot/src/create-pr.ts
+++ b/packages/owl-bot/src/create-pr.ts
@@ -92,10 +92,9 @@ export async function createPullRequestFromLastCommit(
   labels: string[],
   octokit: OctokitType,
   prBody = '',
-  // apiName = '',
+  apiName = '',
   logger = console
 ): Promise<void> {
-  const apiName = '';
   const cmd = newCmd(logger);
   const githubRepo = await octokit.repos.get({owner, repo});
 

--- a/packages/owl-bot/src/owl-bot-yaml-schema.json
+++ b/packages/owl-bot/src/owl-bot-yaml-schema.json
@@ -5,9 +5,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "insert-folder-names-into-pull-request-titles": {
-      "type":"boolean",
-      "description": "Insert the name of the folder when creating pull requests.  Mono-repos will like this."
+    "api-name": {
+      "type":"string",
+      "description": "Gets inserted into pull request titles.  Useful for mono-repos."
     },
     "begin-after-commit-hash": {
       "type": "string",

--- a/packages/owl-bot/src/owl-bot-yaml-schema.json
+++ b/packages/owl-bot/src/owl-bot-yaml-schema.json
@@ -5,6 +5,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "insert-folder-names-into-pull-request-titles": {
+      "type":"boolean",
+      "description": "Insert the name of the folder when creating pull requests.  Mono-repos will like this."
+    },
     "begin-after-commit-hash": {
       "type": "string",
       "description": "Start creating pull requests after this googleapis-gen commit hash."

--- a/packages/owl-bot/src/update-lock.ts
+++ b/packages/owl-bot/src/update-lock.ts
@@ -54,6 +54,7 @@ export async function maybeCreatePullRequestForLockUpdate(
       [core.OWL_BOT_LOCK_UPDATE],
       octokit,
       '',
+      '', // No API name because this PR was not triggered by an API change.
       logger
     );
   } else {

--- a/packages/owl-bot/test/config-files.ts
+++ b/packages/owl-bot/test/config-files.ts
@@ -34,7 +34,7 @@ deep-preserve-regex:
 
 begin-after-commit-hash: abc123
 
-insert-folder-names-into-pull-request-titles: false
+api-name: Billing
 
 docker:
   image: gcr.io/cloud-devrel-resources/synthtool-nodejs:prod
@@ -46,7 +46,7 @@ docker:
       'deep-remove-regex': ['/src'],
       'begin-after-commit-hash': 'abc123',
       docker: {image: 'gcr.io/cloud-devrel-resources/synthtool-nodejs:prod'},
-      'insert-folder-names-into-pull-request-titles': false,
+      'api-name': 'Billing',
     });
   });
 

--- a/packages/owl-bot/test/config-files.ts
+++ b/packages/owl-bot/test/config-files.ts
@@ -46,7 +46,7 @@ docker:
       'deep-remove-regex': ['/src'],
       'begin-after-commit-hash': 'abc123',
       docker: {image: 'gcr.io/cloud-devrel-resources/synthtool-nodejs:prod'},
-      'insert-folder-names-into-pull-request-titles': false
+      'insert-folder-names-into-pull-request-titles': false,
     });
   });
 

--- a/packages/owl-bot/test/config-files.ts
+++ b/packages/owl-bot/test/config-files.ts
@@ -34,6 +34,8 @@ deep-preserve-regex:
 
 begin-after-commit-hash: abc123
 
+insert-folder-names-into-pull-request-titles: false
+
 docker:
   image: gcr.io/cloud-devrel-resources/synthtool-nodejs:prod
 `;
@@ -44,6 +46,7 @@ docker:
       'deep-remove-regex': ['/src'],
       'begin-after-commit-hash': 'abc123',
       docker: {image: 'gcr.io/cloud-devrel-resources/synthtool-nodejs:prod'},
+      'insert-folder-names-into-pull-request-titles': false
     });
   });
 

--- a/packages/owl-bot/test/create-pr.ts
+++ b/packages/owl-bot/test/create-pr.ts
@@ -14,7 +14,12 @@
 
 import {describe, it} from 'mocha';
 import * as assert from 'assert';
-import {MAX_BODY_LENGTH, MAX_TITLE_LENGTH, resplit} from '../src/create-pr';
+import {
+  insertApiName,
+  MAX_BODY_LENGTH,
+  MAX_TITLE_LENGTH,
+  resplit,
+} from '../src/create-pr';
 
 describe('resplit', () => {
   it('leaves a short title unchanged', () => {
@@ -50,5 +55,49 @@ describe('resplit', () => {
     assert.strictEqual(tb.title, 'title');
     assert.strictEqual(tb.body.length, MAX_BODY_LENGTH);
     assert.ok(tb.body.length < body.length);
+  });
+});
+
+describe('insertApiName', () => {
+  it('does nothing when the api name is empty', () => {
+    const title = 'chore(bazel): Update gapic-generator-php to v1.2.1';
+    const newTitle = insertApiName(title, '');
+    assert.deepStrictEqual(newTitle, title);
+  });
+
+  it('inserts the api name after the colon.', () => {
+    const title = 'chore(bazel): Update gapic-generator-php to v1.2.1';
+    const newTitle = insertApiName(title, 'Billing');
+    assert.deepStrictEqual(
+      newTitle,
+      'chore(bazel): [Billing] Update gapic-generator-php to v1.2.1'
+    );
+  });
+
+  it("inserts the api name at the beginning when there's no colon.", () => {
+    const title = 'chore(bazel) Update gapic-generator-php to v1.2.1';
+    const newTitle = insertApiName(title, 'Billing');
+    assert.deepStrictEqual(
+      newTitle,
+      '[Billing] chore(bazel) Update gapic-generator-php to v1.2.1'
+    );
+  });
+
+  it('ignores a colon after a newline.', () => {
+    const title = 'chore(bazel)\n: Update gapic-generator-php to v1.2.1';
+    const newTitle = insertApiName(title, 'Billing');
+    assert.deepStrictEqual(
+      newTitle,
+      '[Billing] chore(bazel)\n: Update gapic-generator-php to v1.2.1'
+    );
+  });
+
+  it('ignores a colon after 40 characters', () => {
+    const title = 'chore(bazel) Update gapic-generator-php to v1.2.1 : colon';
+    const newTitle = insertApiName(title, 'Billing');
+    assert.deepStrictEqual(
+      newTitle,
+      '[Billing] chore(bazel) Update gapic-generator-php to v1.2.1 : colon'
+    );
   });
 });

--- a/packages/owl-bot/test/update-lock.ts
+++ b/packages/owl-bot/test/update-lock.ts
@@ -76,6 +76,7 @@ describe('maybeCreatePullRequestForLockUpdate', () => {
         ['owl-bot-update-lock'],
         {fake: true},
         '',
+        '',
         console,
       ],
     ]);


### PR DESCRIPTION
The repo maintainers need to specify an `api-name` in `.OwlBot.yaml`.  This is annoying, but necessary because:
1. Split repos don't want the API name in the PR title, so there has to be a way of turning it on and off.
2. If there's going to be a flag in `.OwlBot.yaml`, then may as well make it the name of the API instead of using a boolean flag and writing clever code to guess the API name from directory structure.

Fixes #3028
