### PR TITLE
fix(repo-metadata-lint): always run opener

### DIFF
--- a/packages/repo-metadata-lint/src/repo-metadata-lint.ts
+++ b/packages/repo-metadata-lint/src/repo-metadata-lint.ts
@@ -47,9 +47,9 @@ export function handler(app: Probot) {
       logger.info(
         `${results.length} validation errors found for ${owner}/${repo}`
       );
-      const opener = new IssueOpener(owner, repo, context.octokit);
-      await opener.open(results);
     }
+    const opener = new IssueOpener(owner, repo, context.octokit);
+    await opener.open(results);
   });
 
   // Adds failing check to pull requests if .repo-metadata.json is invalid.

--- a/packages/repo-metadata-lint/test/repo-metadata-lint.ts
+++ b/packages/repo-metadata-lint/test/repo-metadata-lint.ts
@@ -60,6 +60,9 @@ describe('repo-metadata-lint', () => {
         .stub()
         .returns(emptyIterator());
       const infoStub = sandbox.stub(logger, 'info');
+      const githubApiRequests = nock('https://api.github.com')
+        .get('/repos/foo-org/foo-repo/issues?labels=repo-metadata%3A%20lint')
+        .reply(200, []);
       await probot.receive({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         name: 'schedule.repository' as any,
@@ -72,6 +75,7 @@ describe('repo-metadata-lint', () => {
         id: 'abc123',
       });
       sandbox.assert.calledWith(infoStub, sinon.match(/no validation errors/));
+      githubApiRequests.done();
     });
 
     it('opens an issue on failure', async () => {


### PR DESCRIPTION
The opener method closes PRs if they no longer have problems, so it
should always be run.