### PR TITLE
fix: use a token when cloning googleapis-gen

### DIFF
--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -30,6 +30,7 @@ import {OWL_BOT_COPY} from './core';
 import {newCmd} from './cmd';
 import {createPullRequestFromLastCommit, getLastCommitBody} from './create-pr';
 import {AffectedRepo} from './configs-store';
+import {githubRepoFromOwnerSlashName} from './github-repo';
 
 // This code generally uses Sync functions because:
 // 1. None of our current designs including calling this code from a web
@@ -350,24 +351,25 @@ export async function loadOwlBotYaml(yamlPath: string): Promise<OwlBotYaml> {
  * @param workDir a local directory where the cloned repo will be created
  * @param logger a logger
  * @param depth the depth param to pass to git clone.
+ * @param accessToken use this access token when cloning the repo.
  * @returns the path to the local repo.
  */
 export function toLocalRepo(
   repo: string,
   workDir: string,
   logger = console,
-  depth = 100
+  depth = 100,
+  accessToken = ''
 ): string {
   if (stat(repo)?.isDirectory()) {
     logger.info(`Using local source repo directory ${repo}`);
     return repo;
   } else {
-    const [, repoName] = repo.split('/');
-    const localDir = path.join(workDir, repoName);
+    const githubRepo = githubRepoFromOwnerSlashName(repo);
+    const localDir = path.join(workDir, githubRepo.repo);
+    const url = githubRepo.getCloneUrl(accessToken);
     const cmd = newCmd(logger);
-    cmd(
-      `git clone --depth=${depth} "https://github.com/${repo}.git" ${localDir}`
-    );
+    cmd(`git clone --depth=${depth} "${url}" ${localDir}`);
     return localDir;
   }
 }

--- a/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
@@ -77,7 +77,13 @@ export async function scanGoogleapisGenAndCreatePullRequests(
   const workDir = tmp.dirSync().name;
   // cloneDepth + 1 because the final commit in a shallow clone is grafted: it contains
   // the combined state of all earlier commits, so we don't want to examine it.
-  const sourceDir = toLocalRepo(sourceRepo, workDir, logger, cloneDepth + 1);
+  const sourceDir = toLocalRepo(
+    sourceRepo,
+    workDir,
+    logger,
+    cloneDepth + 1,
+    await octokitFactory.getGitHubShortLivedAccessToken()
+  );
 
   // Collect the history of commit hashes.
   const cmd = newCmd(logger);

--- a/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
@@ -127,7 +127,9 @@ describe('scanGoogleapisGenAndCreatePullRequests', function () {
     assert.strictEqual(
       await scanGoogleapisGenAndCreatePullRequests(
         abcRepo,
-        {} as OctokitFactory,
+        {
+          getGitHubShortLivedAccessToken: () => Promise.resolve(''),
+        } as OctokitFactory,
         new FakeConfigsStore(),
         1000
       ),


### PR DESCRIPTION
because it's a private repo now
