### PR TITLE
fix(owlbot-cli): allow token to be passed to copy-code

### DIFF
--- a/packages/owl-bot/src/bin/commands/copy-code.ts
+++ b/packages/owl-bot/src/bin/commands/copy-code.ts
@@ -24,6 +24,7 @@ interface Args {
   'source-repo-commit-hash': string;
   dest: string | undefined;
   'config-file': string;
+  token?: string;
 }
 
 export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
@@ -54,6 +55,10 @@ export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
         describe: 'Path in the directory to the .OwlBot.yaml config.',
         type: 'string',
         default: '.github/.OwlBot.yaml',
+      })
+      .option('token', {
+        describe: 'Token for cloning private googleapis-gen repo',
+        type: 'string',
       });
   },
   async handler(argv) {
@@ -63,7 +68,9 @@ export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
       argv['source-repo-commit-hash'],
       destDir,
       tmp.dirSync().name,
-      await loadOwlBotYaml(path.join(destDir, argv['config-file']))
+      await loadOwlBotYaml(path.join(destDir, argv['config-file'])),
+      console,
+      argv.token
     );
   },
 };

--- a/packages/owl-bot/src/bin/commands/copy-code.ts
+++ b/packages/owl-bot/src/bin/commands/copy-code.ts
@@ -70,7 +70,7 @@ export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
       tmp.dirSync().name,
       await loadOwlBotYaml(path.join(destDir, argv['config-file'])),
       console,
-      argv.token
+      argv.token ?? process.env.GITHUB_TOKEN
     );
   },
 };

--- a/packages/owl-bot/src/cmd.ts
+++ b/packages/owl-bot/src/cmd.ts
@@ -19,12 +19,20 @@ export type Cmd = (
   options?: proc.ExecSyncOptions | undefined
 ) => Buffer;
 
+function sanitize(command: string) {
+  command = command.replace(
+    /x-access-token:([^/]+)/,
+    'x-access-token:REDACTED'
+  );
+  return command;
+}
+
 export function newCmd(logger = console): Cmd {
   const cmd = (
     command: string,
     options?: proc.ExecSyncOptions | undefined
   ): Buffer => {
-    logger.info(command);
+    logger.info(sanitize(command));
     return proc.execSync(command, options);
   };
   return cmd;

--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -402,10 +402,17 @@ export async function copyCode(
   destDir: string,
   workDir: string,
   yaml: OwlBotYaml,
-  logger = console
+  logger = console,
+  accessToken?: string
 ): Promise<{sourceCommitHash: string; commitMsgPath: string}> {
   const cmd = newCmd(logger);
-  const sourceDir = toLocalRepo(sourceRepo, workDir, logger);
+  const sourceDir = toLocalRepo(
+    sourceRepo,
+    workDir,
+    logger,
+    100,
+    accessToken ?? ''
+  );
   // Check out the specific hash we want to copy from.
   if ('none' === sourceCommitHash) {
     // User is running copy-code from command line.  The path specified by


### PR DESCRIPTION
Make it possiblet to continue running local copy of copy-code by passing in a user access token.