### PR TITLE
chore: Revert "fix(owlbot-cli): allow token to be passed to copy-code…

### DIFF
--- a/packages/owl-bot/src/bin/commands/copy-code.ts
+++ b/packages/owl-bot/src/bin/commands/copy-code.ts
@@ -24,7 +24,6 @@ interface Args {
   'source-repo-commit-hash': string;
   dest: string | undefined;
   'config-file': string;
-  token?: string;
 }
 
 export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
@@ -55,10 +54,6 @@ export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
         describe: 'Path in the directory to the .OwlBot.yaml config.',
         type: 'string',
         default: '.github/.OwlBot.yaml',
-      })
-      .option('token', {
-        describe: 'Token for cloning private googleapis-gen repo',
-        type: 'string',
       });
   },
   async handler(argv) {
@@ -68,9 +63,7 @@ export const copyCodeCommand: yargs.CommandModule<{}, Args> = {
       argv['source-repo-commit-hash'],
       destDir,
       tmp.dirSync().name,
-      await loadOwlBotYaml(path.join(destDir, argv['config-file'])),
-      console,
-      argv.token ?? process.env.GITHUB_TOKEN
+      await loadOwlBotYaml(path.join(destDir, argv['config-file']))
     );
   },
 };

--- a/packages/owl-bot/src/cmd.ts
+++ b/packages/owl-bot/src/cmd.ts
@@ -19,20 +19,12 @@ export type Cmd = (
   options?: proc.ExecSyncOptions | undefined
 ) => Buffer;
 
-function sanitize(command: string) {
-  command = command.replace(
-    /x-access-token:([^/]+)/,
-    'x-access-token:REDACTED'
-  );
-  return command;
-}
-
 export function newCmd(logger = console): Cmd {
   const cmd = (
     command: string,
     options?: proc.ExecSyncOptions | undefined
   ): Buffer => {
-    logger.info(sanitize(command));
+    logger.info(command);
     return proc.execSync(command, options);
   };
   return cmd;

--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -402,17 +402,10 @@ export async function copyCode(
   destDir: string,
   workDir: string,
   yaml: OwlBotYaml,
-  logger = console,
-  accessToken?: string
+  logger = console
 ): Promise<{sourceCommitHash: string; commitMsgPath: string}> {
   const cmd = newCmd(logger);
-  const sourceDir = toLocalRepo(
-    sourceRepo,
-    workDir,
-    logger,
-    100,
-    accessToken ?? ''
-  );
+  const sourceDir = toLocalRepo(sourceRepo, workDir, logger);
   // Check out the specific hash we want to copy from.
   if ('none' === sourceCommitHash) {
     // User is running copy-code from command line.  The path specified by


### PR DESCRIPTION
… (#3092)"

This reverts commit 5ed8c95c7fe7c974d19eba68e406488bdf0e0683.

Neenu has updated the Java code so it clones googleapis-gen
before calling copy-code.
