### PR TITLE
fix: allow overriding Cloud Run service name in deployment

### DIFF
--- a/packages/canary-bot/cloudbuild.yaml
+++ b/packages/canary-bot/cloudbuild.yaml
@@ -84,6 +84,8 @@ steps:
     id: "deploy-cloud-run-backend"
     waitFor: ["push-docker"]
     entrypoint: bash
+    env:
+      - "SERVICE_NAME=canary-bot-cloud-run-backend"
     args:
       - "-e"
       - "./scripts/publish-cloud-run.sh"
@@ -94,4 +96,4 @@ steps:
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
       # override the bot name
-      - canary-bot-cloud-run-backend
+      - canary-bot-cloud-run

--- a/scripts/publish-cloud-run.sh
+++ b/scripts/publish-cloud-run.sh
@@ -59,8 +59,11 @@ else
     exit 1
 fi
 
+if [ -z "${SERVICE_NAME}" ]; then
+  SERVICE_NAME=${botName//_/-}
+fi
+
 pushd "${directoryName}"
-serviceName=${botName//_/-}
 functionName=${botName//-/_}
 queueName=${botName//_/-}
 
@@ -103,11 +106,11 @@ fi
 if [ -n "${MEMORY}" ]; then
   deployArgs+=( "--memory" "${MEMORY}" )
 fi
-echo "About to cloud run app ${serviceName}"
-gcloud run deploy "${serviceName}" "${deployArgs[@]}"
+echo "About to cloud run app ${SERVICE_NAME}"
+gcloud run deploy "${SERVICE_NAME}" "${deployArgs[@]}"
 
 echo "Adding ability for allUsers to execute the Function"
-gcloud run services add-iam-policy-binding "${serviceName}" \
+gcloud run services add-iam-policy-binding "${SERVICE_NAME}" \
   --member="allUsers" \
   --region "${region}" \
   --role="roles/run.invoker"


### PR DESCRIPTION
Fixes canary deployment. The bot uses the bot name to fetch it's credentials.
