### PR TITLE
fix(release-trigger): split deployment of front/backend

### DIFF
--- a/packages/release-trigger/cloudbuild-test.yaml
+++ b/packages/release-trigger/cloudbuild-test.yaml
@@ -23,11 +23,13 @@ steps:
       - "gcr.io/$PROJECT_ID/release-trigger"
       - "."
 
-  - name: gcr.io/gcp-runtimes/structure_test
-    args:
-      - "-i"
+  - name: gcr.io/gcp-runtimes/container-structure-test
+    args: 
+      - "test"
+      - "--image"
       - "gcr.io/$PROJECT_ID/release-trigger"
       - "--config"
       - "/workspace/packages/release-trigger/container-test.yaml"
       - "-v"
+      - "debug"
     waitFor: ["build-docker"]

--- a/packages/release-trigger/cloudbuild.yaml
+++ b/packages/release-trigger/cloudbuild.yaml
@@ -29,12 +29,31 @@ steps:
     args: ["push", "gcr.io/$PROJECT_ID/release-trigger"]
 
   - name: gcr.io/cloud-builders/gcloud
-    id: "deploy-cloud-run"
+    id: "deploy-frontend"
     waitFor: ["push-docker"]
     entrypoint: bash
     env:
       - "SERVICE_ACCOUNT=autorelease@repo-automation-bots.iam.gserviceaccount.com"
       - "MEMORY=1G"
+    args:
+      - "-e"
+      - "./scripts/publish-cloud-run.sh"
+      - "$_DIRECTORY"
+      - "$PROJECT_ID"
+      - "$_BUCKET"
+      - "$_KEY_LOCATION"
+      - "$_KEY_RING"
+      - "$_FUNCTION_REGION"
+
+  - name: gcr.io/cloud-builders/gcloud
+    id: "deploy-backend"
+    waitFor: ["push-docker"]
+    entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=autorelease@repo-automation-bots.iam.gserviceaccount.com"
+      - "MEMORY=1G"
+      - "SERVICE_NAME=release-trigger-backend"
+      - "CONCURRENCY=4"
     args:
       - "-e"
       - "./scripts/publish-cloud-run.sh"

--- a/packages/release-trigger/package-lock.json
+++ b/packages/release-trigger/package-lock.json
@@ -811,11 +811,11 @@
       }
     },
     "@google-cloud/kms": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-2.4.1.tgz",
-      "integrity": "sha512-i2rghlJNfoG7w1fJF5BuH5mAgunSew5dJYUtH8fqXA8bLkZXOpx/8QwNjAL20aeSCKq+uItal09n1HuSYrnLeg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-2.10.0.tgz",
+      "integrity": "sha512-qS8Vr9GEwzr3zs3tlLsW3HOcchAaG4G26W0ebhNXpYfLFkI9HYZpcwR+WIyPB53XH8slmWUmuZEhzQCskwel/Q==",
       "requires": {
-        "google-gax": "^2.12.0"
+        "google-gax": "^2.24.1"
       }
     },
     "@google-cloud/paginator": {
@@ -838,11 +838,11 @@
       "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
     },
     "@google-cloud/secret-manager": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.7.2.tgz",
-      "integrity": "sha512-c06OquLy4o9P4PqA5V/IFFtkk2h15U0xImIIBRQD5sEYRXoXyROXhIB8najUD1Z4ywpxWoB6nePjxQ2B4uYY6A==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-3.10.1.tgz",
+      "integrity": "sha512-aYnEolmrfUVRSJuKMce772YOyGZIetq4eDfN3yaMJ5BFJ/RO/SJOM1ruD/drKKTM+G39mnsHUK9GzAaoT/43ow==",
       "requires": {
-        "google-gax": "^2.12.0"
+        "google-gax": "^2.24.1"
       }
     },
     "@google-cloud/storage": {
@@ -874,11 +874,11 @@
       }
     },
     "@google-cloud/tasks": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-2.3.2.tgz",
-      "integrity": "sha512-pO+SFnvY/mn8criCauJrk88aLS57V9Mt78uST4TXN79DgESufyICUFNncOhcd4jxQybCG4UTtDQILBJoYua5uQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-2.5.0.tgz",
+      "integrity": "sha512-3hhsLccb8OUI5/0Bg0VNt88XXYHhbKHiBt2n81VNjmwhZXHaKaBzq13l7NGcuOTkjl5hWLXPWDsctAu4m7dKVQ==",
       "requires": {
-        "google-gax": "^2.12.0"
+        "google-gax": "^2.24.1"
       }
     },
     "@googleapis/run": {
@@ -890,11 +890,26 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.4.tgz",
-      "integrity": "sha512-AxtZcm0mArQhY9z8T3TynCYVEaSKxNCa9mVhVwBCUnsuUEe8Zn94bPYYKVQSLt+hJJ1y0ukr3mUvtWfcATL/IQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.5.3.tgz",
+      "integrity": "sha512-q0xgaZ3ymUM+ZOhe1hdocVSdKHCnJ6llLSXcP+MqMXMyYPUZ3mzQOCxZ3Zkg+QZ7sZ950sn7hvueQrIJZumPZg==",
       "requires": {
+        "@grpc/proto-loader": "^0.6.4",
         "@types/node": ">=12.12.47"
+      },
+      "dependencies": {
+        "@grpc/proto-loader": {
+          "version": "0.6.9",
+          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.9.tgz",
+          "integrity": "sha512-UlcCS8VbsU9d3XTXGiEVFonN7hXk+oMXZtoHHG2oSA1/GcDP1q6OUgs20PzHDGizzyi8ufGSUDlk3O2NyY7leg==",
+          "requires": {
+            "@types/long": "^4.0.1",
+            "lodash.camelcase": "^4.3.0",
+            "long": "^4.0.0",
+            "protobufjs": "^6.10.0",
+            "yargs": "^16.2.0"
+          }
+        }
       }
     },
     "@grpc/proto-loader": {
@@ -1166,13 +1181,14 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-7.21.0.tgz",
-      "integrity": "sha512-Mj7Pa6JZgSjfzQfYF3Bf5KpyhzEBv4kHbj2EjCB/vMQiZCiiW30j5rS6t/d0ZN0FBrlSOuJIT+YU8IJt30VyWA==",
+      "version": "9.22.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.22.0.tgz",
+      "integrity": "sha512-wUd7nGfDRHG6xkz311djmq6lIB2tQ+r94SNkyv9o0bQhOsrkwH8fQCM7uVsbpkGUU2lqCYsVoa8z/UC9HJgRaw==",
       "requires": {
         "@octokit/request-error": "^2.0.2",
-        "aggregate-error": "^3.1.0",
-        "debug": "^4.0.0"
+        "@octokit/webhooks-methods": "^2.0.0",
+        "@octokit/webhooks-types": "5.2.0",
+        "aggregate-error": "^3.1.0"
       }
     },
     "@octokit/webhooks-methods": {
@@ -1418,9 +1434,9 @@
       "integrity": "sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg=="
     },
     "@types/bunyan": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.6.tgz",
-      "integrity": "sha512-YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==",
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.8.tgz",
+      "integrity": "sha512-Cblq+Yydg3u+sGiz2mjHjC5MPmdjY+No4qvHrF+BUhblsmSfMvsHLbOG62tPbonsqBj6sbWv1LHcsoe5Jw+/Ow==",
       "requires": {
         "@types/node": "*"
       }
@@ -1447,17 +1463,17 @@
       }
     },
     "@types/end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@types/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha512-d0FD2A4vpFI8wyQeQbr9VDVKtA1PmeGO3Ntn+6j626QTtAQ9HSqWFACP7rTHaV2cspVhLijl00Vvkf/U2UZGWA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@types/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-dYCSlUtCGXuP2axeKD5l1vj/04iNXW8TLXryDa0uA8u8EsNE68jn27ZLg7jAPV+qJAlk1wC4WtRdIoZXvuUl0A==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/express": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.12.tgz",
-      "integrity": "sha512-pTYas6FrP15B1Oa0bkN5tQMNqOcVXa9j4FTFtO8DWI9kppKib+6NJtfTOOLcwxuuYvcX2+dVG6et1SxW/Kc17Q==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -1484,9 +1500,9 @@
       }
     },
     "@types/ioredis": {
-      "version": "4.26.4",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.4.tgz",
-      "integrity": "sha512-QFbjNq7EnOGw6d1gZZt2h26OFXjx7z+eqEnbCHSrDI1OOLEgOHMKdtIajJbuCr9uO+X9kQQRe7Lz6uxqxl5XKg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.7.tgz",
+      "integrity": "sha512-jnSGCD2/TPk02j6v6CGqaCEl0LbmLgK6jUuk/AFaSNUBV+SCHiG7E7fnwJreN6hw9GqtLAFkJs4zFbkJrz11mQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -1640,9 +1656,9 @@
       }
     },
     "@types/uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.28.1",
@@ -3436,38 +3452,61 @@
       }
     },
     "gcf-utils": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-11.4.0.tgz",
-      "integrity": "sha512-8YhdVRUrgxqQRV7IFO1JgUqdkrh1Iy9bELfJqxcCMAcFsJ7fCIEF3faXnw+ykaD0lOJS9iBbQJrrcRvAqU3lbA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.2.0.tgz",
+      "integrity": "sha512-tY/jitGGVoIrXSQ0mcK2hTxP+RMTbIFsk8yHC00PT5C5hbHstsleSWKth6rrzwDSTZX742C6+jLPYfjuJ5R7eg==",
       "requires": {
-        "@google-cloud/kms": "^2.0.0",
-        "@google-cloud/secret-manager": "^3.0.0",
-        "@google-cloud/storage": "^5.3.0",
-        "@google-cloud/tasks": "^2.0.0",
-        "@googleapis/run": "^2.0.0",
+        "@google-cloud/kms": "^2.4.2",
+        "@google-cloud/secret-manager": "^3.7.3",
+        "@google-cloud/storage": "^5.8.5",
+        "@google-cloud/tasks": "^2.3.4",
+        "@googleapis/run": "^5.0.0",
         "@octokit/plugin-enterprise-compatibility": "1.3.0",
         "@octokit/rest": "^18.5.2",
         "@probot/octokit-plugin-config": "^1.0.0",
-        "@types/bunyan": "^1.8.6",
+        "@types/bunyan": "^1.8.7",
         "@types/dotenv": "^6.1.1",
-        "@types/end-of-stream": "^1.4.0",
-        "@types/express": "^4.17.0",
+        "@types/end-of-stream": "^1.4.1",
+        "@types/express": "^4.17.13",
         "@types/into-stream": "^3.1.1",
-        "@types/ioredis": "^4.14.8",
-        "@types/lru-cache": "^5.1.0",
-        "@types/sonic-boom": "^0.7.0",
-        "@types/uuid": "^8.3.0",
+        "@types/ioredis": "^4.26.5",
+        "@types/lru-cache": "^5.1.1",
+        "@types/sonic-boom": "^2.0.0",
+        "@types/uuid": "^8.3.1",
         "body-parser": "^1.19.0",
         "express": "^4.17.1",
-        "gaxios": "^4.0.0",
-        "get-stream": "^6.0.0",
+        "gaxios": "^4.3.0",
+        "get-stream": "^6.0.1",
         "into-stream": "^6.0.0",
-        "octokit-auth-probot": "^1.2.4",
-        "pino": "^6.3.2",
-        "probot": "^11.1.1",
-        "tmp": "^0.2.0",
-        "uuid": "^8.3.0",
+        "octokit-auth-probot": "^1.2.6",
+        "pino": "^6.11.3",
+        "probot": "^12.1.0",
+        "tmp": "^0.2.1",
+        "uuid": "^8.3.2",
         "yargs": "^16.0.0"
+      },
+      "dependencies": {
+        "@googleapis/run": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/@googleapis/run/-/run-5.2.1.tgz",
+          "integrity": "sha512-9GXHPgU8l+8ovg29eSeKGi3ogz4BA/9ZWOLt9K6LMh61HinWlsRDzI9RrxEKI6uZt8Uvooa3ZSE+RdxhaQZr0w==",
+          "requires": {
+            "googleapis-common": "^5.0.1"
+          }
+        },
+        "@types/lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+        },
+        "@types/sonic-boom": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@types/sonic-boom/-/sonic-boom-2.1.1.tgz",
+          "integrity": "sha512-CiKn+8CDgtBspfAVPwC8PXCMPhqeL7pFS4aWuj+WJnHLZlu4OGPctdZ6Mob43jRe0kkd7Ztb2Hcu9kzB+b7ZFw==",
+          "requires": {
+            "sonic-boom": "*"
+          }
+        }
       }
     },
     "gcp-metadata": {
@@ -3591,22 +3630,49 @@
       }
     },
     "google-gax": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.17.0.tgz",
-      "integrity": "sha512-Ze/Oq0atVNKyKvDzQFU8B82V9w36GELQruXGsiY1jnySbieZ9vS75v98V/Z10PktmSVqis4sQ+FwK2gkgwIiiw==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.29.4.tgz",
+      "integrity": "sha512-3o6cByD2fE1yIc6i1gpKMQlJStqlvu8Sa/Ly/HCQ6GPHpltpVfkTT4KVj2YLVa7WTSDoGbsLBDmJ1KfN1uNiRw==",
       "requires": {
-        "@grpc/grpc-js": "~1.3.0",
+        "@grpc/grpc-js": "~1.5.0",
         "@grpc/proto-loader": "^0.6.1",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "fast-text-encoding": "^1.0.3",
-        "google-auth-library": "^7.0.2",
+        "google-auth-library": "^7.6.1",
         "is-stream-ended": "^0.1.4",
         "node-fetch": "^2.6.1",
         "object-hash": "^2.1.1",
-        "protobufjs": "^6.10.2",
+        "proto3-json-serializer": "^0.1.7",
+        "protobufjs": "6.11.2",
         "retry-request": "^4.0.0"
+      },
+      "dependencies": {
+        "google-auth-library": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.11.0.tgz",
+          "integrity": "sha512-3S5jn2quRumvh9F/Ubf7GFrIq71HZ5a6vqosgdIu105kkk0WtSqc2jGCRqtWWOLRS8SX3AHACMOEDxhyWAQIcg==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "proto3-json-serializer": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.8.tgz",
+          "integrity": "sha512-ACilkB6s1U1gWnl5jtICpnDai4VCxmI9GFxuEaYdxtDG2oVI3sVFIUsvUZcQbJgtPM6p+zqKbjTKQZp6Y4FpQw==",
+          "requires": {
+            "protobufjs": "^6.11.2"
+          }
+        }
       }
     },
     "google-p12-pem": {
@@ -3917,15 +3983,16 @@
       }
     },
     "ioredis": {
-      "version": "4.27.6",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.6.tgz",
-      "integrity": "sha512-6W3ZHMbpCa8ByMyC1LJGOi7P2WiOKP9B3resoZOVLDhi+6dDBOW+KNsRq3yI36Hmnb2sifCxHX+YSarTeXh48A==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.3.tgz",
+      "integrity": "sha512-9JOWVgBnuSxpIgfpjc1OeY1OLmA4t2KOWWURTDRXky+eWO0LZhI33pQNT9gYxANUXfh5p/zYephYni6GPRsksQ==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.1",
         "denque": "^1.1.0",
         "lodash.defaults": "^4.2.0",
         "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
         "p-map": "^2.1.0",
         "redis-commands": "1.7.0",
         "redis-errors": "^1.2.0",
@@ -5196,9 +5263,9 @@
       }
     },
     "probot": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/probot/-/probot-11.4.1.tgz",
-      "integrity": "sha512-kxNImVNZIheWtDUFbQSp0F1Qb7EEi4MvZRtKFBQPS3GSklC+u4oqnILfH4GsmXs0g+brrIX7g8qf/SUyDkw2sw==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-12.2.1.tgz",
+      "integrity": "sha512-CpqulMQFwfkh/3J+TcizxQgXeTgIVhw8ZpYq4TU4uHoo1iSC8Xmyrfv2BHRNI1OWRQhCnpJXIWh5EzhpX24Fvw==",
       "requires": {
         "@octokit/core": "^3.2.4",
         "@octokit/plugin-enterprise-compatibility": "^1.2.8",
@@ -5207,12 +5274,12 @@
         "@octokit/plugin-retry": "^3.0.6",
         "@octokit/plugin-throttling": "^3.3.4",
         "@octokit/types": "^6.1.1",
-        "@octokit/webhooks": "7.21.0",
+        "@octokit/webhooks": "^9.8.4",
         "@probot/get-private-key": "^1.1.0",
         "@probot/octokit-plugin-config": "^1.0.0",
         "@probot/pino": "^2.2.0",
         "@types/express": "^4.17.9",
-        "@types/ioredis": "^4.17.8",
+        "@types/ioredis": "^4.27.1",
         "@types/pino": "^6.3.4",
         "@types/pino-http": "^5.0.6",
         "@types/update-notifier": "^5.0.0",
@@ -5222,8 +5289,8 @@
         "dotenv": "^8.2.0",
         "eventsource": "^1.0.7",
         "express": "^4.17.1",
-        "hbs": "^4.1.1",
-        "ioredis": "^4.19.2",
+        "hbs": "^4.2.0",
+        "ioredis": "^4.27.8",
         "js-yaml": "^3.14.1",
         "lru-cache": "^6.0.0",
         "octokit-auth-probot": "^1.2.2",
@@ -5245,6 +5312,15 @@
             "sprintf-js": "~1.0.2"
           }
         },
+        "hbs": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.2.0.tgz",
+          "integrity": "sha512-dQwHnrfWlTk5PvG9+a45GYpg0VpX47ryKF8dULVd6DtwOE6TEcYQXQ5QM6nyOx/h7v3bvEQbdn19EDAcfUAgZg==",
+          "requires": {
+            "handlebars": "4.7.7",
+            "walk": "2.3.15"
+          }
+        },
         "js-yaml": {
           "version": "3.14.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -5260,6 +5336,14 @@
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "walk": {
+          "version": "2.3.15",
+          "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
+          "integrity": "sha512-4eRTBZljBfIISK1Vnt69Gvr2w/wc3U6Vtrw7qiN5iqYJPH7LElcYh/iU4XWhdCy2dZqv1ToMyYlybDylfG/5Vg==",
+          "requires": {
+            "foreachasync": "^3.0.0"
           }
         }
       }

--- a/packages/release-trigger/package.json
+++ b/packages/release-trigger/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@google-automations/bot-config-utils": "^4.0.0",
     "@google-automations/datastore-lock": "^3.0.0",
-    "gcf-utils": "^11.4.0"
+    "gcf-utils": "^13.2.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",

--- a/packages/release-trigger/src/server.ts
+++ b/packages/release-trigger/src/server.ts
@@ -17,6 +17,7 @@ import appFn from './bot';
 
 const bootstrap = new GCFBootstrapper({
   taskTargetEnvironment: 'run',
+  taskTargetName: 'release-trigger-backend',
 });
 const server = bootstrap.server(appFn);
 const port = process.env.PORT ?? 8080;

--- a/packages/release-trigger/test/bot.ts
+++ b/packages/release-trigger/test/bot.ts
@@ -111,7 +111,7 @@ describe('bot', () => {
         .resolves();
 
       await probot.receive({
-        name: 'release.published',
+        name: 'release',
         payload: payload,
         id: 'abc123',
       });
@@ -172,7 +172,7 @@ describe('bot', () => {
         .resolves();
 
       await probot.receive({
-        name: 'release.published',
+        name: 'release',
         payload: payload,
         id: 'abc123',
       });
@@ -215,7 +215,7 @@ describe('bot', () => {
         .resolves();
 
       await probot.receive({
-        name: 'pull_request.unlabeled',
+        name: 'pull_request',
         payload: payload,
         id: 'abc123',
       });
@@ -247,7 +247,7 @@ describe('bot', () => {
         .resolves();
 
       await probot.receive({
-        name: 'pull_request.unlabeled',
+        name: 'pull_request',
         payload: payload,
         id: 'abc123',
       });
@@ -271,7 +271,7 @@ describe('bot', () => {
         .resolves();
 
       await probot.receive({
-        name: 'pull_request.unlabeled',
+        name: 'pull_request',
         payload: payload,
         id: 'abc123',
       });
@@ -294,7 +294,7 @@ describe('bot', () => {
         .resolves(true);
 
       await probot.receive({
-        name: 'pull_request.labeled',
+        name: 'pull_request',
         payload: payload,
         id: 'abc123',
       });
@@ -314,7 +314,7 @@ describe('bot', () => {
         .resolves(true);
 
       await probot.receive({
-        name: 'pull_request.labeled',
+        name: 'pull_request',
         payload: payload,
         id: 'abc123',
       });

--- a/scripts/publish-cloud-run.sh
+++ b/scripts/publish-cloud-run.sh
@@ -44,10 +44,12 @@ else
   minInstances="0"
 fi
 
-if [ $# -ge 10 ]; then
-  concurrency=${10}
-else
-  concurrency="80"
+if [ -z "${CONCURRENCY}" ]; then
+  if [ $# -ge 10 ]; then
+    CONCURRENCY=${10}
+  else
+    CONCURRENCY="80"
+  fi
 fi
 
 if [ "${project}" == "repo-automation-bots" ]; then
@@ -97,7 +99,7 @@ deployArgs=(
   "--min-instances"
   "${minInstances}"
   "--concurrency"
-  "${concurrency}"
+  "${CONCURRENCY}"
   "--quiet"
 )
 if [ -n "${SERVICE_ACCOUNT}" ]; then


### PR DESCRIPTION
Deploys a separate release-trigger backend that only runs with concurrency of 4. This allows the front-end to handle all the webhooks which require a 10 second response at 80 concurrency. This actual backend work which requires significantly more memory is now throttled at 4 concurrent requests.

Fixes #3105 
Fixes #2744 
