### PR TITLE
deps: update release-please to 13.4.4

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -5716,9 +5716,9 @@
       }
     },
     "release-please": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.4.3.tgz",
-      "integrity": "sha512-NQnyqcVHC0sqV4vheNp+mAZkgpMfaI1tgVL55XsT7+vF0cdaSze2CPcxeLWGEVBPC2RVMMtSk4iIfTukjaxNZw==",
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.4.4.tgz",
+      "integrity": "sha512-ecacm4VTNY/Wx+LdnfQoMGmW8910gKiK/aeYHGvQ49vgfX7eLRH1YU0kqIHk//H+ZG2VPEwNjypp2yeE/+r0Dg==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",
@@ -5780,9 +5780,9 @@
           }
         },
         "type-fest": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.10.0.tgz",
-          "integrity": "sha512-u2yreDMllFI3VCpWt0rKrGs/E2LO0YHBwiiOIj+ilQh9+ALMaa4lNBSdoDvuHN3cbKcYk9L1BXP49x9RT+o/SA=="
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.11.0.tgz",
+          "integrity": "sha512-GwRKR1jZMAQP/hVR929DWB5Z2lwSIM/nNcHEfDj2E0vOMhcYbqFxGKE5JaSzMdzmEtWJiamEn6VwHs/YVXVhEQ=="
         },
         "typescript": {
           "version": "3.9.10",

--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -5716,9 +5716,9 @@
       }
     },
     "release-please": {
-      "version": "13.4.1",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.4.1.tgz",
-      "integrity": "sha512-gi9sWOQRZRLUja5sZC7KDp0DdhplyjlxLztbi4Q0MAqriTs04zg5ijvtthIjmkEBJDF3vhDrd3FFT8JPTQhOYA==",
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.4.3.tgz",
+      "integrity": "sha512-NQnyqcVHC0sqV4vheNp+mAZkgpMfaI1tgVL55XsT7+vF0cdaSze2CPcxeLWGEVBPC2RVMMtSk4iIfTukjaxNZw==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -33,7 +33,7 @@
     "@octokit/webhooks": "^9.20.0",
     "@octokit/rest": "^18.12.0",
     "gcf-utils": "^13.1.0",
-    "release-please": "^13.4.1"
+    "release-please": "^13.4.3"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -33,7 +33,7 @@
     "@octokit/webhooks": "^9.20.0",
     "@octokit/rest": "^18.12.0",
     "gcf-utils": "^13.1.0",
-    "release-please": "^13.4.3"
+    "release-please": "^13.4.4"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",


### PR DESCRIPTION
### Bug Fixes

* Manifest.fromFile no longer ignores manifestFile arg
* multi-component manifest release notes for single component release
* release notes should parse initial version heading
* delegate empty commit handling to strategies
* extra file should include strategy path