### PR TITLE
fix: record pull request created to copy code from googleapis-gen int…

### DIFF
--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -252,6 +252,7 @@ ${copyTagLine}`,
  * @param sourceRepo: the source repository, either a local path or googleapis/googleapis-gen
  * @param sourceRepoCommit: the commit from which to copy code. Empty means the most recent commit.
  * @param destRepo: the destination repository, either a local path or a github path like googleapis/nodejs-vision.
+ * @returns a url to a github issue or pull request.
  */
 export async function copyCodeAndCreatePullRequest(
   sourceRepo: string,

--- a/packages/owl-bot/src/copy-state-store.ts
+++ b/packages/owl-bot/src/copy-state-store.ts
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 /**
- * A state store for the operation of copying files from googleapis-gen
- * into client library reposities.
+ * Records the build id for builds that run the post processor on code that's
+ * been copied from googleapis-gen into the client library repos.
  */
 export interface CopyStateStore {
   /**

--- a/packages/owl-bot/src/copy-state-store.ts
+++ b/packages/owl-bot/src/copy-state-store.ts
@@ -1,0 +1,34 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * A state store for the operation of copying files from googleapis-gen
+ * into client library reposities.
+ */
+export interface CopyStateStore {
+  /**
+   * Records a build id of the post-processor run that was started for
+   * code copied into a client library repository.
+   * @param a unique id for the copy operation.
+   * @param buildId the google cloud build id.
+   */
+  RecordBuildForCopy(copyTag: string, buildId: string): Promise<void>;
+
+  /**
+   * Finds an existing branch for the copy operation.
+   * @param a unique id for the copy operation.
+   * @returns the empty string if none exists.
+   */
+  FindBuildForCopy(copyTag: string): Promise<string | undefined>;
+}

--- a/packages/owl-bot/src/copy-state-store.ts
+++ b/packages/owl-bot/src/copy-state-store.ts
@@ -23,12 +23,12 @@ export interface CopyStateStore {
    * @param a unique id for the copy operation.
    * @param buildId the google cloud build id.
    */
-  RecordBuildForCopy(copyTag: string, buildId: string): Promise<void>;
+  recordBuildForCopy(copyTag: string, buildId: string): Promise<void>;
 
   /**
    * Finds an existing branch for the copy operation.
    * @param a unique id for the copy operation.
    * @returns the empty string if none exists.
    */
-  FindBuildForCopy(copyTag: string): Promise<string | undefined>;
+  findBuildForCopy(copyTag: string): Promise<string | undefined>;
 }

--- a/packages/owl-bot/src/create-pr.ts
+++ b/packages/owl-bot/src/create-pr.ts
@@ -82,6 +82,7 @@ export function insertApiName(prTitle: string, apiName: string): string {
  * Creates a pull request using the title and commit message from the most
  * recent commit.
  * @argument apiName Name of the API to optionally include in the PR title.
+ * @returns an link to the pull request
  */
 export async function createPullRequestFromLastCommit(
   owner: string,
@@ -94,7 +95,7 @@ export async function createPullRequestFromLastCommit(
   prBody = '',
   apiName = '',
   logger = console
-): Promise<void> {
+): Promise<string> {
   const cmd = newCmd(logger);
   const githubRepo = await octokit.repos.get({owner, repo});
 
@@ -132,4 +133,5 @@ export async function createPullRequestFromLastCommit(
       labels,
     });
   }
+  return pull.data.html_url;
 }

--- a/packages/owl-bot/src/database.ts
+++ b/packages/owl-bot/src/database.ts
@@ -221,14 +221,14 @@ export class FirestoreCopyStateStore implements CopyStateStore {
     this.copyBuilds = collectionsPrefix + 'copy-builds';
   }
 
-  async RecordBuildForCopy(copyTag: string, buildId: string): Promise<void> {
+  async recordBuildForCopy(copyTag: string, buildId: string): Promise<void> {
     await this.db
       .collection(this.copyBuilds)
       .doc(encodeId(copyTag))
       .set({buildId});
   }
 
-  async FindBuildForCopy(copyTag: string): Promise<string | undefined> {
+  async findBuildForCopy(copyTag: string): Promise<string | undefined> {
     return (
       await this.db.collection(this.copyBuilds).doc(encodeId(copyTag)).get()
     ).data()?.buildId;

--- a/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
@@ -18,11 +18,13 @@ import tmp from 'tmp';
 import {
   copyCodeAndCreatePullRequest,
   copyExists,
+  copyTagFrom,
   newRepoHistoryCache,
   toLocalRepo,
 } from './copy-code';
 import {getFilesModifiedBySha} from '.';
 import {newCmd} from './cmd';
+import {CopyStateStore} from './copy-state-store';
 
 interface Todo {
   repo: AffectedRepo;
@@ -71,6 +73,7 @@ export async function scanGoogleapisGenAndCreatePullRequests(
   configsStore: ConfigsStore,
   copyExistsSearchDepth: number,
   cloneDepth = 100,
+  copyStateStore?: CopyStateStore,
   logger = console
 ): Promise<number> {
   // Clone the source repo.
@@ -116,6 +119,7 @@ export async function scanGoogleapisGenAndCreatePullRequests(
     logger.info(`affecting ${repos.length} repos.`);
     repos.forEach(repo => logger.info(repo));
     const stackSize = todoStack.length;
+    let copyBuildId: string | undefined;
     for (const repo of repos) {
       octokit = octokit ?? (await octokitFactory.getShortLivedOctokit());
       const repoFullName = repo.repo.toString();
@@ -130,7 +134,16 @@ export async function scanGoogleapisGenAndCreatePullRequests(
           `Ignoring ${repoFullName} because ${commitHash} is too old.`
         );
       } else if (
-        !(await copyExists(
+        (copyBuildId = await copyStateStore?.FindBuildForCopy(
+          copyTagFrom(repo.yamlPath, commitHash)
+        ))
+      ) {
+        logger.info(
+          `Found build ${copyBuildId} for ${repo.yamlPath}:${commitHash}.`
+        );
+      } else if (
+        copyExistsSearchDepth > 0 &&
+        (await copyExists(
           octokit,
           repo,
           commitHash,
@@ -139,6 +152,8 @@ export async function scanGoogleapisGenAndCreatePullRequests(
           logger
         ))
       ) {
+        // copyExists already logged that we found it.
+      } else {
         const todo: Todo = {repo, commitHash};
         logger.info(`Pushing todo onto stack: ${todo}`);
         todoStack.push(todo);
@@ -156,13 +171,17 @@ export async function scanGoogleapisGenAndCreatePullRequests(
 
   // Copy files beginning with the oldest commit hash.
   for (const todo of todoStack.reverse()) {
-    await copyCodeAndCreatePullRequest(
+    const htmlUrl = await copyCodeAndCreatePullRequest(
       sourceDir,
       todo.commitHash,
       todo.repo,
       octokitFactory,
       logger
     );
+    if (copyStateStore) {
+      const copyTag = copyTagFrom(todo.repo.yamlPath, todo.commitHash);
+      copyStateStore.RecordBuildForCopy(copyTag, htmlUrl);
+    }
   }
   return todoStack.length;
 }

--- a/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
@@ -134,7 +134,7 @@ export async function scanGoogleapisGenAndCreatePullRequests(
           `Ignoring ${repoFullName} because ${commitHash} is too old.`
         );
       } else if (
-        (copyBuildId = await copyStateStore?.FindBuildForCopy(
+        (copyBuildId = await copyStateStore?.findBuildForCopy(
           copyTagFrom(repo.yamlPath, commitHash)
         ))
       ) {
@@ -180,7 +180,7 @@ export async function scanGoogleapisGenAndCreatePullRequests(
     );
     if (copyStateStore) {
       const copyTag = copyTagFrom(todo.repo.yamlPath, todo.commitHash);
-      copyStateStore.RecordBuildForCopy(copyTag, htmlUrl);
+      copyStateStore.recordBuildForCopy(copyTag, htmlUrl);
     }
   }
   return todoStack.length;

--- a/packages/owl-bot/system-test/database.ts
+++ b/packages/owl-bot/system-test/database.ts
@@ -14,7 +14,7 @@
 
 import {describe, it, before} from 'mocha';
 import admin from 'firebase-admin';
-import {FirestoreConfigsStore} from '../src/database';
+import {FirestoreConfigsStore, FirestoreCopyStateStore} from '../src/database';
 import {Configs} from '../src/configs-store';
 import {v4 as uuidv4} from 'uuid';
 import * as assert from 'assert';
@@ -40,6 +40,16 @@ describe('database', () => {
       // No connection to firestore.  Not possible to test.
       this.skip();
     }
+  });
+
+  it('stores and retrieves copy state', async () => {
+    const db = admin.firestore();
+    const store = new FirestoreCopyStateStore(db, 'test-' + uuidv4() + '-');
+    const copyTag = uuidv4();
+    const buildId = uuidv4();
+    assert.ok(!(await store.findBuildForCopy(copyTag)));
+    await store.recordBuildForCopy(copyTag, buildId);
+    assert.strictEqual(await store.findBuildForCopy(copyTag), buildId);
   });
 
   it('stores and retrieves configs', async () => {

--- a/packages/owl-bot/test/copy-code.ts
+++ b/packages/owl-bot/test/copy-code.ts
@@ -59,8 +59,7 @@ Copy-Tag: ${copyTag}
       yamlPath: 'some-api/.OwlBot.yaml',
       repo: githubRepoFromOwnerSlashName('googleapis/spell-checker'),
     };
-    assert.strictEqual(
-      true,
+    assert.ok(
       await copyExists(
         octokit as unknown as OctokitType,
         destRepo,
@@ -84,8 +83,7 @@ Copy-Tag: ${copyTag}
       repo: githubRepoFromOwnerSlashName('googleapis/spell-checker'),
     };
     const cache = newRepoHistoryCache();
-    assert.strictEqual(
-      true,
+    assert.ok(
       await copyExists(
         octokit as unknown as OctokitType,
         destRepo,
@@ -96,8 +94,7 @@ Copy-Tag: ${copyTag}
     );
 
     // Confirm its in the cache.
-    assert.strictEqual(
-      true,
+    assert.ok(
       await copyExists(
         (await fakeOctokit()) as unknown as OctokitType,
         destRepo,
@@ -121,8 +118,7 @@ Copy-Tag: ${copyTag}
       yamlPath: 'some-api/.OwlBot.yaml',
       repo: githubRepoFromOwnerSlashName('googleapis/spell-checker'),
     };
-    assert.strictEqual(
-      true,
+    assert.ok(
       await copyExists(
         octokit as unknown as OctokitType,
         destRepo,
@@ -151,14 +147,13 @@ Copy-Tag: ${copyTag}
       yamlPath: '.github/.OwlBot.yaml',
       repo: githubRepoFromOwnerSlashName('googleapis/spell-checker'),
     };
-    assert.strictEqual(
-      false,
-      await copyExists(
+    assert.ok(
+      !(await copyExists(
         octokit as unknown as OctokitType,
         destRepo,
         'abc123',
         1000
-      )
+      ))
     );
   });
 
@@ -181,14 +176,13 @@ Copy-Tag: ${copyTag}
       yamlPath: 'some-api/.OwlBot.yaml',
       repo: githubRepoFromOwnerSlashName('googleapis/spell-checker'),
     };
-    assert.strictEqual(
-      false,
-      await copyExists(
+    assert.ok(
+      !(await copyExists(
         octokit as unknown as OctokitType,
         destRepo,
         'def456',
         1000
-      )
+      ))
     );
   });
 
@@ -203,8 +197,7 @@ Source-Link: https://github.com/googleapis/googleapis/abc123
       yamlPath: '.github/.OwlBot.yaml',
       repo: githubRepoFromOwnerSlashName('googleapis/spell-checker'),
     };
-    assert.strictEqual(
-      true,
+    assert.ok(
       await copyExists(
         octokit as unknown as OctokitType,
         destRepo,

--- a/packages/owl-bot/test/fake-octokit.ts
+++ b/packages/owl-bot/test/fake-octokit.ts
@@ -56,9 +56,13 @@ export class FakePulls {
   }
 
   create(pull: any) {
-    this.pulls.push(pull);
+    const myPull = {
+      html_url: `http://github.com/fake/pulls/${this.pulls.length + 1}`,
+      ...pull,
+    };
+    this.pulls.push(myPull);
     return Promise.resolve({
-      data: {html_url: `http://github.com/fake/pulls/${this.pulls.length}`},
+      data: myPull,
     });
   }
 }

--- a/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
@@ -42,11 +42,11 @@ const cmd = newCmd();
 
 class FakeCopyStateStore implements CopyStateStore {
   readonly store: Map<string, string> = new Map();
-  RecordBuildForCopy(copyTag: string, buildId: string): Promise<void> {
+  recordBuildForCopy(copyTag: string, buildId: string): Promise<void> {
     this.store.set(copyTag, buildId);
     return Promise.resolve();
   }
-  FindBuildForCopy(copyTag: string): Promise<string | undefined> {
+  findBuildForCopy(copyTag: string): Promise<string | undefined> {
     return Promise.resolve(this.store.get(copyTag));
   }
 }

--- a/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
@@ -31,6 +31,7 @@ import {
   newFakeOctokit,
   newFakeOctokitFactory,
 } from './fake-octokit';
+import {CopyStateStore} from '../src/copy-state-store';
 
 // Use anys to mock parts of the octokit API.
 // We'll still see compile time errors if in the src/ code if there's a type error
@@ -38,6 +39,17 @@ import {
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 const cmd = newCmd();
+
+class FakeCopyStateStore implements CopyStateStore {
+  readonly store: Map<string, string> = new Map();
+  RecordBuildForCopy(copyTag: string, buildId: string): Promise<void> {
+    this.store.set(copyTag, buildId);
+    return Promise.resolve();
+  }
+  FindBuildForCopy(copyTag: string): Promise<string | undefined> {
+    return Promise.resolve(this.store.get(copyTag));
+  }
+}
 
 function factory(octokit: any): OctokitFactory {
   return {
@@ -137,17 +149,52 @@ describe('scanGoogleapisGenAndCreatePullRequests', function () {
     );
   });
 
+  it('skips pull requests that were already created', async () => {
+    const [, configsStore] = makeDestRepoAndConfigsStore(bYaml);
+    const copyTag = cc.copyTagFrom('.github/.OwlBot.yaml', abcCommits[1]);
+    const pulls = new FakePulls();
+    pulls.create({body: `Copy-Tag: ${copyTag}`});
+    const issues = new FakeIssues();
+    const octokit = newFakeOctokit(pulls, issues);
+    const prCount = await scanGoogleapisGenAndCreatePullRequests(
+      abcRepo,
+      factory(octokit),
+      configsStore,
+      1000
+    );
+    assert.strictEqual(prCount, 0);
+  });
+
+  it("doesn't skip pull requests when search depth is zero", async () => {
+    const [, configsStore] = makeDestRepoAndConfigsStore(bYaml);
+    const copyTag = cc.copyTagFrom('.github/.OwlBot.yaml', abcCommits[1]);
+    const pulls = new FakePulls();
+    pulls.create({body: `Copy-Tag: ${copyTag}`});
+    const issues = new FakeIssues();
+    const octokit = newFakeOctokit(pulls, issues);
+    const prCount = await scanGoogleapisGenAndCreatePullRequests(
+      abcRepo,
+      factory(octokit),
+      configsStore,
+      0
+    );
+    assert.strictEqual(prCount, 1);
+  });
+
   it('copies files and creates a pull request', async () => {
     const [destRepo, configsStore] = makeDestRepoAndConfigsStore(bYaml);
 
     const pulls = new FakePulls();
     const issues = new FakeIssues();
     const octokit = newFakeOctokit(pulls, issues);
+    const copyStateStore = new FakeCopyStateStore();
     await scanGoogleapisGenAndCreatePullRequests(
       abcRepo,
       factory(octokit),
       configsStore,
-      1000
+      1000,
+      undefined,
+      copyStateStore
     );
 
     // Confirm it created one pull request.
@@ -181,6 +228,21 @@ Copy-Tag: ${copyTag}`
     // But of course the main branch doesn't have it until the PR is merged.
     cmd('git checkout main', {cwd: destDir});
     assert.ok(!cc.stat(bpath));
+
+    // Confirm the PR was recorded in firestore.
+    assert.ok(copyStateStore.store.get(copyTag));
+
+    // Because the PR is recorded in firestore, a second call should skip
+    // creating a new one.
+    const prCount = await scanGoogleapisGenAndCreatePullRequests(
+      abcRepo,
+      factory(octokit),
+      configsStore,
+      1000,
+      undefined,
+      copyStateStore
+    );
+    assert.strictEqual(prCount, 0);
   });
 
   it('creates 3 pull requests for 3 matching commits', async () => {

--- a/packages/owl-bot/test/update-lock.ts
+++ b/packages/owl-bot/test/update-lock.ts
@@ -48,7 +48,7 @@ describe('maybeCreatePullRequestForLockUpdate', () => {
     const calls: any[][] = [];
     function recordCall(...args: any[]) {
       calls.push(args);
-      return Promise.resolve();
+      return Promise.resolve(`result-${calls.length}`);
     }
 
     // Mock the octokit factory:


### PR DESCRIPTION
…o client library repositories

The first step towards fixing #2834.

All the new code paths are controlled by flags, so nothing will change when this PR is merged.

Next steps:
1. Switch on flag --track-builds-in-firestore.
2. Wait a couple days.
3. Switch flag --search-depth to zero.
4. Remove all the code that searched through git history.
5. Write code to create cloud builds rather than create pull requests directly.
