### PR TITLE
fix: flip flag to create PRs for failed lock updates

### DIFF
--- a/packages/owl-bot/src/bin/commands/scan-and-retry-failed-lock-updates.ts
+++ b/packages/owl-bot/src/bin/commands/scan-and-retry-failed-lock-updates.ts
@@ -46,6 +46,7 @@ export const scanAndRetryFailedLockUpdatesCommand: yargs.CommandModule<
           'Trigger this build trigger when all the regular builds failed.',
         type: 'string',
         demand: false,
+        default: '7887fb1c-55c1-4693-8fca-de0b9e503ea1',
       })
       .option('project-id', {
         describe: 'The Google Cloud project id.',


### PR DESCRIPTION
Follow up to https://github.com/googleapis/repo-automation-bots/pull/3117

Fixes https://github.com/googleapis/repo-automation-bots/issues/2709
