### PR TITLE
chore: flip flag to turn off searching for duplicate pull requests in …

### DIFF
--- a/packages/owl-bot/src/bin/commands/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/bin/commands/scan-googleapis-gen-and-create-pull-requests.ts
@@ -74,7 +74,7 @@ export const scanGoogleapisGenAndCreatePullRequestsCommand: yargs.CommandModule<
           'When searching pull request and issue histories to see if a pull' +
           ' request for the commit was already created, search this deep',
         type: 'number',
-        default: 1000,
+        default: 0,
       })
       .option('track-builds-in-firestore', {
         describe:


### PR DESCRIPTION
…git history

instead, completely rely on firestore records flipped on by #3133
