### PR TITLE
fix: allow release-please to handle default package name

### DIFF
--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -193,7 +193,6 @@ async function buildManifest(
     : configuration.manifest
     ? 'simple'
     : releaseTypeFromRepoLanguage(repoLanguage);
-  const packageName = configuration.packageName || github.repository.repo;
 
   const releaserConfig: ReleaserConfig = {
     releaseType,
@@ -202,7 +201,7 @@ async function buildManifest(
     bumpPatchForMinorPreMajor: configuration.bumpPatchForMinorPreMajor,
     draft: configuration.draft,
     draftPullRequest: configuration.draftPullRequest,
-    packageName,
+    packageName: configuration.packageName,
     includeComponentInTag: !!configuration.monorepoTags,
     pullRequestTitlePattern: configuration.pullRequestTitlePattern,
     // changelogSections: configuration.changelogSections,

--- a/packages/release-please/test/release-please.ts
+++ b/packages/release-please/test/release-please.ts
@@ -199,9 +199,7 @@ describe('ReleasePleaseBot', () => {
       });
 
       it('should allow release-please to configure the default package-name', async () => {
-        getConfigStub.resolves(
-          loadConfig('ruby_release.yml')
-        );
+        getConfigStub.resolves(loadConfig('ruby_release.yml'));
         await probot.receive(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           {name: 'push', payload: payload as any, id: 'abc123'}

--- a/packages/release-please/test/release-please.ts
+++ b/packages/release-please/test/release-please.ts
@@ -198,6 +198,30 @@ describe('ReleasePleaseBot', () => {
         );
       });
 
+      it('should allow release-please to configure the default package-name', async () => {
+        getConfigStub.resolves(
+          loadConfig('ruby_release.yml')
+        );
+        await probot.receive(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          {name: 'push', payload: payload as any, id: 'abc123'}
+        );
+
+        sinon.assert.calledOnce(createPullRequestsStub);
+        sinon.assert.notCalled(createReleasesStub);
+        sinon.assert.calledOnceWithExactly(
+          fromConfigStub,
+          sinon.match.instanceOf(GitHub),
+          'master',
+          sinon.match({
+            releaseType: 'ruby',
+            packageName: undefined,
+          }),
+          sinon.match.any,
+          undefined
+        );
+      });
+
       it('should allow overriding the package-name from configuration', async () => {
         getConfigStub.resolves(
           loadConfig('ruby_release_alternate_pkg_name.yml')


### PR DESCRIPTION
In v13, release-please is more capable of detecting the default package name. This GitHub app does not have enough knowledge to accurately determine the default package name.
