### PR TITLE
fix: run-on pull request titles

### DIFF
--- a/packages/owl-bot/src/create-pr.ts
+++ b/packages/owl-bot/src/create-pr.ts
@@ -19,36 +19,37 @@ import {OctokitType} from './octokit-util';
 export const MAX_TITLE_LENGTH = 255;
 export const MAX_BODY_LENGTH = 64 * 1024 - 1;
 
+export const REGENERATE_CHECKBOX_TEXT =
+  '- [x] Regenerate this pull request now.';
+export const EMPTY_REGENERATE_CHECKBOX_TEXT = REGENERATE_CHECKBOX_TEXT.replace(
+  '[x]',
+  '[ ]'
+);
+
 /***
  * Github will reject the pull request if the title is longer than 255
  * characters.  This function will move characters from the title to the body
  * if the title is too long.
+ *
+ * @param rawBody the subject and body of the commit message.
  */
 export function resplit(
-  title: string,
-  body: string
+  rawBody: string,
+  withRegenerateCheckbox: WithRegenerateCheckbox
 ): {title: string; body: string} {
+  const regexp = /([^\r\n]*)([\r\n]*)((.|\r|\n)*)/;
+  const match = regexp.exec(rawBody)!;
+  let title = match[1];
+  let body = match[3];
   if (title.length > MAX_TITLE_LENGTH) {
     const splitIndex = MAX_TITLE_LENGTH - 3; // 3 dots.
-    body = '...' + title.substring(splitIndex) + '\n\n' + body;
-    title = title.substring(0, splitIndex) + '...';
+    title = rawBody.substring(0, splitIndex) + '...';
+    body = rawBody.substring(splitIndex);
+  }
+  if (withRegenerateCheckbox === WithRegenerateCheckbox.Yes) {
+    body = EMPTY_REGENERATE_CHECKBOX_TEXT + '\n\n' + body;
   }
   return {title, body: body.substring(0, MAX_BODY_LENGTH)};
-}
-
-/**
- * Returns the body of the most recent commit message in a git directory.
- */
-export function getLastCommitBody(
-  localRepoDir: string,
-  logger = console
-): string {
-  const cmd = newCmd(logger);
-  return cmd('git log -1 --format=%b', {
-    cwd: localRepoDir,
-  })
-    .toString('utf8')
-    .trim();
 }
 
 // Exported for testing only.
@@ -78,9 +79,25 @@ export function insertApiName(prTitle: string, apiName: string): string {
   }
 }
 
+/**
+ * Should createPullRequestFromLastCommit() force push to github?
+ *
+ * More type safe and readable than a boolean.
+ */
 export enum Force {
   Yes = '-f',
   No = '',
+}
+
+/**
+ * Should createPullRequestFromLastCommit() create a pull request body with
+ * a "[x] Regenerate this pull request now" checkbox?
+ *
+ * More type safe and readable than a boolean.
+ */
+export enum WithRegenerateCheckbox {
+  Yes = 'yes',
+  No = 'no',
 }
 
 /**
@@ -97,7 +114,7 @@ export async function createPullRequestFromLastCommit(
   pushUrl: string,
   labels: string[],
   octokit: OctokitType,
-  prBody = '',
+  withRegenerateCheckbox = WithRegenerateCheckbox.No,
   apiName = '',
   forceFlag: Force = Force.No,
   logger = console
@@ -109,16 +126,15 @@ export async function createPullRequestFromLastCommit(
   cmd(`git push ${forceFlag} origin ${branch}`, {cwd: localRepoDir});
 
   // Use the commit's subject and body as the pull request's title and body.
-  const commitSubject: string = cmd('git log -1 --format=%s', {
+  const rawBody: string = cmd('git log -1 --format=%B', {
     cwd: localRepoDir,
   })
     .toString('utf8')
     .trim();
-  const commitBody = prBody ?? getLastCommitBody(localRepoDir, logger);
 
   const {title, body} = resplit(
-    insertApiName(commitSubject, apiName),
-    commitBody
+    insertApiName(rawBody, apiName),
+    withRegenerateCheckbox
   );
 
   // Create a pull request.

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -31,8 +31,8 @@ import {
 import {OWLBOT_RUN_LABEL, OWL_BOT_IGNORE, OWL_BOT_LABELS} from './labels';
 import {OwlBotLock} from './config-files';
 import {octokitFactoryFrom} from './octokit-util';
-import {REGENERATE_CHECKBOX_TEXT} from './copy-code';
 import {githubRepo} from './github-repo';
+import {REGENERATE_CHECKBOX_TEXT} from './create-pr';
 
 // We use lower case organization names here, so we need to always
 // check against lower cased owner.

--- a/packages/owl-bot/src/update-lock.ts
+++ b/packages/owl-bot/src/update-lock.ts
@@ -70,7 +70,7 @@ export async function createPullRequestForLockUpdate(
     githubRepo.getCloneUrl(token),
     [core.OWL_BOT_LOCK_UPDATE],
     octokit,
-    '',
+    createPr.WithRegenerateCheckbox.No,
     '', // No API name because this PR was not triggered by an API change.
     createPr.Force.No,
     logger

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -31,7 +31,7 @@ import {Configs} from '../src/configs-store';
 import {OWL_BOT_LOCK_PATH} from '../src/config-files';
 import * as labelUtilsModule from '@google-automations/label-utils';
 import {FirestoreConfigsStore} from '../src/database';
-import {REGENERATE_CHECKBOX_TEXT} from '../src/copy-code';
+import {REGENERATE_CHECKBOX_TEXT} from '../src/create-pr';
 
 nock.disableNetConnect();
 const sandbox = sinon.createSandbox();

--- a/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
@@ -34,6 +34,7 @@ import {
 import {CopyStateStore} from '../src/copy-state-store';
 import tmp from 'tmp';
 import {copyTagFrom} from '../src/copy-code';
+import {EMPTY_REGENERATE_CHECKBOX_TEXT} from '../src/create-pr';
 
 // Use anys to mock parts of the octokit API.
 // We'll still see compile time errors if in the src/ code if there's a type error
@@ -487,7 +488,7 @@ Copy-Tag: ${copyTagFrom('.github/.OwlBot.yaml', abcCommits[2])}`;
     );
 
     // Confirm commit messages were merged and pushed to pull-branch.
-    const gitLog = cmd('git log -1 --format=%s%n%n%b pull-branch', {
+    const gitLog = cmd('git log -1 --format=%B pull-branch', {
       cwd: destDir,
     }).toString('utf-8');
     assert.strictEqual(gitLog, `${commitMessage2}\n\n${commitMessage1}\n\n`);
@@ -495,7 +496,7 @@ Copy-Tag: ${copyTagFrom('.github/.OwlBot.yaml', abcCommits[2])}`;
     // Confirm the pull request body was updated.
     assert.deepStrictEqual(pulls.updates, [
       {
-        body: `${cc.EMPTY_REGENERATE_CHECKBOX_TEXT}\n\n${commitMessage2}\n\n${commitMessage1}\n\n`,
+        body: `${EMPTY_REGENERATE_CHECKBOX_TEXT}\n\n${commitMessage2}\n\n${commitMessage1}\n\n`,
         owner: 'googleapis',
         pull_number: 1,
         repo: 'nodejs-spell-check',

--- a/packages/owl-bot/test/update-lock.ts
+++ b/packages/owl-bot/test/update-lock.ts
@@ -24,7 +24,7 @@ import {
 } from '../src/update-lock';
 import {OctokitFactory, OctokitType} from '../src/octokit-util';
 import {githubRepoFromOwnerSlashName} from '../src/github-repo';
-import {Force} from '../src/create-pr';
+import {Force, WithRegenerateCheckbox} from '../src/create-pr';
 
 // Use anys to mock parts of the octokit API.
 // We'll still see compile time errors if in the src/ code if there's a type error
@@ -77,7 +77,7 @@ describe('maybeCreatePullRequestForLockUpdate', () => {
         'https://x-access-token:b4@github.com/googleapis/nodejs-speech.git',
         ['owl-bot-update-lock'],
         {fake: true},
-        '',
+        WithRegenerateCheckbox.No,
         '',
         Force.No,
         console,


### PR DESCRIPTION
The fundamental problem was that `git log --format=%s%n%n%b` considers multiple lines at the top of a commit message to be the "subject".  It expects the subject and body to be separated by a blank line.

Instead, use `git log --format=%B` which gives one raw text of the combined subject and body.  Then, owl-bot takes the first line.

Fixes #3039

