### PR TITLE
feat: flip flag on to enable the regenerate checkbox to correctly han…

### DIFF
--- a/packages/owl-bot/src/bin/commands/copy-code-into-pull-request.ts
+++ b/packages/owl-bot/src/bin/commands/copy-code-into-pull-request.ts
@@ -75,7 +75,7 @@ export const copyCodeIntoPullRequestCommand: yargs.CommandModule<{}, Args> = {
           'Use an entirely new code path that works with multiple commits in a single pull request.',
         type: 'boolean',
         demand: false,
-        default: false,
+        default: true,
       });
   },
   async handler(argv) {


### PR DESCRIPTION
…dle pull requests with multiple commits

No pull requests with multiple commits exist yet.  This new code path should
behave the same as the current code path for regenerating pull requests
with only one commit.  This flag must be switched on before switching on
the flag to actually generate pull requests with multiple commits.
