### PR TITLE
fix: cherry-pick PR title should match commit message

### DIFF
--- a/packages/cherry-pick-bot/__snapshots__/cherry-pick.js
+++ b/packages/cherry-pick-bot/__snapshots__/cherry-pick.js
@@ -1,0 +1,79 @@
+exports['cherryPickCommits should cherry pick a single commit 1'] = {
+  ref: 'refs/heads/temp-target-branch',
+  sha: 'devbranchsha',
+};
+
+exports['cherryPickCommits should cherry pick a single commit 2'] = {
+  author: {
+    name: 'author-name',
+    email: 'author@email.com',
+  },
+  committer: {
+    name: 'committer-name',
+    email: 'committer@email.com',
+  },
+  message: 'sibling of abc123',
+  parents: ['parentsha'],
+  tree: 'treesha',
+};
+
+exports['cherryPickCommits should cherry pick a single commit 3'] = {
+  force: true,
+  sha: 'newcommitsha',
+};
+
+exports['cherryPickCommits should cherry pick a single commit 4'] = {
+  base: 'temp-target-branch',
+  commit_message: 'Merge abc123 into temp-target-branch',
+  head: 'abc123',
+};
+
+exports['cherryPickCommits should cherry pick a single commit 5'] = {
+  author: {
+    name: 'author-name',
+    email: 'author@email.com',
+  },
+  committer: {
+    name: 'committer-name',
+    email: 'committer@email.com',
+  },
+  message: 'commit message for abc123',
+  parents: ['devbranchsha'],
+  tree: 'mergetreesha',
+};
+
+exports['cherryPickCommits should cherry pick a single commit 6'] = {
+  force: true,
+  sha: 'newcommitsha2',
+};
+
+exports['cherryPickCommits should cherry pick a single commit 7'] = {
+  force: true,
+  sha: 'newcommitsha2',
+};
+
+exports['cherryPickAsPullRequest opens a pull request for single commit 1'] = {
+  ref: 'refs/heads/cherry-pick-e99a18-dev',
+  sha: 'basesha',
+};
+
+exports['cherryPickAsPullRequest opens a pull request for single commit 2'] = {
+  head: 'cherry-pick-e99a18-dev',
+  base: 'dev',
+  title: 'commit message for abc123',
+  body: '\n\nCherry-picked commit message for abc123',
+};
+
+exports['cherryPickAsPullRequest opens a pull request for multiple commits 1'] =
+  {
+    ref: 'refs/heads/cherry-pick-e48234-dev',
+    sha: 'basesha',
+  };
+
+exports['cherryPickAsPullRequest opens a pull request for multiple commits 2'] =
+  {
+    head: 'cherry-pick-e48234-dev',
+    base: 'dev',
+    title: 'commit message for abc123',
+    body: 'commit message for def234\n\nCherry-picked commit message for abc123, commit message for def234',
+  };

--- a/packages/cherry-pick-bot/package-lock.json
+++ b/packages/cherry-pick-bot/package-lock.json
@@ -30,6 +30,16 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@bahmutov/data-driven": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bahmutov/data-driven/-/data-driven-1.0.0.tgz",
+      "integrity": "sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==",
+      "dev": true,
+      "requires": {
+        "check-more-types": "2.24.0",
+        "lazy-ass": "1.6.0"
+      }
+    },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -1303,6 +1313,12 @@
         "picomatch": "^2.0.4"
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1706,6 +1722,12 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "dev": true
+    },
     "chokidar": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
@@ -1806,6 +1828,12 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+    },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -2027,6 +2055,24 @@
         "path-type": "^4.0.0"
       }
     },
+    "disparity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/disparity/-/disparity-3.0.0.tgz",
+      "integrity": "sha512-n94Rzbv2ambRaFzrnBf34IEiyOdIci7maRpMkoQWB6xFYGA7Nbs0Z5YQzMfTeyQeelv23nayqOcssBoc6rKrgw==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "diff": "^4.0.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2132,6 +2178,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-quotes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-quotes/-/escape-quotes-1.0.2.tgz",
+      "integrity": "sha1-tIltSmz4LdWzP0m3E0CMY4D2zZc=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2716,6 +2771,12 @@
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
+    "folktale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/folktale/-/folktale-2.3.2.tgz",
+      "integrity": "sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ==",
+      "dev": true
+    },
     "foreachasync": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
@@ -3170,10 +3231,33 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-only": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/has-only/-/has-only-1.1.1.tgz",
+      "integrity": "sha512-3GuFy9rDw0xvovCHb4SOKiRImbZ+a8boFBUyGNRPVd2mRyQOzYdau5G9nodUXC1ZKYN59hrHFkW1lgBQscYfTg==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -3571,6 +3655,12 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "its-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/its-name/-/its-name-1.0.0.tgz",
+      "integrity": "sha1-IGXxiD7LVoxl9xEt2/EjQB+uSvA=",
+      "dev": true
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
@@ -3594,6 +3684,12 @@
       "requires": {
         "argparse": "^2.0.1"
       }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-bigint": {
       "version": "1.0.0",
@@ -3735,6 +3831,12 @@
       "requires": {
         "package-json": "^6.3.0"
       }
+    },
+    "lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "dev": true
     },
     "leven": {
       "version": "2.1.0",
@@ -4074,6 +4176,12 @@
           "dev": true
         }
       }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
     },
     "mocha": {
       "version": "8.4.0",
@@ -4419,6 +4527,12 @@
         "path-key": "^3.0.0"
       }
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "object-hash": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
@@ -4696,6 +4810,12 @@
         "load-json-file": "^5.2.0"
       }
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4910,6 +5030,18 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
+    "quote": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
+      "integrity": "sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE=",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
       "dev": true
     },
     "randombytes": {
@@ -5444,6 +5576,109 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
       "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
+    },
+    "snap-shot-compare": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/snap-shot-compare/-/snap-shot-compare-3.0.0.tgz",
+      "integrity": "sha512-bdwNOAGuKwPU+qsn0ASxTv+QfkXU+3VmkcDOkt965tes+JQQc8d6SfoLiEiRVhCey4v+ip2IjNUSbZm5nnkI9g==",
+      "dev": true,
+      "requires": {
+        "check-more-types": "2.24.0",
+        "debug": "4.1.1",
+        "disparity": "3.0.0",
+        "folktale": "2.3.2",
+        "lazy-ass": "1.6.0",
+        "strip-ansi": "5.2.0",
+        "variable-diff": "1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "snap-shot-core": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/snap-shot-core/-/snap-shot-core-10.2.4.tgz",
+      "integrity": "sha512-A7tkcfmvnRKge4VzFLAWA4UYMkvFY4TZKyL+D6hnHjI3HJ4pTepjG5DfR2ACeDKMzCSTQ5EwR2iOotI+Z37zsg==",
+      "dev": true,
+      "requires": {
+        "arg": "4.1.3",
+        "check-more-types": "2.24.0",
+        "common-tags": "1.8.0",
+        "debug": "4.3.1",
+        "escape-quotes": "1.0.2",
+        "folktale": "2.3.2",
+        "is-ci": "2.0.0",
+        "jsesc": "2.5.2",
+        "lazy-ass": "1.6.0",
+        "mkdirp": "1.0.4",
+        "pluralize": "8.0.0",
+        "quote": "0.4.0",
+        "ramda": "0.27.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
+    "snap-shot-it": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/snap-shot-it/-/snap-shot-it-7.9.6.tgz",
+      "integrity": "sha512-t/ADZfQ8EUk4J76S5cmynye7qg1ecUFqQfANiOMNy0sFmYUaqfx9K/AWwpdcpr3vFsDptM+zSuTtKD0A1EOLqA==",
+      "dev": true,
+      "requires": {
+        "@bahmutov/data-driven": "1.0.0",
+        "check-more-types": "2.24.0",
+        "common-tags": "1.8.0",
+        "debug": "4.3.1",
+        "has-only": "1.1.1",
+        "its-name": "1.0.0",
+        "lazy-ass": "1.6.0",
+        "pluralize": "8.0.0",
+        "ramda": "0.27.1",
+        "snap-shot-compare": "3.0.0",
+        "snap-shot-core": "10.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
     },
     "sonic-boom": {
       "version": "1.4.1",
@@ -6000,6 +6235,58 @@
       "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
       "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==",
       "dev": true
+    },
+    "variable-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/variable-diff/-/variable-diff-1.1.0.tgz",
+      "integrity": "sha1-0r1cZtt2wTh52W5qMG7cmJ35eNo=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "object-assign": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
     },
     "vary": {
       "version": "1.1.2",

--- a/packages/cherry-pick-bot/package.json
+++ b/packages/cherry-pick-bot/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@google-automations/bot-config-utils": "^4.0.0",
+    "@octokit/rest": "^18.12.0",
     "gcf-utils": "^13.1.0",
     "yargs": "^17.3.1"
   },
@@ -44,6 +45,7 @@
     "nock": "^13.0.0",
     "sinon": "^12.0.1",
     "smee-client": "^1.1.0",
+    "snap-shot-it": "^7.0.0",
     "typescript": "~4.4.3"
   },
   "engines": {

--- a/packages/cherry-pick-bot/test/cherry-pick.ts
+++ b/packages/cherry-pick-bot/test/cherry-pick.ts
@@ -15,9 +15,19 @@
 import nock from 'nock';
 import {describe, it} from 'mocha';
 import * as assert from 'assert';
-import {parseCherryPickComment} from '../src/cherry-pick';
+import snapshot from 'snap-shot-it';
+import {Octokit} from '@octokit/rest';
+import {
+  parseCherryPickComment,
+  cherryPickAsPullRequest,
+  cherryPickCommits,
+} from '../src/cherry-pick';
+import * as CherryPickModule from '../src/cherry-pick';
+import sinon from 'sinon';
 
 nock.disableNetConnect();
+
+const sandbox = sinon.createSandbox();
 
 describe('parseCherryPickComment', () => {
   it('parses a command comment', () => {
@@ -31,6 +41,190 @@ describe('parseCherryPickComment', () => {
   });
 });
 
-describe('cherryPick', () => {});
+describe('cherryPickCommits', () => {
+  let octokit: Octokit;
 
-describe('cherryPickAsPullRequest', () => {});
+  beforeEach(() => {
+    octokit = new Octokit({
+      auth: 'fakeToken',
+    });
+  });
+
+  it('should cherry pick a single commit', async () => {
+    const req = nock('https://api.github.com')
+      .get('/repos/testOwner/testRepo/git/ref/heads%2Ftarget-branch')
+      .reply(200, {object: {sha: 'devbranchsha'}})
+      .post('/repos/testOwner/testRepo/git/refs', body => {
+        snapshot(body);
+        return true;
+      })
+      .reply(200)
+      .get('/repos/testOwner/testRepo/git/commits/devbranchsha')
+      .reply(200, {
+        tree: {
+          sha: 'treesha',
+        },
+      })
+      .get('/repos/testOwner/testRepo/git/commits/abc123')
+      .reply(200, {
+        message: 'commit message for abc123',
+        author: {name: 'author-name', email: 'author@email.com'},
+        committer: {name: 'committer-name', email: 'committer@email.com'},
+        parents: [{sha: 'parentsha'}],
+      })
+      .post('/repos/testOwner/testRepo/git/commits', body => {
+        snapshot(body);
+        return true;
+      })
+      .reply(200, {sha: 'newcommitsha'})
+      .patch(
+        '/repos/testOwner/testRepo/git/refs/heads%2Ftemp-target-branch',
+        body => {
+          snapshot(body);
+          return true;
+        }
+      )
+      .reply(200)
+      .post('/repos/testOwner/testRepo/merges', body => {
+        snapshot(body);
+        return true;
+      })
+      .reply(200, {commit: {tree: {sha: 'mergetreesha'}}})
+      .post('/repos/testOwner/testRepo/git/commits', body => {
+        snapshot(body);
+        return true;
+      })
+      .reply(200, {sha: 'newcommitsha2'})
+      .patch(
+        '/repos/testOwner/testRepo/git/refs/heads%2Ftemp-target-branch',
+        body => {
+          snapshot(body);
+          return true;
+        }
+      )
+      .reply(200)
+      .patch(
+        '/repos/testOwner/testRepo/git/refs/heads%2Ftarget-branch',
+        body => {
+          snapshot(body);
+          return true;
+        }
+      )
+      .reply(200)
+      .delete('/repos/testOwner/testRepo/git/refs/heads%2Ftemp-target-branch')
+      .reply(200);
+
+    const commits = ['abc123'];
+    const newCommits = await cherryPickCommits(
+      octokit,
+      'testOwner',
+      'testRepo',
+      commits,
+      'target-branch'
+    );
+    assert.strictEqual(newCommits.length, 1);
+    assert.strictEqual(newCommits[0].message, 'commit message for abc123');
+    assert.strictEqual(newCommits[0].sha, 'newcommitsha2');
+    req.done();
+  });
+});
+
+describe('cherryPickAsPullRequest', () => {
+  let octokit: Octokit;
+
+  beforeEach(() => {
+    octokit = new Octokit({
+      auth: 'fakeToken',
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('opens a pull request for single commit', async () => {
+    const req = nock('https://api.github.com')
+      .get('/repos/testOwner/testRepo/branches/dev')
+      .reply(200, {commit: {sha: 'basesha'}})
+      .post('/repos/testOwner/testRepo/git/refs', body => {
+        snapshot(body);
+        return true;
+      })
+      .reply(200)
+      .post('/repos/testOwner/testRepo/pulls', body => {
+        snapshot(body);
+        return true;
+      })
+      .reply(200, {
+        number: 1234,
+        html_url: 'https://github.com/testOwner/testRepo/pull/1234',
+        title: 'title from API',
+        body: 'body from API',
+      });
+
+    sandbox
+      .stub(CherryPickModule, 'cherryPickCommits')
+      .resolves([{message: 'commit message for abc123', sha: 'abc123'}]);
+    const commits = ['abc123'];
+    const pullRequest = await cherryPickAsPullRequest(
+      octokit,
+      'testOwner',
+      'testRepo',
+      commits,
+      'dev'
+    );
+
+    assert.strictEqual(pullRequest.number, 1234);
+    assert.strictEqual(
+      pullRequest.html_url,
+      'https://github.com/testOwner/testRepo/pull/1234'
+    );
+    assert.strictEqual(pullRequest.title, 'title from API');
+    assert.strictEqual(pullRequest.body, 'body from API');
+    req.done();
+  });
+
+  it('opens a pull request for multiple commits', async () => {
+    const req = nock('https://api.github.com')
+      .get('/repos/testOwner/testRepo/branches/dev')
+      .reply(200, {commit: {sha: 'basesha'}})
+      .post('/repos/testOwner/testRepo/git/refs', body => {
+        snapshot(body);
+        return true;
+      })
+      .reply(200)
+      .post('/repos/testOwner/testRepo/pulls', body => {
+        snapshot(body);
+        return true;
+      })
+      .reply(200, {
+        number: 1234,
+        html_url: 'https://github.com/testOwner/testRepo/pull/1234',
+        title: 'title from API',
+        body: 'body from API',
+      });
+
+    sandbox.stub(CherryPickModule, 'cherryPickCommits').resolves([
+      {message: 'commit message for abc123', sha: 'abc123'},
+      {message: 'commit message for def234', sha: 'def234'},
+    ]);
+
+    const commits = ['abc123', 'def234'];
+    const pullRequest = await cherryPickAsPullRequest(
+      octokit,
+      'testOwner',
+      'testRepo',
+      commits,
+      'dev'
+    );
+
+    assert.strictEqual(pullRequest.number, 1234);
+    assert.strictEqual(
+      pullRequest.html_url,
+      'https://github.com/testOwner/testRepo/pull/1234'
+    );
+    assert.strictEqual(pullRequest.title, 'title from API');
+    assert.strictEqual(pullRequest.body, 'body from API');
+    req.done();
+  });
+});


### PR DESCRIPTION
Currently, the cherry-picked PR title is something like `chore: cherry-pick <SHA> to <branch>`. If this is auto-merged or squash merged, the commit message will be incorrect.

