### PR TITLE
build: fix team config in blunderbuss

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -59,4 +59,4 @@ assign_prs_by:
     - SurferJeffAtGoogle
 
 assign_prs:
-  - '@googleapis/github-automation'
+  - googleapis/github-automation


### PR DESCRIPTION
team should not include `@`
