### PR TITLE
fix(conventional-commit-lint): check if automerge is enabled before using commit message vs title message

### DIFF
--- a/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
+++ b/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
@@ -1,3 +1,9 @@
+exports['ConventionalCommitLint PR With Multiple Commits has a valid title, invalid commit, automerge enabled 1'] = {
+  "name": "conventionalcommits.org",
+  "conclusion": "success",
+  "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+}
+
 exports['ConventionalCommitLint sets a "failure" context on PR, if commits fail linting 1'] = {
   "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
   "conclusion": "failure",
@@ -10,6 +16,24 @@ exports['ConventionalCommitLint sets a "failure" context on PR, if commits fail 
 }
 
 exports['ConventionalCommitLint sets a "success" context on PR, if commit lint succeeds 1'] = {
+  "name": "conventionalcommits.org",
+  "conclusion": "success",
+  "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+}
+
+exports['ConventionalCommitLint sets a "success" context on PR, if the body is less than 256 in length 1'] = {
+  "name": "conventionalcommits.org",
+  "conclusion": "success",
+  "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+}
+
+exports['ConventionalCommitLint sets a "success" context on PR, if the footer is less than 256 in length 1'] = {
+  "name": "conventionalcommits.org",
+  "conclusion": "success",
+  "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+}
+
+exports['ConventionalCommitLint sets a "success" context on PR, if subject contains a full stop 1'] = {
   "name": "conventionalcommits.org",
   "conclusion": "success",
   "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
@@ -33,24 +57,6 @@ exports['ConventionalCommitLint PR With Multiple Commits has an invalid pull req
 }
 
 exports['ConventionalCommitLint PR With Multiple Commits has a valid title, invalid commit, automerge label 1'] = {
-  "name": "conventionalcommits.org",
-  "conclusion": "success",
-  "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
-}
-
-exports['ConventionalCommitLint sets a "success" context on PR, if the body is less than 256 in length 1'] = {
-  "name": "conventionalcommits.org",
-  "conclusion": "success",
-  "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
-}
-
-exports['ConventionalCommitLint sets a "success" context on PR, if the footer is less than 256 in length 1'] = {
-  "name": "conventionalcommits.org",
-  "conclusion": "success",
-  "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
-}
-
-exports['ConventionalCommitLint sets a "success" context on PR, if subject contains a full stop 1'] = {
   "name": "conventionalcommits.org",
   "conclusion": "success",
   "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"

--- a/packages/conventional-commit-lint/src/conventional-commit-lint.ts
+++ b/packages/conventional-commit-lint/src/conventional-commit-lint.ts
@@ -74,11 +74,20 @@ export = (app: Probot) => {
         return label.name;
       })
       .includes(AUTOMERGE_LABEL);
+
+    const autoMergeEnabledStatus = (
+      await context.octokit.pulls.get(commitParams)
+    ).data.auto_merge;
+
+    const hasAutoMergeEnabled =
+      autoMergeEnabledStatus &&
+      autoMergeEnabledStatus?.merge_method === 'squash';
+
     // if there is only one commit, and we're not not using automerge
     // to land the pull request, lint the commit rather than the title.
     // This is done because GitHub uses the commit title, rather than the
     // issue title, if there is only one commit:
-    if (commits.length === 1 && !hasAutomergeLabel) {
+    if (commits.length === 1 && !hasAutomergeLabel && !hasAutoMergeEnabled) {
       message = commits[0].commit.message;
     }
 

--- a/packages/conventional-commit-lint/test/conventional-commit-lint.ts
+++ b/packages/conventional-commit-lint/test/conventional-commit-lint.ts
@@ -58,6 +58,8 @@ describe('ConventionalCommitLint', () => {
     const requests = nock('https://api.github.com')
       .get('/repos/bcoe/test-release-please/pulls/11/commits?per_page=100')
       .reply(200, invalidCommits)
+      .get('/repos/bcoe/test-release-please/pulls/11?per_page=100')
+      .reply(200)
       .post('/repos/bcoe/test-release-please/check-runs', body => {
         snapshot(body);
         return true;
@@ -78,6 +80,8 @@ describe('ConventionalCommitLint', () => {
     const requests = nock('https://api.github.com')
       .get('/repos/bcoe/test-release-please/pulls/11/commits?per_page=100')
       .reply(200, validCommits)
+      .get('/repos/bcoe/test-release-please/pulls/11?per_page=100')
+      .reply(200)
       .post('/repos/bcoe/test-release-please/check-runs', body => {
         snapshot(body);
         return true;
@@ -119,6 +123,8 @@ describe('ConventionalCommitLint', () => {
       const requests = nock('https://api.github.com')
         .get('/repos/bcoe/test-release-please/pulls/11/commits?per_page=100')
         .reply(200, invalidCommits)
+        .get('/repos/bcoe/test-release-please/pulls/11?per_page=100')
+        .reply(200)
         .post('/repos/bcoe/test-release-please/check-runs', body => {
           snapshot(body);
           return true;
@@ -147,6 +153,8 @@ describe('ConventionalCommitLint', () => {
       const requests = nock('https://api.github.com')
         .get('/repos/bcoe/test-release-please/pulls/11/commits?per_page=100')
         .reply(200, invalidCommits)
+        .get('/repos/bcoe/test-release-please/pulls/11?per_page=100')
+        .reply(200)
         .post('/repos/bcoe/test-release-please/check-runs', body => {
           snapshot(body);
           return true;
@@ -167,6 +175,30 @@ describe('ConventionalCommitLint', () => {
       const requests = nock('https://api.github.com')
         .get('/repos/bcoe/test-release-please/pulls/11/commits?per_page=100')
         .reply(200, invalidCommit)
+        .get('/repos/bcoe/test-release-please/pulls/11?per_page=100')
+        .reply(200)
+        .post('/repos/bcoe/test-release-please/check-runs', body => {
+          snapshot(body);
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({name: 'pull_request', payload, id: 'abc123'});
+      requests.done();
+    });
+
+    it('has a valid title, invalid commit, automerge enabled', async () => {
+      const payload = require(resolve(
+        fixturesPath,
+        './pull_request_synchronize'
+      ));
+      // create a history that has one valid commit, and one invalid commit:
+      const invalidCommit = require(resolve(fixturesPath, './invalid_commit'));
+      const requests = nock('https://api.github.com')
+        .get('/repos/bcoe/test-release-please/pulls/11/commits?per_page=100')
+        .reply(200, invalidCommit)
+        .get('/repos/bcoe/test-release-please/pulls/11?per_page=100')
+        .reply(200, {auto_merge: {merge_method: 'squash'}})
         .post('/repos/bcoe/test-release-please/check-runs', body => {
           snapshot(body);
           return true;
@@ -190,6 +222,8 @@ describe('ConventionalCommitLint', () => {
     const requests = nock('https://api.github.com')
       .get('/repos/bcoe/test-release-please/pulls/11/commits?per_page=100')
       .reply(200, validCommits)
+      .get('/repos/bcoe/test-release-please/pulls/11?per_page=100')
+      .reply(200)
       .post('/repos/bcoe/test-release-please/check-runs', body => {
         snapshot(body);
         return true;
@@ -212,6 +246,8 @@ describe('ConventionalCommitLint', () => {
     const requests = nock('https://api.github.com')
       .get('/repos/bcoe/test-release-please/pulls/11/commits?per_page=100')
       .reply(200, validCommits)
+      .get('/repos/bcoe/test-release-please/pulls/11?per_page=100')
+      .reply(200)
       .post('/repos/bcoe/test-release-please/check-runs', body => {
         snapshot(body);
         return true;
@@ -234,6 +270,8 @@ describe('ConventionalCommitLint', () => {
     const requests = nock('https://api.github.com')
       .get('/repos/bcoe/test-release-please/pulls/11/commits?per_page=100')
       .reply(200, validCommits)
+      .get('/repos/bcoe/test-release-please/pulls/11?per_page=100')
+      .reply(200)
       .post('/repos/bcoe/test-release-please/check-runs', body => {
         snapshot(body);
         return true;


### PR DESCRIPTION
Fixes #2340 