### PR TITLE
feat(repo-metadata-lint): Allow 'unreleased' as a release_level

### DIFF
--- a/packages/repo-metadata-lint/src/repo-metadata-schema.json
+++ b/packages/repo-metadata-lint/src/repo-metadata-schema.json
@@ -18,7 +18,7 @@
     },
     "release_level": {
       "type": "string",
-      "enum": ["preview", "stable"]
+      "enum": ["unreleased", "preview", "stable"]
     }
   },
   "required": ["library_type", "release_level", "client_documentation"]

--- a/packages/repo-metadata-lint/test/validate.ts
+++ b/packages/repo-metadata-lint/test/validate.ts
@@ -226,4 +226,21 @@ describe('validate', () => {
     assert.strictEqual(result.status, 'success');
     sandbox.assert.calledOnce(validApiShortNames);
   });
+
+  it('succeeds for release_level of unreleased', async () => {
+    const validApiShortNames = mockValidApiShortNames();
+    const file = JSON.stringify({
+      release_level: 'unreleased',
+      library_type: 'GAPIC_AUTO',
+      client_documentation: 'https://example.com',
+      api_shortname: 'bigquery',
+    });
+    const validate = new Validate(octokit);
+    const result = await validate.validate(
+      'apis/foo/.repo-metadata.json',
+      file
+    );
+    assert.strictEqual(result.status, 'success');
+    sandbox.assert.calledOnce(validApiShortNames);
+  });
 });


### PR DESCRIPTION
Fixes #3195
