### PR TITLE
fix: calls to github.git.deleteRef

### DIFF
--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -621,7 +621,7 @@ async function updatePullRequestAfterPostProcessor(
     });
     if (pull.head.repo.full_name === `${owner}/${repo}`) {
       logger.info(`Deleting branch ${pull.head.ref}`);
-      await octokit.git.deleteRef({owner, repo, ref: pull.head.ref});
+      await octokit.git.deleteRef({owner, repo, ref: `heads/${pull.head.ref}`});
     } else {
       logger.info(
         `I won't delete the ${pull.head.ref} branch in the fork ` +

--- a/packages/owl-bot/src/maybe-create-pull-request-for-copy.ts
+++ b/packages/owl-bot/src/maybe-create-pull-request-for-copy.ts
@@ -70,7 +70,7 @@ export async function deleteCopyBranch(
   (await octokitFactory.getShortLivedOctokit()).git.deleteRef({
     owner: githubRepo.owner,
     repo: githubRepo.repo,
-    ref: branch,
+    ref: `heads/${branch}`,
   });
 }
 

--- a/packages/owl-bot/test/maybe-create-pull-request-for-copy.ts
+++ b/packages/owl-bot/test/maybe-create-pull-request-for-copy.ts
@@ -49,7 +49,7 @@ describe('maybe-create-pull-request-for-copy', () => {
 
       await deleteCopyBranch(factory, abcRepo);
       assert.deepStrictEqual(deadRefs, [
-        {owner: 'googleapis', ref: 'deadBranch', repo: 'nodejs-data-fusion'},
+        {owner: 'googleapis', ref: 'heads/deadBranch', repo: 'nodejs-data-fusion'},
       ]);
     });
   });

--- a/packages/owl-bot/test/maybe-create-pull-request-for-copy.ts
+++ b/packages/owl-bot/test/maybe-create-pull-request-for-copy.ts
@@ -49,7 +49,11 @@ describe('maybe-create-pull-request-for-copy', () => {
 
       await deleteCopyBranch(factory, abcRepo);
       assert.deepStrictEqual(deadRefs, [
-        {owner: 'googleapis', ref: 'heads/deadBranch', repo: 'nodejs-data-fusion'},
+        {
+          owner: 'googleapis',
+          ref: 'heads/deadBranch',
+          repo: 'nodejs-data-fusion',
+        },
       ]);
     });
   });

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -409,7 +409,7 @@ describe('owlBot', () => {
       .patch('/repos/googleapis/owl-bot-testing/pulls/33')
       .reply(200)
       // Delete the branch
-      .delete('/repos/googleapis/owl-bot-testing/git/refs/abc123')
+      .delete('/repos/googleapis/owl-bot-testing/git/refs/heads%2Fabc123')
       .reply(200);
     const triggerBuildStub = sandbox
       .stub(core, 'triggerPostProcessBuild')


### PR DESCRIPTION
Calls were failing with ` HttpError: Reference does not exist`

The ref needs a `heads/` prefix to delete a branch, as described here https://github.com/octokit/octokit.rb/issues/363

Fixes https://github.com/googleapis/repo-automation-bots/issues/3071
