### PR TITLE
chore: delete obsolete code paths

### DIFF
--- a/packages/owl-bot/src/bin/commands/copy-code-and-create-pull-request.ts
+++ b/packages/owl-bot/src/bin/commands/copy-code-and-create-pull-request.ts
@@ -24,7 +24,6 @@ interface Args extends OctokitParams {
   'source-repo-commit-hash': string;
   'dest-repo': string;
   'dest-owlbot-yaml': string;
-  'search-depth': number;
 }
 
 export const copyCodeAndCreatePullRequestCommand: yargs.CommandModule<
@@ -74,18 +73,11 @@ export const copyCodeAndCreatePullRequestCommand: yargs.CommandModule<
         type: 'string',
         default: '.github/.OwlBot.yaml',
         demand: false,
-      })
-      .option('search-depth', {
-        describe:
-          'When searching pull request and issue histories to see if a pull' +
-          ' request for the commit was already created, search this deep',
-        type: 'number',
-        default: 1000,
       });
   },
   async handler(argv) {
     const octokitFactory = await octokitFactoryFrom(argv);
-    await cc.copyCodeAndCreatePullRequest(
+    await cc.copyCodeAndAppendOrCreatePullRequest(
       argv['source-repo'],
       argv['source-repo-commit-hash'],
       {

--- a/packages/owl-bot/src/bin/commands/copy-code-into-pull-request.ts
+++ b/packages/owl-bot/src/bin/commands/copy-code-into-pull-request.ts
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// To Run: node ./build/src/bin/owl-bot.js copy-code <args>
-
 import yargs = require('yargs');
 import {DEFAULT_OWL_BOT_YAML_PATH} from '../../config-files';
-import {copyCodeIntoPullRequest, regeneratePullRequest} from '../../copy-code';
+import {regeneratePullRequest} from '../../copy-code';
 import {githubRepoFromOwnerSlashName} from '../../github-repo';
 import {octokitFactoryFromToken} from '../../octokit-util';
 
@@ -27,7 +25,6 @@ interface Args {
   'dest-repo': string;
   'dest-branch': string;
   'github-token': string;
-  'multi-commit': boolean;
 }
 
 export const copyCodeIntoPullRequestCommand: yargs.CommandModule<{}, Args> = {
@@ -69,37 +66,17 @@ export const copyCodeIntoPullRequestCommand: yargs.CommandModule<{}, Args> = {
         describe: 'Short-lived github token.',
         type: 'string',
         demand: true,
-      })
-      .option('multi-commit', {
-        describe:
-          'Use an entirely new code path that works with multiple commits in a single pull request.',
-        type: 'boolean',
-        demand: false,
-        default: true,
       });
   },
   async handler(argv) {
-    if (argv['multi-commit']) {
-      await regeneratePullRequest(
-        argv['source-repo'],
-        {
-          repo: githubRepoFromOwnerSlashName(argv['dest-repo']),
-          yamlPath: argv['owl-bot-yaml-path'],
-        },
-        argv['dest-branch'],
-        octokitFactoryFromToken(argv['github-token'])
-      );
-    } else {
-      await copyCodeIntoPullRequest(
-        argv['source-repo'],
-        argv['source-repo-commit-hash'],
-        {
-          repo: githubRepoFromOwnerSlashName(argv['dest-repo']),
-          yamlPath: argv['owl-bot-yaml-path'],
-        },
-        argv['dest-branch'],
-        octokitFactoryFromToken(argv['github-token'])
-      );
-    }
+    await regeneratePullRequest(
+      argv['source-repo'],
+      {
+        repo: githubRepoFromOwnerSlashName(argv['dest-repo']),
+        yamlPath: argv['owl-bot-yaml-path'],
+      },
+      argv['dest-branch'],
+      octokitFactoryFromToken(argv['github-token'])
+    );
   },
 };

--- a/packages/owl-bot/src/bin/commands/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/bin/commands/scan-googleapis-gen-and-create-pull-requests.ts
@@ -25,7 +25,6 @@ interface Args extends OctokitParams {
   'firestore-project': string;
   'clone-depth': number;
   'track-builds-in-firestore': boolean;
-  'multi-commit': boolean;
 }
 
 export const scanGoogleapisGenAndCreatePullRequestsCommand: yargs.CommandModule<
@@ -75,13 +74,6 @@ export const scanGoogleapisGenAndCreatePullRequestsCommand: yargs.CommandModule<
           ' to copy the same code twice.',
         type: 'boolean',
         default: true,
-      })
-      .option('multi-commit', {
-        describe:
-          "Add new commits to open PRs when there's already one open. " +
-          'Otherwise, opens a new PR for every new upstream change.',
-        type: 'boolean',
-        default: true,
       });
   },
   async handler(argv) {
@@ -99,8 +91,7 @@ export const scanGoogleapisGenAndCreatePullRequestsCommand: yargs.CommandModule<
       octokitFactoryFrom(argv),
       configsStore,
       argv['clone-depth'],
-      copyStateStore,
-      argv['multi-commit']
+      copyStateStore
     );
   },
 };

--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -696,42 +696,6 @@ export async function regeneratePullRequest(
 }
 
 /**
- * Copies the code from googleapis-gen into an existing pull request.
- * Uses `git push -f` to completely replace the existing contents of the branch.
- *
- * @param sourceRepo: the source repository, either a local path or googleapis/googleapis-gen
- * @param sourceRepoCommit: the commit from which to copy code. Empty means the most recent commit.
- * @param destRepo: the destination repository, either a local path or a github path like googleapis/nodejs-vision.
- */
-export async function copyCodeIntoPullRequest(
-  sourceRepo: string,
-  sourceRepoCommitHash: string,
-  destRepo: AffectedRepo,
-  destBranch: string,
-  octokitFactory: OctokitFactory,
-  logger = console
-): Promise<void> {
-  const dest = await copyCodeIntoLocalBranch(
-    sourceRepo,
-    sourceRepoCommitHash,
-    destRepo,
-    destBranch,
-    octokitFactory,
-    undefined,
-    logger
-  );
-  if (dest.kind === 'CreatedGithubIssue') {
-    return;
-  }
-
-  const token = await octokitFactory.getGitHubShortLivedAccessToken();
-  const cmd = newCmd(logger);
-  const pushUrl = destRepo.repo.getCloneUrl(token);
-  cmd(`git remote set-url origin ${pushUrl}`, {cwd: dest.dir});
-  cmd(`git push -f origin ${destBranch}`, {cwd: dest.dir});
-}
-
-/**
  * Loads the OwlBot yaml from the dest directory.  Throws an exception if not found
  * or invalid.
  */

--- a/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
@@ -17,7 +17,6 @@ import {OctokitType, OctokitFactory} from './octokit-util';
 import tmp from 'tmp';
 import {
   copyCodeAndAppendOrCreatePullRequest,
-  copyCodeAndCreatePullRequest,
   copyTagFrom,
   toLocalRepo,
 } from './copy-code';
@@ -72,7 +71,6 @@ export async function scanGoogleapisGenAndCreatePullRequests(
   configsStore: ConfigsStore,
   cloneDepth = 100,
   copyStateStore?: CopyStateStore,
-  multiCommit = false,
   logger = console
 ): Promise<number> {
   // Clone the source repo.
@@ -159,10 +157,7 @@ export async function scanGoogleapisGenAndCreatePullRequests(
 
   // Copy files beginning with the oldest commit hash.
   for (const todo of todoStack.reverse()) {
-    const copyFunction = multiCommit
-      ? copyCodeAndAppendOrCreatePullRequest
-      : copyCodeAndCreatePullRequest;
-    const htmlUrl = await copyFunction(
+    const htmlUrl = await copyCodeAndAppendOrCreatePullRequest(
       sourceDir,
       todo.commitHash,
       todo.repo,

--- a/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
@@ -412,32 +412,6 @@ describe('regenerate pull requests', function () {
     cmd('git checkout main', {cwd: abcRepo});
   });
 
-  it('copies files into a pull request', async () => {
-    const destRepo = makeDestRepo(bYaml);
-    const pulls = new FakePulls();
-    const issues = new FakeIssues();
-    const octokit = newFakeOctokit(pulls, issues);
-    const factory = newFakeOctokitFactory(octokit, 'test-token');
-    const sourceHash = abcCommits[1];
-
-    await cc.copyCodeIntoPullRequest(
-      abcRepo,
-      sourceHash,
-      {repo: destRepo, yamlPath: '.github/.OwlBot.yaml'},
-      'test-branch',
-      factory
-    );
-    // Confirm new pull request was pushed to test-branch.
-    const destDir = destRepo.getCloneUrl();
-    const gitLog = cmd('git log test-branch', {cwd: destDir}).toString('utf-8');
-    assert.match(
-      gitLog,
-      RegExp(
-        `.*Source-Link: https://github.com/googleapis/googleapis-gen/commit/${sourceHash}.*`
-      )
-    );
-  });
-
   it('regenerates a pull request', async () => {
     const destRepo = makeDestRepo(bYaml);
     const pulls = new FakePulls();


### PR DESCRIPTION
Flags prevented these obsolete code paths from executing, so they're safe to delete.