### PR TITLE
fix: owl-bot now only tracks copies in firestore

### DIFF
--- a/packages/owl-bot/src/bin/commands/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/bin/commands/scan-googleapis-gen-and-create-pull-requests.ts
@@ -24,7 +24,6 @@ interface Args extends OctokitParams {
   'source-repo': string;
   'firestore-project': string;
   'clone-depth': number;
-  'track-builds-in-firestore': boolean;
   'multi-commit': boolean;
 }
 
@@ -69,13 +68,6 @@ export const scanGoogleapisGenAndCreatePullRequestsCommand: yargs.CommandModule<
         type: 'number',
         default: 100,
       })
-      .option('track-builds-in-firestore', {
-        describe:
-          "Record copy jobs in firestore, so that we don't try" +
-          ' to copy the same code twice.',
-        type: 'boolean',
-        default: true,
-      })
       .option('multi-commit', {
         describe:
           "Add new commits to open PRs when there's already one open. " +
@@ -91,9 +83,7 @@ export const scanGoogleapisGenAndCreatePullRequestsCommand: yargs.CommandModule<
     });
     const db = admin.firestore();
     const configsStore = new FirestoreConfigsStore(db!);
-    const copyStateStore = argv['track-builds-in-firestore']
-      ? new FirestoreCopyStateStore(db!)
-      : undefined;
+    const copyStateStore = new FirestoreCopyStateStore(db!);
     await scanGoogleapisGenAndCreatePullRequests(
       argv['source-repo'],
       octokitFactoryFrom(argv),

--- a/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
@@ -71,7 +71,7 @@ export async function scanGoogleapisGenAndCreatePullRequests(
   octokitFactory: OctokitFactory,
   configsStore: ConfigsStore,
   cloneDepth = 100,
-  copyStateStore?: CopyStateStore,
+  copyStateStore: CopyStateStore,
   multiCommit = false,
   logger = console
 ): Promise<number> {
@@ -132,7 +132,7 @@ export async function scanGoogleapisGenAndCreatePullRequests(
           `Ignoring ${repoFullName} because ${commitHash} is too old.`
         );
       } else if (
-        (copyBuildId = await copyStateStore?.findBuildForCopy(
+        (copyBuildId = await copyStateStore.findBuildForCopy(
           repo.repo,
           copyTagFrom(repo.yamlPath, commitHash)
         ))

--- a/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
@@ -157,7 +157,8 @@ describe('scanGoogleapisGenAndCreatePullRequests', function () {
           getGitHubShortLivedAccessToken: () => Promise.resolve(''),
         } as OctokitFactory,
         new FakeConfigsStore(),
-        1000
+        1000,
+        new FakeCopyStateStore()
       ),
       0
     );
@@ -347,7 +348,8 @@ Copy-Tag: ${copyTag}`
       abcRepo,
       factory(octokit),
       configsStore,
-      1000
+      1000,
+      new FakeCopyStateStore()
     );
 
     // Confirm it created one pull request.
@@ -370,7 +372,8 @@ Copy-Tag: ${copyTag}`
       abcRepo,
       factory(octokit),
       configsStore,
-      1000
+      1000,
+      new FakeCopyStateStore()
     );
 
     // Confirm it created one pull request.
@@ -389,7 +392,8 @@ Copy-Tag: ${copyTag}`
       abcRepo,
       factory(octokit),
       configsStore,
-      1000
+      1000,
+      new FakeCopyStateStore()
     );
 
     // Confirm it created one pull request.


### PR DESCRIPTION
So remove the flag, and make the copyStateStore argument required.
