### PR TITLE
feat(auto-approve): add rules for Java/PHP apiary codegen

### DIFF
--- a/packages/auto-approve/README.md
+++ b/packages/auto-approve/README.md
@@ -21,9 +21,11 @@ processes:
   - "PythonDependency"
   - "NodeDependency"
   - "NodeRelease"
+  - "JavaApiaryCodegen"
   - "JavaDependency"
   - "OwlBotTemplateChanges"
   - "OwlBotAPIChanges"
+  - "PHPApiaryCodegen"
 ```
 
 These seven processes represent different workflows for what auto-approve will approve and merge in a given repository. To see their logic in full, see the corresponding file in /src/process-checks.
@@ -84,6 +86,9 @@ Below is what each process checks for:
     - Increase the non-major package version
     - Only change the top-level package
     - Approve on a day between Mon - Thurs PST (so as to not trigger a weekend release)
+* JavaApiaryCodegen
+  - Checks that the author is 'yoshi-code-bot'
+  - Checks that the title of the PR matches the regexp: /^Regenerate .* client$/
 * JavaDependency:
   - Checks that the author is 'renovate-bot'
   - Checks that the title of the PR matches the regexp: /^(fix|chore)\(deps\): update dependency (@?\S*) to v(\S*)$/
@@ -107,6 +112,9 @@ Below is what each process checks for:
   - Checks that the .repo-metadata.json of the repo contains "library_type": "GAPIC_AUTO"
   - Checks that there are no other PRs in that repository that have been opened by gcf-owl-bot[bot]
   - Checks that the PR does not have any commits from any other authors other than gcf-owl-bot[bot]
+* PHPApiaryCodegen
+  - Checks that the author is 'yoshi-code-bot'
+  - Checks that the title of the PR matches the regexp: /^Regenerate .* client$/
 
   
 

--- a/packages/auto-approve/__snapshots__/check-config.test.js
+++ b/packages/auto-approve/__snapshots__/check-config.test.js
@@ -35,7 +35,7 @@ exports['check for config whether YAML file has valid schema should fail if ther
 `
 
 exports['check for config whether YAML file has valid schema V2 should fail if YAML has any other properties than the ones specified 1'] = `
-[{"wrongProperty":{"allowedValues":["UpdateDiscoveryArtifacts","RegenerateReadme","DiscoveryDocUpdate","PythonDependency","NodeDependency","NodeRelease","JavaDependency","OwlBotTemplateChanges","OwlBotAPIChanges"]},"message":"must be equal to one of the allowed values"}]
+[{"wrongProperty":{"allowedValues":["UpdateDiscoveryArtifacts","RegenerateReadme","DiscoveryDocUpdate","PythonDependency","NodeDependency","NodeRelease","JavaApiaryCodegen","JavaDependency","OwlBotTemplateChanges","OwlBotAPIChanges","PHPApiaryCodegen"]},"message":"must be equal to one of the allowed values"}]
 `
 
 exports['check for config whether YAML file has valid schema V2 should fail if the property is wrong 1'] = `

--- a/packages/auto-approve/src/check-pr-v2.ts
+++ b/packages/auto-approve/src/check-pr-v2.ts
@@ -26,6 +26,8 @@ import {NodeRelease} from './process-checks/node/release';
 import {JavaDependency} from './process-checks/java/dependency';
 import {OwlBotTemplateChanges} from './process-checks/owl-bot-template-changes';
 import {OwlBotAPIChanges} from './process-checks/owl-bot-api-changes';
+import {JavaApiaryCodegen} from './process-checks/java/apiary-codegen';
+import {PHPApiaryCodegen} from './process-checks/php/apiary-codegen';
 // This file manages the logic to check whether a given PR matches the config in the repository
 
 // We need this typeMap to convert the JSON input (string) into a corresponding type.
@@ -55,6 +57,10 @@ const typeMap = [
     configType: NodeRelease,
   },
   {
+    configValue: 'JavaApiaryCodegen',
+    configType: JavaApiaryCodegen,
+  },
+  {
     configValue: 'JavaDependency',
     configType: JavaDependency,
   },
@@ -65,6 +71,10 @@ const typeMap = [
   {
     configValue: 'OwlBotAPIChanges',
     configType: OwlBotAPIChanges,
+  },
+  {
+    configValue: 'PHPApiaryCodegen',
+    configType: PHPApiaryCodegen,
   },
 ];
 

--- a/packages/auto-approve/src/process-checks/java/apiary-codegen.ts
+++ b/packages/auto-approve/src/process-checks/java/apiary-codegen.ts
@@ -1,0 +1,77 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {LanguageRule, File, Process} from '../../interfaces';
+import {
+  checkAuthor,
+  checkTitleOrBody,
+  reportIndividualChecks,
+} from '../../utils-for-pr-checking';
+import {Octokit} from '@octokit/rest';
+
+export class JavaApiaryCodegen extends Process implements LanguageRule {
+  classRule: {
+    author: string;
+    titleRegex: RegExp;
+  };
+
+  constructor(
+    incomingPrAuthor: string,
+    incomingTitle: string,
+    incomingFileCount: number,
+    incomingChangedFiles: File[],
+    incomingRepoName: string,
+    incomingRepoOwner: string,
+    incomingPrNumber: number,
+    incomingOctokit: Octokit,
+    incomingBody?: string
+  ) {
+    super(
+      incomingPrAuthor,
+      incomingTitle,
+      incomingFileCount,
+      incomingChangedFiles,
+      incomingRepoName,
+      incomingRepoOwner,
+      incomingPrNumber,
+      incomingOctokit,
+      incomingBody
+    ),
+      (this.classRule = {
+        author: 'yoshi-code-bot',
+        titleRegex: /^Regenerate .* client$/,
+      });
+  }
+
+  public async checkPR(): Promise<boolean> {
+    const authorshipMatches = checkAuthor(
+      this.classRule.author,
+      this.incomingPR.author
+    );
+
+    const titleMatches = checkTitleOrBody(
+      this.incomingPR.title,
+      this.classRule.titleRegex
+    );
+    reportIndividualChecks(
+      ['authorshipMatches', 'titleMatches'],
+      [authorshipMatches, titleMatches],
+      this.incomingPR.repoOwner,
+      this.incomingPR.repoName,
+      this.incomingPR.prNumber
+    );
+
+    return authorshipMatches && titleMatches;
+  }
+}

--- a/packages/auto-approve/src/process-checks/php/apiary-codegen.ts
+++ b/packages/auto-approve/src/process-checks/php/apiary-codegen.ts
@@ -1,0 +1,77 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {LanguageRule, File, Process} from '../../interfaces';
+import {
+  checkAuthor,
+  checkTitleOrBody,
+  reportIndividualChecks,
+} from '../../utils-for-pr-checking';
+import {Octokit} from '@octokit/rest';
+
+export class PHPApiaryCodegen extends Process implements LanguageRule {
+  classRule: {
+    author: string;
+    titleRegex: RegExp;
+  };
+
+  constructor(
+    incomingPrAuthor: string,
+    incomingTitle: string,
+    incomingFileCount: number,
+    incomingChangedFiles: File[],
+    incomingRepoName: string,
+    incomingRepoOwner: string,
+    incomingPrNumber: number,
+    incomingOctokit: Octokit,
+    incomingBody?: string
+  ) {
+    super(
+      incomingPrAuthor,
+      incomingTitle,
+      incomingFileCount,
+      incomingChangedFiles,
+      incomingRepoName,
+      incomingRepoOwner,
+      incomingPrNumber,
+      incomingOctokit,
+      incomingBody
+    ),
+      (this.classRule = {
+        author: 'yoshi-code-bot',
+        titleRegex: /^Regenerate .* client$/,
+      });
+  }
+
+  public async checkPR(): Promise<boolean> {
+    const authorshipMatches = checkAuthor(
+      this.classRule.author,
+      this.incomingPR.author
+    );
+
+    const titleMatches = checkTitleOrBody(
+      this.incomingPR.title,
+      this.classRule.titleRegex
+    );
+    reportIndividualChecks(
+      ['authorshipMatches', 'titleMatches'],
+      [authorshipMatches, titleMatches],
+      this.incomingPR.repoOwner,
+      this.incomingPR.repoName,
+      this.incomingPR.prNumber
+    );
+
+    return authorshipMatches && titleMatches;
+  }
+}

--- a/packages/auto-approve/src/valid-pr-schema-v2.json
+++ b/packages/auto-approve/src/valid-pr-schema-v2.json
@@ -18,9 +18,11 @@
           "PythonDependency",
           "NodeDependency",
           "NodeRelease",
+          "JavaApiaryCodegen",
           "JavaDependency",
           "OwlBotTemplateChanges",
-          "OwlBotAPIChanges"
+          "OwlBotAPIChanges",
+          "PHPApiaryCodegen"
         ]
       }
     }

--- a/packages/auto-approve/test/java-apiary-codegen.test.ts
+++ b/packages/auto-approve/test/java-apiary-codegen.test.ts
@@ -1,0 +1,96 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {JavaApiaryCodegen} from '../src/process-checks/java/apiary-codegen';
+import {describe, it} from 'mocha';
+import assert from 'assert';
+const {Octokit} = require('@octokit/rest');
+
+const octokit = new Octokit({
+  auth: 'mypersonalaccesstoken123',
+});
+describe('JavaApiaryCodegen', () => {
+  it('should get constructed with the appropriate values', () => {
+    const rule = new JavaApiaryCodegen(
+      'testAuthor',
+      'testTitle',
+      3,
+      [{filename: 'hello', sha: '2345'}],
+      'testRepoName',
+      'testRepoOwner',
+      1,
+      octokit,
+      'body'
+    );
+
+    const expectation = {
+      incomingPR: {
+        author: 'testAuthor',
+        title: 'testTitle',
+        fileCount: 3,
+        changedFiles: [{filename: 'hello', sha: '2345'}],
+        repoName: 'testRepoName',
+        repoOwner: 'testRepoOwner',
+        prNumber: 1,
+        body: 'body',
+      },
+      classRule: {
+        author: 'yoshi-code-bot',
+        titleRegex: /^Regenerate .* client$/,
+      },
+      octokit,
+    };
+
+    assert.deepStrictEqual(rule.incomingPR, expectation.incomingPR);
+    assert.deepStrictEqual(rule.classRule, expectation.classRule);
+    assert.deepStrictEqual(rule.octokit, octokit);
+  });
+
+  it('should return false in checkPR if incoming PR does not match classRules', async () => {
+    const rule = new JavaApiaryCodegen(
+      'testAuthor',
+      'testTitle',
+      3,
+      [{filename: 'hello', sha: '2345'}],
+      'testRepoName',
+      'testRepoOwner',
+      1,
+      octokit,
+      'body'
+    );
+
+    assert.deepStrictEqual(await rule.checkPR(), false);
+  });
+
+  it('should return true in checkPR if incoming PR does match classRules', async () => {
+    const rule = new JavaApiaryCodegen(
+      'yoshi-code-bot',
+      'Regenerate admin client',
+      2,
+      [
+        {
+          filename: 'README.md',
+          sha: '2345',
+        },
+      ],
+      'testRepoName',
+      'testRepoOwner',
+      1,
+      octokit,
+      'body'
+    );
+
+    assert.ok(await rule.checkPR());
+  });
+});

--- a/packages/auto-approve/test/php-apairy-codegen.test.ts
+++ b/packages/auto-approve/test/php-apairy-codegen.test.ts
@@ -1,0 +1,96 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PHPApiaryCodegen} from '../src/process-checks/php/apiary-codegen';
+import {describe, it} from 'mocha';
+import assert from 'assert';
+const {Octokit} = require('@octokit/rest');
+
+const octokit = new Octokit({
+  auth: 'mypersonalaccesstoken123',
+});
+describe('PHPApiaryCodegen', () => {
+  it('should get constructed with the appropriate values', () => {
+    const rule = new PHPApiaryCodegen(
+      'testAuthor',
+      'testTitle',
+      3,
+      [{filename: 'hello', sha: '2345'}],
+      'testRepoName',
+      'testRepoOwner',
+      1,
+      octokit,
+      'body'
+    );
+
+    const expectation = {
+      incomingPR: {
+        author: 'testAuthor',
+        title: 'testTitle',
+        fileCount: 3,
+        changedFiles: [{filename: 'hello', sha: '2345'}],
+        repoName: 'testRepoName',
+        repoOwner: 'testRepoOwner',
+        prNumber: 1,
+        body: 'body',
+      },
+      classRule: {
+        author: 'yoshi-code-bot',
+        titleRegex: /^Regenerate .* client$/,
+      },
+      octokit,
+    };
+
+    assert.deepStrictEqual(rule.incomingPR, expectation.incomingPR);
+    assert.deepStrictEqual(rule.classRule, expectation.classRule);
+    assert.deepStrictEqual(rule.octokit, octokit);
+  });
+
+  it('should return false in checkPR if incoming PR does not match classRules', async () => {
+    const rule = new PHPApiaryCodegen(
+      'testAuthor',
+      'testTitle',
+      3,
+      [{filename: 'hello', sha: '2345'}],
+      'testRepoName',
+      'testRepoOwner',
+      1,
+      octokit,
+      'body'
+    );
+
+    assert.deepStrictEqual(await rule.checkPR(), false);
+  });
+
+  it('should return true in checkPR if incoming PR does match classRules', async () => {
+    const rule = new PHPApiaryCodegen(
+      'yoshi-code-bot',
+      'Regenerate admin client',
+      2,
+      [
+        {
+          filename: 'README.md',
+          sha: '2345',
+        },
+      ],
+      'testRepoName',
+      'testRepoOwner',
+      1,
+      octokit,
+      'body'
+    );
+
+    assert.ok(await rule.checkPR());
+  });
+});


### PR DESCRIPTION
With the migration off of autosynth, apiary codegen for PHP and Java is using GitHub actions PRs from forks. We can no longer auto-approve via the GitHub actions workflows.

This adds 2 new auto-approve rules that check author and title patterns.