### PR TITLE
feat(datastor-lock): add peek method

### DIFF
--- a/packages/datastore-lock/README.md
+++ b/packages/datastore-lock/README.md
@@ -27,6 +27,7 @@ const lockId = 'blunderbuss';
 const target = context.payload.pull_request.url;
 
 const lock = new DatastoreLock(lockId, target);
+// await lock.peek(); // was there already a lock perhaps?
 const result = await lock.acquire();
 if (!result) {
 	// failure

--- a/packages/datastore-lock/test/datastore-lock.ts
+++ b/packages/datastore-lock/test/datastore-lock.ts
@@ -61,4 +61,33 @@ describe('datastore-lock', () => {
       }, Error);
     });
   });
+
+  describe('peek', () => {
+    it('returns true if a lock already exists on a key', async () => {
+      // First request for lock.
+      const l = new DatastoreLock('datastore-lock-test', 'test');
+      assert(await l.acquire());
+      // Second request asks, is there a lock?
+      const l2 = new DatastoreLock('datastore-lock-test', 'test');
+      assert(await l2.peek());
+      // Cleanup.
+      await l.release();
+    });
+    it('returns false if no lock exists on the key', async () => {
+      // First request for lock.
+      const l = new DatastoreLock('datastore-lock-test', 'test');
+      assert.strictEqual(await l.peek(), false);
+    });
+    it('return false if peek is called after timeout', async () => {
+      // First request for lock.
+      const l = new DatastoreLock('datastore-lock-test', 'test', 100);
+      assert(await l.acquire());
+      await new Promise(resolve => {
+        setTimeout(resolve, 250);
+      });
+      // Second request asks, is there a lock? It should have timed out:
+      const l2 = new DatastoreLock('datastore-lock-test', 'test');
+      assert.strictEqual(await l2.peek(), false);
+    });
+  });
 });


### PR DESCRIPTION
Add a peek method, for checking if lock exists without claiming a lock.