### PR TITLE
fix(release-please): allow json/xml extraFiles configuration options

### DIFF
--- a/packages/release-please/src/config-schema.json
+++ b/packages/release-please/src/config-schema.json
@@ -84,7 +84,11 @@
                 "extraFiles": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "anyOf": [
+                            {"type": "string"},
+                            {"$ref": "#/definitions/ExtraJsonFile"},
+                            {"$ref": "#/definitions/ExtraXmlFile"}
+                        ]
                     }
                 },
                 "releaseLabel": {
@@ -103,6 +107,34 @@
                     "type": "string"
                 }
             }
+        },
+        "ExtraJsonFile": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "jsonpath": {
+                    "type": "string"
+                }
+            }
+        },
+        "ExtraXmlFile": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "xpath": {
+                    "type": "string"
+                }
+            }            
         }
     },
     "properties": {

--- a/packages/release-please/test/config-schema.ts
+++ b/packages/release-please/test/config-schema.ts
@@ -1,0 +1,58 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it} from 'mocha';
+import { validateConfig } from "@google-automations/bot-config-utils";
+import { ConfigurationOptions } from "../src/config-constants";
+import schema from '../src/config-schema.json';
+import * as fs from 'fs';
+import { resolve } from 'path';
+import * as assert from 'assert';
+
+const fixturesPath = resolve(__dirname, '../../test/fixtures');
+function loadConfig(configFile: string) {
+  return fs.readFileSync(resolve(fixturesPath, 'config', configFile), 'utf-8');
+}
+
+function assertValidConfig(config: string) {
+  const configYaml = loadConfig(`${config}.yml`);
+  const result = validateConfig<ConfigurationOptions>(configYaml, schema, {});
+  assert.ok(result.isValid);
+}
+
+function assertInvalidConfig(config: string, errorPattern: RegExp) {
+  const configYaml = loadConfig(`${config}.yml`);
+  const result = validateConfig<ConfigurationOptions>(configYaml, schema, {});
+  assert.ok(!result.isValid);
+  assert.ok(result.errorText);
+  assert.ok(result.errorText.match(errorPattern));
+}
+
+describe('config-schema', () => {
+  it('validates a basic config', () => {
+    assertValidConfig('valid',);
+  })
+  it('validates extra files', () => {
+    assertValidConfig('extra_files');
+  })
+  it('validates extra json files', () => {
+    assertValidConfig('extra_files_json');
+  })
+  it('validates extra xml files', () => {
+    assertValidConfig('extra_files_xml');
+  })
+  it('rejects extra fields', () => {
+    assertInvalidConfig('invalid', /must NOT have additional properties/);
+  });
+});

--- a/packages/release-please/test/config-schema.ts
+++ b/packages/release-please/test/config-schema.ts
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 import {describe, it} from 'mocha';
-import { validateConfig } from "@google-automations/bot-config-utils";
-import { ConfigurationOptions } from "../src/config-constants";
+import {validateConfig} from '@google-automations/bot-config-utils';
+import {ConfigurationOptions} from '../src/config-constants';
 import schema from '../src/config-schema.json';
 import * as fs from 'fs';
-import { resolve } from 'path';
+import {resolve} from 'path';
 import * as assert from 'assert';
 
 const fixturesPath = resolve(__dirname, '../../test/fixtures');
@@ -41,17 +41,17 @@ function assertInvalidConfig(config: string, errorPattern: RegExp) {
 
 describe('config-schema', () => {
   it('validates a basic config', () => {
-    assertValidConfig('valid',);
-  })
+    assertValidConfig('valid');
+  });
   it('validates extra files', () => {
     assertValidConfig('extra_files');
-  })
+  });
   it('validates extra json files', () => {
     assertValidConfig('extra_files_json');
-  })
+  });
   it('validates extra xml files', () => {
     assertValidConfig('extra_files_xml');
-  })
+  });
   it('rejects extra fields', () => {
     assertInvalidConfig('invalid', /must NOT have additional properties/);
   });

--- a/packages/release-please/test/fixtures/config/extra_files_json.yml
+++ b/packages/release-please/test/fixtures/config/extra_files_json.yml
@@ -1,0 +1,4 @@
+extraFiles:
+  - type: json
+    path: src/foo.json
+    jsonpath: $..version

--- a/packages/release-please/test/fixtures/config/extra_files_xml.yml
+++ b/packages/release-please/test/fixtures/config/extra_files_xml.yml
@@ -1,0 +1,4 @@
+extraFiles:
+  - type: json
+    path: src/foo.xml
+    xpath: //Project/Version

--- a/packages/release-please/test/fixtures/config/invalid.yml
+++ b/packages/release-please/test/fixtures/config/invalid.yml
@@ -1,0 +1,1 @@
+unknownField: true


### PR DESCRIPTION
In release-please 13.6.0, we added the ability to specify generic JSON and XML files for updating with jsonpath/xpath specifiers respectively.

This PR adds those config options to the config file validation and adds a few tests to verify that the new schema works.
