### PR TITLE
fix(owl-bot): only use lock around running post-processor

### DIFF
--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -415,7 +415,8 @@ async function runPostProcessorWithLock(
   octokit: Octokit,
   breakLoop = true
 ) {
-  // Short-circuit if post-processor already running for this SHA:
+  // Short-circuit if post-processor already running for this SHA, preventing two post-processor images
+  // from both executing and pushing changes against the same PR.
   const target = `${opts.owner}_${opts.repo}_${opts.sha}`;
   let lock: DatastoreLock;
   try {

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -423,7 +423,9 @@ async function runPostProcessorWithLock(
     lock = await owlbot.acquireLock(target);
   } catch (err) {
     if (err instanceof LockError) {
-      logger.info(`acquireLock failed: target=${target}`);
+      logger.info(
+        `acquireLock failed: target=${target} - post processor is likely already running from another trigger`
+      );
       return;
     } else {
       throw err;

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -102,19 +102,6 @@ function OwlBot(privateKey: string | undefined, app: Probot, db?: Db): void {
   app.on(['pull_request.labeled'], async context => {
     const head = context.payload.pull_request.head.repo.full_name;
     const [owner, repo] = head.split('/');
-    // Short-circuit if post-processor already running for this SHA:
-    const target = `${owner}_${repo}_${context.payload.pull_request.head.sha}`;
-    let lock: DatastoreLock;
-    try {
-      lock = await owlbot.acquireLock(target);
-    } catch (err) {
-      if (err instanceof LockError) {
-        logger.info(`acquireLock failed: target=${target}`);
-        return;
-      } else {
-        throw err;
-      }
-    }
     logger.info(
       `runPostProcessor: repo=${owner}/${repo} action=${context.payload.action} sha=${context.payload.pull_request.head.sha}`
     );
@@ -126,7 +113,6 @@ function OwlBot(privateKey: string | undefined, app: Probot, db?: Db): void {
       context.payload,
       context.octokit
     );
-    await lock.release();
   });
 
   // Did someone click the "Regenerate this pull request" checkbox?
@@ -186,24 +172,10 @@ function OwlBot(privateKey: string | undefined, app: Probot, db?: Db): void {
         return;
       }
 
-      // Short-circuit if post-processor already running for this SHA:
-      const target = `${owner}_${repo}_${context.payload.pull_request.head.sha}`;
-      let lock: DatastoreLock;
-      try {
-        lock = await owlbot.acquireLock(target);
-      } catch (err) {
-        if (err instanceof LockError) {
-          logger.info(`acquireLock failed: target=${target}`);
-          return;
-        } else {
-          throw err;
-        }
-      }
-
       logger.info(
         `runPostProcessor: repo=${owner}/${repo} action=${context.payload.action} sha=${context.payload.pull_request.head.sha}`
       );
-      await runPostProcessor(
+      await runPostProcessorWithLock(
         appId,
         privateKey,
         project,
@@ -217,10 +189,10 @@ function OwlBot(privateKey: string | undefined, app: Probot, db?: Db): void {
           owner,
           repo,
           defaultBranch,
+          sha: context.payload.pull_request.head.sha,
         },
         context.octokit
       );
-      lock.release();
     }
   );
 
@@ -369,7 +341,7 @@ async function handlePullRequestLabeled(
 
   // If label is explicitly added, run as if PR is made against default branch:
   const defaultBranch = payload?.repository?.default_branch;
-  await runPostProcessor(
+  await runPostProcessorWithLock(
     appId,
     privateKey,
     project,
@@ -383,6 +355,7 @@ async function handlePullRequestLabeled(
       owner,
       repo,
       defaultBranch,
+      sha: payload.pull_request.head.sha,
     },
     octokit,
     isBotAccount(payload.sender.login)
@@ -433,6 +406,44 @@ function isBotAccount(sender: string): boolean {
   return /.*\[bot]$/.test(sender);
 }
 
+async function runPostProcessorWithLock(
+  appId: number,
+  privateKey: string,
+  project: string,
+  trigger: string,
+  opts: RunPostProcessorOpts,
+  octokit: Octokit,
+  breakLoop = true
+) {
+  // Short-circuit if post-processor already running for this SHA:
+  const target = `${opts.owner}_${opts.repo}_${opts.sha}`;
+  let lock: DatastoreLock;
+  try {
+    lock = await owlbot.acquireLock(target);
+  } catch (err) {
+    if (err instanceof LockError) {
+      logger.info(`acquireLock failed: target=${target}`);
+      return;
+    } else {
+      throw err;
+    }
+  }
+
+  try {
+    return await runPostProcessor(
+      appId,
+      privateKey,
+      project,
+      trigger,
+      opts,
+      octokit,
+      breakLoop
+    );
+  } finally {
+    await lock.release();
+  }
+}
+
 interface RunPostProcessorOpts {
   head: string;
   base: string;
@@ -441,6 +452,7 @@ interface RunPostProcessorOpts {
   installation: number;
   owner: string;
   repo: string;
+  sha: string;
   defaultBranch?: string;
 }
 const runPostProcessor = async (

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -1776,6 +1776,9 @@ describe('locking behavior', () => {
     sandbox.replace(owlbot, 'acquireLock', async () => {
       return Promise.reject(new owlbot.LockError());
     });
+    const githubMock = nock('https://api.github.com')
+      .delete('/repos/googleapis/owl-bot-testing/issues/33/labels/owlbot%3Arun')
+      .reply(200);
     const payload = {
       action: 'labeled',
       installation: {
@@ -1817,6 +1820,7 @@ describe('locking behavior', () => {
       payload: payload as any,
       id: 'abc123',
     });
+    githubMock.done();
   });
   it('returns immediately from synchronize event if lock acquired in labeled event', async () => {
     let first = true;


### PR DESCRIPTION
Currently, owlbot obtains a lock on a owner/repo/sha as soon as an event that could trigger a post-processor event runs. Instead, it should only attempt to run the post-processor under a lock.

This change moves the lock acquisition to a helper that wraps the run post-processor logic. This allows the webhook handlers to do their pre-checks and clean up no matter if it actually ends up running the post-processor or not.

Fixes #3257 
