### PR TITLE
build(owl-bot): deploy backend in cloud run

### DIFF
--- a/packages/owl-bot/Dockerfile.backend
+++ b/packages/owl-bot/Dockerfile.backend
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/owl-bot/Dockerfile.backend
+++ b/packages/owl-bot/Dockerfile.backend
@@ -1,0 +1,49 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use a multi-stage docker build to limit production dependencies.
+
+# Use the official lightweight Node.js 14 image.
+# https://hub.docker.com/_/node
+FROM node:14-slim AS BUILD
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+# Copy application dependency manifests to the container image.
+# A wildcard is used to ensure copying both package.json AND package-lock.json (when available).
+# Copying this first prevents re-running npm install on every code change.
+COPY package*.json ./
+
+# Install build dependencies.
+RUN npm ci
+
+# Now copy all the code so we can compile
+COPY . ./
+
+RUN npm run compile
+
+FROM node:14-slim
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=BUILD /usr/src/app/build build
+RUN npm ci --only=production
+
+ENV NODE_ENV "production"
+
+# Run the web service on container startup.
+CMD [ "npm", "--no-update-notifier", "run", "start-backend" ]

--- a/packages/owl-bot/cloudbuild.yaml
+++ b/packages/owl-bot/cloudbuild.yaml
@@ -92,3 +92,44 @@ steps:
       # concurrency: We saw some errors in gRPC stack (#2265) with the default
       # 80 concurrency.
       - "40"
+
+  - name: gcr.io/cloud-builders/docker
+    id: "build-docker-backend"
+    waitFor: ["-"]
+    dir: packages/owl-bot
+    args:
+      - "build"
+      - "-f"
+      - "Dockerfile.backend"
+      - "-t"
+      - "gcr.io/$PROJECT_ID/owl-bot-backend"
+      - "."
+
+  - name: gcr.io/cloud-builders/docker
+    id: "push-docker-backend"
+    waitFor: ["build-docker-backend"]
+    args: ["push", "gcr.io/$PROJECT_ID/owl-bot-backend"]
+
+  - name: gcr.io/cloud-builders/gcloud
+    id: "deploy-cloud-run"
+    waitFor: ["push-docker-backend"]
+    entrypoint: bash
+    env:
+      - "IMAGE_NAME=gcr.io/$PROJECT_ID/owl-bot-backend"
+      - "SERVICE_NAME=owl-bot-backend"
+      - "MEMORY=1G"
+      # we could go higher
+      - "CONCURRENCY=20"
+    args:
+      - "-e"
+      - "./scripts/publish-cloud-run.sh"
+      - "$_DIRECTORY"
+      - "$PROJECT_ID"
+      - "$_BUCKET"
+      - "$_KEY_LOCATION"
+      - "$_KEY_RING"
+      - "$_FUNCTION_REGION"
+      # botName
+      - "owl-bot"
+      # timeout
+      - "3600"

--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -11,6 +11,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
+    "start-backend": "node ./build/src/server-backend.js",
     "start-frontend": "node ./build/src/server-frontend.js",
     "start:local": "probot run ./build/src/run-probot-locally.js",
     "clean": "gts clean",
@@ -75,7 +76,7 @@
     "firebase-admin": "^10.0.0",
     "fs-extra": "^10.0.0",
     "gaxios": "^4.3.0",
-    "gcf-utils": "^13.1.0",
+    "gcf-utils": "^13.2.0",
     "glob": "^7.1.7",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^8.5.1",

--- a/packages/owl-bot/src/server-backend.ts
+++ b/packages/owl-bot/src/server-backend.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/owl-bot/src/server-backend.ts
+++ b/packages/owl-bot/src/server-backend.ts
@@ -1,0 +1,44 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// eslint-disable-next-line node/no-extraneous-import
+import {Probot} from 'probot';
+import {GCFBootstrapper} from 'gcf-utils';
+
+import {owlbot} from './owl-bot';
+
+const bootstrap = new GCFBootstrapper({
+  taskTargetEnvironment: 'run',
+  taskTargetName: 'owl-bot-backend',
+});
+
+// Unlike other probot apps, owl-bot-post-processor requires the ability
+// to generate its own auth token for Cloud Build, we use the helper in
+// GCFBootstrapper to load this from Secret Manager:
+
+const server = bootstrap.server(
+  async (app: Probot) => {
+    const config = await bootstrap.getProbotConfig(false);
+    owlbot.OwlBot(config.privateKey, app);
+  },
+  {maxRetries: 10, maxPubSubRetries: 3}
+);
+
+const port = process.env.PORT ?? 8080;
+
+server
+  .listen(port, () => {
+    console.log(`Listening on port ${port}`);
+  })
+  .setTimeout(0); // Disable automatic timeout on incoming connections.


### PR DESCRIPTION
This should be safely deployed because there's no changes in the
frontend and cloud functions deployment.

After deploying the backend, we can change the task target in the
frontend to switch the backend.

Towards #3318 