### PR TITLE
build(owl-bot): route traffic to the cloud-run backend

### DIFF
--- a/packages/owl-bot/src/server-frontend.ts
+++ b/packages/owl-bot/src/server-frontend.ts
@@ -17,7 +17,8 @@ import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
 const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
+  taskTargetEnvironment: 'run',
+  taskTargetName: 'owl-bot-backend',
 });
 
 // We only need to deploy gcf-utils in the frontend server because only thing


### PR DESCRIPTION
fixes #3318 

This PR will change the task target to the backend deployed in Cloud Run.