### PR TITLE
Revert "build(owl-bot): route traffic to the cloud-run backend"

### DIFF
--- a/packages/owl-bot/src/server-frontend.ts
+++ b/packages/owl-bot/src/server-frontend.ts
@@ -17,8 +17,7 @@ import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
 const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'run',
-  taskTargetName: 'owl-bot-backend',
+  taskTargetEnvironment: 'functions',
 });
 
 // We only need to deploy gcf-utils in the frontend server because only thing


### PR DESCRIPTION
Reverts googleapis/repo-automation-bots#3322

This PR is to revert the routing change in #3322.