### PR TITLE
fix: Auto-label/size-label bot size calculations should be changed

### DIFF
--- a/packages/auto-label/README.md
+++ b/packages/auto-label/README.md
@@ -143,18 +143,18 @@ staleness:
 Bot runs on a pull request when it changes and labels them with T-shirt size indicator if feature is enabled. 
 
 Currently there are following labels available:
+  `size: u` for empty pull request.
 
-  `size: xs` for pull request with less than 50 changes.
+  `size: xs` for pull request with less than 10 changes.
   
-  `size: s` for pull request with less than 250 changes.
+  `size: s` for pull request with less than 50 changes.
   
-  `size: m` for pull request with less than 1000 changes.
+  `size: m` for pull request with less than 250 changes.
   
-  `size: l` for pull request with less than 1250 changes.
+  `size: l` for pull request with less than 1000 changes.
   
-  `size: xl` for pull request with less than 1500 changes.
-  
-  `size: xxl` for pull request with more than 1500 changes.
+  `size: xl` for pull request with 1000 or more changes.
+
   
 
 Size labeling is turned off by default. To turn on size labeling:

--- a/packages/auto-label/src/helper.ts
+++ b/packages/auto-label/src/helper.ts
@@ -61,43 +61,43 @@ export const DEFAULT_CONFIGS = {
  * Given a fact that by default pull request size labeling feature is off,
  * we will update those labels in repo only when configuration is enabled
  * Currently there are following labels available:
- *   "size: xs" for pull request with less than 50 changes.
- *   "size: s" for pull request with less than 250 changes.
- *   "size: m" for pull request with less than 1000 changes.
- *   "size: l" for pull request with less than 1250 changes.
- *   "size: xl" for pull request with less than 1500 changes.
- *   "size: xxl" for pull request with more than 1500 changes.
+ *   "size: u" for empty pull request.
+ *   "size: xs" for pull request with less than 10 changes.
+ *   "size: s" for pull request with less than 50 changes.
+ *   "size: m" for pull request with less than 250 changes.
+ *   "size: l" for pull request with less than 1000 changes.
+ *   "size: xl" for pull request with 1000 or more changes.
  */
 export const PULL_REQUEST_SIZE_LABELS = [
   {
+    name: 'size: u',
+    description: 'Pull request is empty.',
+    color: 'a2ff00',
+  },
+  {
     name: 'size: xs',
     description: 'Pull request size is extra small.',
-    color: '2deb01',
+    color: '00ff4b',
   },
   {
     name: 'size: s',
     description: 'Pull request size is small.',
-    color: '2cc785',
+    color: '9cfa00',
   },
   {
     name: 'size: m',
     description: 'Pull request size is medium.',
-    color: '5d743d',
+    color: 'effa00',
   },
   {
     name: 'size: l',
     description: 'Pull request size is large.',
-    color: 'd65692',
+    color: 'ff7a00',
   },
   {
     name: 'size: xl',
     description: 'Pull request size is extra large.',
-    color: '912925',
-  },
-  {
-    name: 'size: xxl',
-    description: 'Pull request size is extra extra large.',
-    color: 'd22b5f',
+    color: 'c6040f',
   },
 ];
 
@@ -150,18 +150,18 @@ export function isExpiredByDays(time: string, limit: number) {
  * Checks whether the intended label already exists by given prefix
  */
 export function getPullRequestSize(changes: number): string {
-  if (changes >= 1500) {
-    return 'xxl';
-  } else if (changes >= 1250) {
-    return 'xl';
-  } else if (changes >= 1000) {
-    return 'l';
-  } else if (changes >= 250) {
-    return 'm';
-  } else if (changes >= 50) {
+  if (changes <= 0) {
+    return 'u';
+  } else if (changes < 10) {
+    return 'xs';
+  } else if (changes < 50) {
     return 's';
+  } else if (changes < 250) {
+    return 'm';
+  } else if (changes < 1000) {
+    return 'l';
   }
-  return 'xs';
+  return 'xl';
 }
 
 // *** Helper functions for product type labels ***

--- a/packages/auto-label/test/auto-label.ts
+++ b/packages/auto-label/test/auto-label.ts
@@ -301,7 +301,7 @@ describe('auto-label', () => {
         './events/pr_opened_files.json'
       ));
       const expected_labels = {
-        labels: ['size: s'],
+        labels: ['size: m'],
       };
       const ghRequests = nock('https://api.github.com')
         .get('/repos/testOwner/testRepo/pulls/12/files')
@@ -341,15 +341,15 @@ describe('auto-label', () => {
         './events/pr_opened_files.json'
       ));
       const expected_labels = {
-        labels: ['size: s'],
+        labels: ['size: m'],
       };
       const ghRequests = nock('https://api.github.com')
         .get('/repos/testOwner/testRepo/pulls/12/files')
         .reply(200, pr_files_payload)
-        .delete('/repos/testOwner/testRepo/issues/12/labels/size%3A%20xxl')
+        .delete('/repos/testOwner/testRepo/issues/12/labels/size%3A%20xl')
         .reply(200, [
           {
-            name: 'size: xxl',
+            name: 'size: xl',
             color: 'C9FFE5',
           },
         ])

--- a/packages/auto-label/test/fixtures/events/pr_updates_size_change.json
+++ b/packages/auto-label/test/fixtures/events/pr_updates_size_change.json
@@ -50,7 +50,7 @@
 
     ],
     "labels": [
-      {"name": "size: xxl"}
+      {"name": "size: xl"}
     ],
     "milestone": null,
     "draft": false,


### PR DESCRIPTION
Changing the T-Shirt size categories and providing an ability to mark empty pull requests

Fixes #[3324](https://github.com/googleapis/repo-automation-bots/issues/3324) 🦕
