### PR TITLE
feat(trusted-contribution): track label added metric

### DIFF
--- a/packages/trusted-contribution/test/trusted-contribution.ts
+++ b/packages/trusted-contribution/test/trusted-contribution.ts
@@ -19,6 +19,7 @@ import {resolve} from 'path';
 import {Probot, createProbot, ProbotOctokit} from 'probot';
 import {
   PullRequestOpenedEvent,
+  PullRequestLabeledEvent,
   PullRequestSynchronizeEvent,
 } from '@octokit/webhooks-types';
 // eslint-disable-next-line node/no-extraneous-import
@@ -860,6 +861,70 @@ describe('TrustedContributionTestRunner', () => {
         id: 'abc123',
       });
       requests.done();
+    });
+  });
+
+  describe('pull_request.labeled', () => {
+    it('logs metric for pull_request.labeled, if run label is present', async () => {
+      const metricStub = sandbox.stub(logger, 'metric');
+      await probot.receive({
+        name: 'pull_request',
+        payload: {
+          action: 'labeled',
+          pull_request: {
+            number: 3,
+            head: {
+              sha: 'testsha',
+            },
+            user: {
+              login: 'renovate-bot',
+            },
+            labels: [{name: 'kokoro:run'}],
+          },
+          repository: {
+            name: 'google-auth-library-java',
+            owner: {
+              login: 'chingor13',
+            },
+          },
+          sender: {
+            login: 'bcoe',
+          },
+        } as PullRequestLabeledEvent,
+        id: 'abc123',
+      });
+      assert.ok(metricStub.calledOnce);
+    });
+
+    it('does not log metric for pull_request.labeled, if no run label', async () => {
+      const metricStub = sandbox.stub(logger, 'metric');
+      await probot.receive({
+        name: 'pull_request',
+        payload: {
+          action: 'labeled',
+          pull_request: {
+            number: 3,
+            head: {
+              sha: 'testsha',
+            },
+            user: {
+              login: 'renovate-bot',
+            },
+            labels: [{name: 'cla: yes'}],
+          },
+          repository: {
+            name: 'google-auth-library-java',
+            owner: {
+              login: 'chingor13',
+            },
+          },
+          sender: {
+            login: 'bcoe',
+          },
+        } as PullRequestLabeledEvent,
+        id: 'abc123',
+      });
+      assert.ok(metricStub.notCalled);
     });
   });
 });


### PR DESCRIPTION
Log a metric that can be used to guesstimate how often a user manually adds kokoro: run.

