### PR TITLE
metrics(trusted_contribution): log "unnecessary" run_label_added/synchronize

### DIFF
--- a/packages/trusted-contribution/test/trusted-contribution.ts
+++ b/packages/trusted-contribution/test/trusted-contribution.ts
@@ -875,6 +875,15 @@ describe('TrustedContributionTestRunner', () => {
             number: 3,
             head: {
               sha: 'testsha',
+              repo: {
+                full_name: 'googleapis/foo',
+              },
+            },
+            base: {
+              sha: 'testsha',
+              repo: {
+                full_name: 'googleapis/foo',
+              },
             },
             user: {
               login: 'renovate-bot',
@@ -906,11 +915,60 @@ describe('TrustedContributionTestRunner', () => {
             number: 3,
             head: {
               sha: 'testsha',
+              repo: {
+                full_name: 'googleapis/foo',
+              },
+            },
+            base: {
+              sha: 'testsha',
+              repo: {
+                full_name: 'googleapis/foo',
+              },
             },
             user: {
               login: 'renovate-bot',
             },
             labels: [{name: 'cla: yes'}],
+          },
+          repository: {
+            name: 'google-auth-library-java',
+            owner: {
+              login: 'chingor13',
+            },
+          },
+          sender: {
+            login: 'bcoe',
+          },
+        } as PullRequestLabeledEvent,
+        id: 'abc123',
+      });
+      assert.ok(metricStub.notCalled);
+    });
+
+    it('does not log metric for pull_request.labeled, of label added to external PR', async () => {
+      const metricStub = sandbox.stub(logger, 'metric');
+      await probot.receive({
+        name: 'pull_request',
+        payload: {
+          action: 'labeled',
+          pull_request: {
+            number: 3,
+            head: {
+              sha: 'testsha',
+              repo: {
+                full_name: 'googleapis/foo',
+              },
+            },
+            base: {
+              sha: 'testsha',
+              repo: {
+                full_name: 'external/foo',
+              },
+            },
+            user: {
+              login: 'renovate-bot',
+            },
+            labels: [{name: 'kokoro:run'}],
           },
           repository: {
             name: 'google-auth-library-java',


### PR DESCRIPTION
We care about `run_label_added`, or `synchronize` being clicked, if it should have not been necessary.

For forks of repositories, it's expected that labels need to be added (for external contributors). When the label is added manually on a non-fork, probably it's that something went wrong.