### PR TITLE
test(canary-bot): test the new gcf-utils with Cloud Functions backend

### DIFF
--- a/packages/canary-bot/src/server.ts
+++ b/packages/canary-bot/src/server.ts
@@ -15,7 +15,9 @@
 import {GCFBootstrapper} from 'gcf-utils';
 import appFn from './canary-bot';
 
-const bootstrap = new GCFBootstrapper();
+const bootstrap = new GCFBootstrapper({
+  taskTargetEnvironment: 'functions',
+});
 
 const server = bootstrap.server(appFn);
 const port = process.env.PORT ?? 8080;


### PR DESCRIPTION
It turned out that the previous PR targets the backend in Cloud Run.
We need to explicitly specify functions backend.