### PR TITLE
fix(canary-bot): specify the correct task target name

### DIFF
--- a/packages/canary-bot/src/server.ts
+++ b/packages/canary-bot/src/server.ts
@@ -17,6 +17,7 @@ import appFn from './canary-bot';
 
 const bootstrap = new GCFBootstrapper({
   taskTargetEnvironment: 'functions',
+  taskTargetName: 'canary_bot',
 });
 
 const server = bootstrap.server(appFn);


### PR DESCRIPTION
Otherwise it enqueues a task with a wrong target name
(canary_bot_cloud_run).