### PR TITLE
chore(canary-bot): use debug version of gcf-utils

### DIFF
--- a/packages/canary-bot/package-lock.json
+++ b/packages/canary-bot/package-lock.json
@@ -2744,9 +2744,9 @@
       }
     },
     "gcf-utils": {
-      "version": "13.3.2-beta.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.3.2-beta.0.tgz",
-      "integrity": "sha512-gULGQc29vPKU9aTKv6G7juYB2OF6IGcxe0ROcMdDCEcTPo5BcMqWMt8CcKzN12ZqPDorFtMWAy1K/h7BL2iJ7Q==",
+      "version": "13.3.2-beta.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.3.2-beta.1.tgz",
+      "integrity": "sha512-4VUrFCqOSD6HriHUtPjTj/YEDEsDjwhTep0xFkMYqeMv6L6M6Y8pWAqkz4Lh0YKjsGKvwm+HKOx6J28M088NSA==",
       "requires": {
         "@google-cloud/kms": "^2.4.2",
         "@google-cloud/secret-manager": "^3.7.3",

--- a/packages/canary-bot/package.json
+++ b/packages/canary-bot/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "dayjs": "^1.10.7",
-    "gcf-utils": "13.3.2-beta.0"
+    "gcf-utils": "13.3.2-beta.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",


### PR DESCRIPTION
To debug HTTP 400.
