### PR TITLE
feat(label-sync): add label for automation-team

### DIFF
--- a/packages/label-sync/src/labels.json
+++ b/packages/label-sync/src/labels.json
@@ -11,6 +11,11 @@
       "color": "#6950f6"
     },
     {
+      "name": "automation-team",
+      "description": "Label added to repositories owned by the automation team",
+      "color": "#6950f6"
+    },
+    {
       "name": "eol",
       "description": "End of life. Deprecating support for a previous version.",
       "color": "c9abb2"


### PR DESCRIPTION
Start differentiating between automation work and core Node.js work.