### PR TITLE
chore(canary-bot): Use gcf-utils 13.3.0

### DIFF
--- a/packages/canary-bot/cloudbuild.yaml
+++ b/packages/canary-bot/cloudbuild.yaml
@@ -63,7 +63,7 @@ steps:
     id: "push-docker"
     waitFor: ["build-docker"]
     args: ["push", "gcr.io/$PROJECT_ID/canary-bot-cloud-run"]
-  
+
   - name: gcr.io/cloud-builders/gcloud
     id: "deploy-cloud-run"
     waitFor: ["push-docker"]
@@ -86,6 +86,7 @@ steps:
     entrypoint: bash
     env:
       - "SERVICE_NAME=canary-bot-cloud-run-backend"
+      - "SECURE_ACCESS=true"
     args:
       - "-e"
       - "./scripts/publish-cloud-run.sh"

--- a/packages/canary-bot/package-lock.json
+++ b/packages/canary-bot/package-lock.json
@@ -176,9 +176,9 @@
       }
     },
     "@googleapis/run": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@googleapis/run/-/run-7.0.1.tgz",
-      "integrity": "sha512-s6F9k02jngKXXR5lErHA9OTpC7+iZ5q5hun/RnPS7dfWXbnrc4NlmcVctIwIi42eo3xOWaUdx5yv/uFljoFoTQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@googleapis/run/-/run-8.0.1.tgz",
+      "integrity": "sha512-3jLWfEhyDMT65Bk5rPmdej9GZs9bZCSdW9j/nxWylM8NL5RpfiWUXXrPMr7kyOpkW3T4dgQOLLu2WEFDl1jszg==",
       "requires": {
         "googleapis-common": "^5.0.1"
       }
@@ -2744,15 +2744,15 @@
       }
     },
     "gcf-utils": {
-      "version": "13.3.2-beta.1",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.3.2-beta.1.tgz",
-      "integrity": "sha512-4VUrFCqOSD6HriHUtPjTj/YEDEsDjwhTep0xFkMYqeMv6L6M6Y8pWAqkz4Lh0YKjsGKvwm+HKOx6J28M088NSA==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.3.0.tgz",
+      "integrity": "sha512-3fycebqpy9aLJvckDDfzGimiOE72RA51pGMWny4+ApIxSMXEHG5TnbXTK+bSjM076VmJXMVtCXFjZTOTWMjuug==",
       "requires": {
         "@google-cloud/kms": "^2.4.2",
         "@google-cloud/secret-manager": "^3.7.3",
         "@google-cloud/storage": "^5.8.5",
         "@google-cloud/tasks": "^2.3.4",
-        "@googleapis/run": "^7.0.0",
+        "@googleapis/run": "^8.0.0",
         "@octokit/plugin-enterprise-compatibility": "1.3.0",
         "@octokit/rest": "^18.5.2",
         "@probot/octokit-plugin-config": "^1.0.0",

--- a/packages/canary-bot/package.json
+++ b/packages/canary-bot/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "dayjs": "^1.10.7",
-    "gcf-utils": "13.3.2-beta.1"
+    "gcf-utils": "^13.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",

--- a/packages/canary-bot/src/server.ts
+++ b/packages/canary-bot/src/server.ts
@@ -16,8 +16,8 @@ import {GCFBootstrapper} from 'gcf-utils';
 import appFn from './canary-bot';
 
 const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-  taskTargetName: 'canary_bot',
+  taskTargetEnvironment: 'run',
+  taskTargetName: 'canary-bot-cloud-run-backend',
 });
 
 const server = bootstrap.server(appFn);

--- a/scripts/publish-cloud-run.sh
+++ b/scripts/publish-cloud-run.sh
@@ -115,11 +115,13 @@ fi
 echo "About to cloud run app ${SERVICE_NAME}"
 gcloud run deploy "${SERVICE_NAME}" "${deployArgs[@]}"
 
-echo "Adding ability for allUsers to execute the Function"
-gcloud run services add-iam-policy-binding "${SERVICE_NAME}" \
-  --member="allUsers" \
-  --region "${region}" \
-  --role="roles/run.invoker"
+if [ -z "${SECURE_ACCESS}" ]; then
+  echo "Adding ability for allUsers to execute the service"
+  gcloud run services add-iam-policy-binding "${SERVICE_NAME}" \
+    --member="allUsers" \
+    --region "${region}" \
+    --role="roles/run.invoker"
+fi
 
 echo "Deploying Queue ${queueName}"
 


### PR DESCRIPTION
Also route the canary-bot-cloud-run to the Cloud Run backend and narrow the backend access.