### PR TITLE
fix(label-sync): colors must be unique

### DIFF
--- a/packages/label-sync/src/labels.json
+++ b/packages/label-sync/src/labels.json
@@ -8,12 +8,12 @@
     {
       "name": "api: N/A",
       "description": "Tells auto-label to not auto-detect the API for this issue",
-      "color": "#6950f6"
+      "color": "#6950f5"
     },
     {
       "name": "automation-team",
       "description": "Label added to repositories owned by the automation team",
-      "color": "#6950f6"
+      "color": "#505050"
     },
     {
       "name": "eol",


### PR DESCRIPTION
I broke label sync by having colors that weren't unique (TIL).

I changed both colliding labels because I believe we're not in a broken state.