### PR TITLE
Revert "build(owl-bot): route traffic to the cloud run backend (#3383)"

### DIFF
--- a/packages/owl-bot/src/server-frontend.ts
+++ b/packages/owl-bot/src/server-frontend.ts
@@ -17,8 +17,7 @@ import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
 const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'run',
-  taskTargetName: 'owl-bot-backend',
+  taskTargetEnvironment: 'functions',
 });
 
 // We only need to deploy gcf-utils in the frontend server because only thing


### PR DESCRIPTION
This reverts commit 023b62716a172e94fb225e0a2b0960183ae879cc.

This is to roll back owl-bot.