### PR TITLE
Revert "build(owl-bot): route tasks to Cloud Run backend"

### DIFF
--- a/packages/owl-bot/src/server-frontend.ts
+++ b/packages/owl-bot/src/server-frontend.ts
@@ -17,8 +17,7 @@ import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
 const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'run',
-  taskTargetName: 'owl-bot-backend',
+  taskTargetEnvironment: 'functions',
 });
 
 // We only need to deploy gcf-utils in the frontend server because only thing


### PR DESCRIPTION
Reverts googleapis/repo-automation-bots#3387

This reverts Cloud task to the original owl-bot Cloud Functions backend.
