### PR TITLE
build(owl-bot): temporarily disable signature verification

### DIFF
--- a/packages/owl-bot/src/server-backend.ts
+++ b/packages/owl-bot/src/server-backend.ts
@@ -32,7 +32,8 @@ const server = bootstrap.server(
     const config = await bootstrap.getProbotConfig(false);
     owlbot.OwlBot(config.privateKey, app);
   },
-  {maxRetries: 10, maxPubSubRetries: 3}
+  // Temporary skip the signature verification for debugging.
+  {maxRetries: 10, maxPubSubRetries: 3, skipVerification: true}
 );
 
 const port = process.env.PORT ?? 8080;


### PR DESCRIPTION
This is solely for debugging purposes.

I will craft a Cloud Task task pointing to the Cloud Run service and verify the backend service is working correctly.
