### PR TITLE
build(owl-bot): use owl-bot service account for the backend

### DIFF
--- a/packages/owl-bot/cloudbuild.yaml
+++ b/packages/owl-bot/cloudbuild.yaml
@@ -122,6 +122,7 @@ steps:
       - "IMAGE_NAME=gcr.io/$PROJECT_ID/owl-bot-backend"
       - "SERVICE_NAME=owl-bot-backend"
       - "MEMORY=4G"
+      - "SERVICE_ACCOUNT=owl-bot-web-backend@repo-automation-bots.iam.gserviceaccount.com"
       # we could go higher
       - "CONCURRENCY=20"
       # Substitutions


### PR DESCRIPTION
I just created the service account "owl-bot-web-backend@repo-automation-bots.iam.gserviceaccount.com" and added necessary permissions.