### PR TITLE
debug(owl-bot): log build error

### DIFF
--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -163,7 +163,9 @@ export async function triggerPostProcessBuild(
     return {detailsURL, ...summarizeBuild(build)};
   } catch (e) {
     const err = e as Error;
-    logger.error(err);
+    logger.error(`triggerPostProcessBuild: ${err.message}`, {
+      stack: err.stack,
+    });
     return buildFailureFrom(detailsURL);
   }
 }


### PR DESCRIPTION
Make it easier to detect a build error in logs.

Refs: #3402 