### PR TITLE
Revert "chore(owl-bot): change the routing to Cloud Run backend"

### DIFF
--- a/packages/owl-bot/src/server-frontend.ts
+++ b/packages/owl-bot/src/server-frontend.ts
@@ -17,8 +17,7 @@ import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
 const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'run',
-  taskTargetName: 'owl-bot-backend',
+  taskTargetEnvironment: 'functions',
 });
 
 // We only need to deploy gcf-utils in the frontend server because only thing


### PR DESCRIPTION
Reverts googleapis/repo-automation-bots#3412

This is to revert the change for routing Cloud Task to Cloud Run backend. If anyone finds owl-bot is not working properly, you can approve this and merge this.