### PR TITLE
fix: receiving unhandled rejection applying label to java-cloud-bom

### DIFF
--- a/packages/auto-label/src/auto-label.ts
+++ b/packages/auto-label/src/auto-label.ts
@@ -417,23 +417,35 @@ async function updatePullRequestSizeLabel(
       logger.info(
         `Deleting ${size_label.name} in ${owner}/${repo}/${pull_number}...`
       );
-      context.octokit.issues.removeLabel({
-        owner,
-        repo,
-        issue_number: pull_number,
-        name: size_label.name,
-      });
+      context.octokit.issues
+        .removeLabel({
+          owner,
+          repo,
+          issue_number: pull_number,
+          name: size_label.name,
+        })
+        .catch(e => {
+          logger.warn(
+            `removeLabel failed for size label ${size_label.name} in ${owner}/${repo}/${pull_number}: ${e}`
+          );
+        });
     }
     // Update the PR size label
     logger.info(
       `Request size label added to PR #${pull_number} in ${owner}/${repo}, label is "${pr_size}"`
     );
-    await context.octokit.issues.addLabels({
-      owner,
-      repo,
-      issue_number: pull_number,
-      labels: [pr_size],
-    });
+    await context.octokit.issues
+      .addLabels({
+        owner,
+        repo,
+        issue_number: pull_number,
+        labels: [pr_size],
+      })
+      .catch(e => {
+        logger.warn(
+          `addLabels failed for size label ${pr_size} in ${owner}/${repo}/${pull_number}: ${e}`
+        );
+      });
   }
 }
 


### PR DESCRIPTION
We are getting "HttpError: Label does not exist" on `addLabels` call. Based on https://octokit.github.io/rest.js/v18, such error could be thrown only on `removeLabel` API only - to be sure to outcome GitHub bug, the fix should be wrap calls in `catch` to avoid crash.  

Fixes #[3429](https://github.com/googleapis/repo-automation-bots/issues/3429) 🦕
