### PR TITLE
deps: update release-please to 13.10.2

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -14,7 +14,7 @@
         "@octokit/rest": "^18.12.0",
         "@octokit/webhooks": "^9.20.0",
         "gcf-utils": "^13.1.0",
-        "release-please": "^13.8.0"
+        "release-please": "^13.10.2"
       },
       "devDependencies": {
         "@types/mocha": "^9.0.0",
@@ -7497,9 +7497,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.8.0.tgz",
-      "integrity": "sha512-J3F+M5ihrC3wpRiW1+wpoujL7tVwBBggPbnPejK+nmfjZbLoaDvv0JAjdd92iATL8jzdyV4RLHPoz6YMfIhZFA==",
+      "version": "13.10.2",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.10.2.tgz",
+      "integrity": "sha512-1BRdxKIZXTNDdhiJGFQkO4cEizxg/aj5+TcZpmnGBDBO/oZoPd87yACpFfT2P0aJJEPTTKcS40vYR8YNekeHdA==",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",
@@ -15070,9 +15070,9 @@
       }
     },
     "release-please": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.8.0.tgz",
-      "integrity": "sha512-J3F+M5ihrC3wpRiW1+wpoujL7tVwBBggPbnPejK+nmfjZbLoaDvv0JAjdd92iATL8jzdyV4RLHPoz6YMfIhZFA==",
+      "version": "13.10.2",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.10.2.tgz",
+      "integrity": "sha512-1BRdxKIZXTNDdhiJGFQkO4cEizxg/aj5+TcZpmnGBDBO/oZoPd87yACpFfT2P0aJJEPTTKcS40vYR8YNekeHdA==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -33,7 +33,7 @@
     "@octokit/webhooks": "^9.20.0",
     "@octokit/rest": "^18.12.0",
     "gcf-utils": "^13.1.0",
-    "release-please": "^13.8.0"
+    "release-please": "^13.10.2"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",


### PR DESCRIPTION
### Bug Fixes

* bump retries for pull request iterator from 1 to 3
* don't crash when pull request iterator GraphQL returns no response
* fixed maxResults check in tag and release iterators
* GraphQL retry now uses exponential backoff
* **java:** snapshots should bump versionsMap versions
* **ruby-yoshi:** Remove bolded scope and fix link removal