### PR TITLE
build: use dedicated service accounts

### DIFF
--- a/packages/generated-files-bot/cloudbuild.yaml
+++ b/packages/generated-files-bot/cloudbuild.yaml
@@ -26,6 +26,8 @@ steps:
     id: "publish-function"
     waitFor: ["build"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=web-backend@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-function.sh"

--- a/packages/header-checker-lint/cloudbuild.yaml
+++ b/packages/header-checker-lint/cloudbuild.yaml
@@ -26,6 +26,8 @@ steps:
     id: "publish-function"
     waitFor: ["build"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=web-backend@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-function.sh"

--- a/packages/merge-on-green/cloudbuild.yaml
+++ b/packages/merge-on-green/cloudbuild.yaml
@@ -26,6 +26,8 @@ steps:
     id: "publish-function"
     waitFor: ["build"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=web-backend@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-function.sh"

--- a/packages/policy/cloudbuild.yaml
+++ b/packages/policy/cloudbuild.yaml
@@ -26,6 +26,8 @@ steps:
     id: "publish-function"
     waitFor: ["build"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=policy-bot-backend@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-function.sh"


### PR DESCRIPTION
for the following 4 bots:
- generated-files-bot
- header-checker-lint
- merge-on-green
- policy

The policy-bot is using its own service account because it needs
BigQuery permission.

part of #3424 