### PR TITLE
build: use web-backend service account for bot deployments

### DIFF
--- a/packages/release-please/cloudbuild.yaml
+++ b/packages/release-please/cloudbuild.yaml
@@ -26,6 +26,8 @@ steps:
     id: "publish-function"
     waitFor: ["build"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=web-backend@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-function.sh"
@@ -70,6 +72,8 @@ steps:
     id: "deploy-cloud-run"
     waitFor: ["push-docker"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=web-frontend@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-cloud-run.sh"

--- a/packages/snippet-bot/cloudbuild.yaml
+++ b/packages/snippet-bot/cloudbuild.yaml
@@ -26,6 +26,8 @@ steps:
     id: "publish-function"
     waitFor: ["build"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=web-backend@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-function.sh"
@@ -70,6 +72,8 @@ steps:
     id: "deploy-cloud-run"
     waitFor: ["push-docker"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=web-frontend@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-cloud-run.sh"

--- a/packages/sync-repo-settings/cloudbuild.yaml
+++ b/packages/sync-repo-settings/cloudbuild.yaml
@@ -26,6 +26,8 @@ steps:
     id: "publish-function"
     waitFor: ["build"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=web-backend@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-function.sh"

--- a/packages/trusted-contribution/cloudbuild.yaml
+++ b/packages/trusted-contribution/cloudbuild.yaml
@@ -26,6 +26,8 @@ steps:
     id: "publish-function"
     waitFor: ["build"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=web-backend@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-function.sh"


### PR DESCRIPTION
for the following 4 bots:
- release-please
- snippet-bot
- sync-repo-settings
- trusted-contribution

part of #3424
