### PR TITLE
feat: instantiate new child logger for each request

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -480,9 +480,14 @@ export class GCFBootstrapper {
         return;
       }
 
-      const requestLogger = logger.child(
-        buildTriggerInfo(triggerType, id, name, request.body)
-      );
+      /**
+       * Note: any logs written before resetting bindings may contain
+       * bindings from previous executions
+       */
+      const triggerInfo = buildTriggerInfo(triggerType, id, name, request.body);
+      logger.resetBindings();
+      logger.addBindings(triggerInfo);
+      const requestLogger = logger.child(triggerInfo);
       try {
         if (triggerType === TriggerType.UNKNOWN) {
           response.sendStatus(400);

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -534,6 +534,7 @@ export class GCFBootstrapper {
             return;
           }
 
+          setContextLogger(payload, requestLogger);
           // TODO: find out the best way to get this type, and whether we can
           // keep using a custom event name.
           await this.probot.receive({
@@ -541,11 +542,8 @@ export class GCFBootstrapper {
             name: name as any,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             id: id as any,
-            payload: {
-              ...payload,
-              logger: requestLogger,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            } as any,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            payload: payload as any,
           });
         } else if (triggerType === TriggerType.GITHUB) {
           await this.enqueueTask({
@@ -1121,6 +1119,11 @@ export class GCFBootstrapper {
       return payload;
     }
   }
+}
+
+// Helper to inject the request logger
+function setContextLogger(payload, logger: GCFLogger) {
+  payload.logger = logger;
 }
 
 // Helper to extract the request logger from the request payload.

--- a/packages/gcf-utils/src/logging/gcf-logger.ts
+++ b/packages/gcf-utils/src/logging/gcf-logger.ts
@@ -33,6 +33,7 @@ export class GCFLogger {
     this.warn = this.warn.bind(this);
     this.metric = this.metric.bind(this);
     this.error = this.error.bind(this);
+    this.child = this.child.bind(this);
   }
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -160,6 +161,16 @@ export class GCFLogger {
    */
   public addBindings(properties: object) {
     this.pino = this.pino.child(properties);
+  }
+
+  /**
+   * Return a new child logger with attached static properties to all logs
+   * @param properties static properties to bind
+   */
+  public child(properties: object): GCFLogger {
+    const child = new GCFLogger(this.destination);
+    child.addBindings(properties);
+    return child;
   }
 
   /**

--- a/packages/gcf-utils/src/logging/trigger-info-builder.ts
+++ b/packages/gcf-utils/src/logging/trigger-info-builder.ts
@@ -67,15 +67,16 @@ export function buildTriggerInfo(
     triggerInfo.trigger.github_delivery_guid = githubDeliveryGUID;
   }
 
-  // if (triggerType === TriggerType.GITHUB) {
-  const webhookProperties = {
-    trigger_source_repo: getRepositoryDetails(requestBody),
-    trigger_sender: requestBody.sender?.login || UNKNOWN,
-    payload_hash: getPayloadHash(requestBody),
-    github_event_type: getEventTypeDetails(githubEventName, requestBody.action),
-  };
-  triggerInfo.trigger = {...webhookProperties, ...triggerInfo.trigger};
-  // }
+  // TODO: include these properties in more event types
+  if (triggerType === TriggerType.GITHUB) {
+    const webhookProperties = {
+      trigger_source_repo: getRepositoryDetails(requestBody),
+      trigger_sender: requestBody.sender?.login || UNKNOWN,
+      payload_hash: getPayloadHash(requestBody),
+      github_event_type: getEventTypeDetails(githubEventName, requestBody.action),
+    };
+    triggerInfo.trigger = {...webhookProperties, ...triggerInfo.trigger};
+  }
 
   return triggerInfo;
 }

--- a/packages/gcf-utils/src/logging/trigger-info-builder.ts
+++ b/packages/gcf-utils/src/logging/trigger-info-builder.ts
@@ -73,7 +73,10 @@ export function buildTriggerInfo(
       trigger_source_repo: getRepositoryDetails(requestBody),
       trigger_sender: requestBody.sender?.login || UNKNOWN,
       payload_hash: getPayloadHash(requestBody),
-      github_event_type: getEventTypeDetails(githubEventName, requestBody.action),
+      github_event_type: getEventTypeDetails(
+        githubEventName,
+        requestBody.action
+      ),
     };
     triggerInfo.trigger = {...webhookProperties, ...triggerInfo.trigger};
   }

--- a/packages/gcf-utils/src/logging/trigger-info-builder.ts
+++ b/packages/gcf-utils/src/logging/trigger-info-builder.ts
@@ -67,18 +67,15 @@ export function buildTriggerInfo(
     triggerInfo.trigger.github_delivery_guid = githubDeliveryGUID;
   }
 
-  if (triggerType === TriggerType.GITHUB) {
-    const webhookProperties = {
-      trigger_source_repo: getRepositoryDetails(requestBody),
-      trigger_sender: requestBody.sender?.login || UNKNOWN,
-      payload_hash: getPayloadHash(requestBody),
-      github_event_type: getEventTypeDetails(
-        githubEventName,
-        requestBody.action
-      ),
-    };
-    triggerInfo.trigger = {...webhookProperties, ...triggerInfo.trigger};
-  }
+  // if (triggerType === TriggerType.GITHUB) {
+  const webhookProperties = {
+    trigger_source_repo: getRepositoryDetails(requestBody),
+    trigger_sender: requestBody.sender?.login || UNKNOWN,
+    payload_hash: getPayloadHash(requestBody),
+    github_event_type: getEventTypeDetails(githubEventName, requestBody.action),
+  };
+  triggerInfo.trigger = {...webhookProperties, ...triggerInfo.trigger};
+  // }
 
   return triggerInfo;
 }


### PR DESCRIPTION
probot does not expose a way to provide a per-request logger to the event handler function. Instead, we inject our own into the payload and extract within the handler.

```ts
import {getContextLogger} from 'gcf-utils';
// ...

app.on('event', async context => {
  const logger = getContextLogger(context);
  logger.info('some message');  
});
```

You can still `import {logger} from 'gcf-utils'` which will get you the root logger, but it will not have any context values set.

Note: `context.log` can be set/configured (and [we are](https://github.com/googleapis/repo-automation-bots/pull/3459/files#diff-2d10ce1b796b0a4b6f0cbcfb880b8921d11a4710fe6af0f89c85c1abf8ce64fdR340)), but it cannot be modified per-request.

Fixes #3421 