### PR TITLE
build(label-sync): use web-backend service account

### DIFF
--- a/packages/label-sync/cloudbuild.yaml
+++ b/packages/label-sync/cloudbuild.yaml
@@ -26,6 +26,8 @@ steps:
     id: "publish-function"
     waitFor: ["build"]
     entrypoint: bash
+    env:
+      - "SERVICE_ACCOUNT=web-backend@repo-automation-bots.iam.gserviceaccount.com"
     args:
       - "-e"
       - "./scripts/publish-function.sh"


### PR DESCRIPTION
part of #3424 

This is the last one.