### PR TITLE
Revert "build: sdd srs yaml file (#1419)"

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,5 +13,5 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-nodejs:latest
-  digest: sha256:80bfa0c67226453b37b501be7748b2fa2a2676cfeec0012e79e3a1a8f1cbe6a3
-# created: 2022-04-14T19:57:08.518420247Z
+  digest: sha256:bb4d47d0e770abad62699a4664ce6b9ff1629d50c276a6c75860a6a1853dd19b
+# created: 2022-04-01T19:19:56.587347289Z

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,17 +1,20 @@
+rebaseMergeAllowed: true
+squashMergeAllowed: true
+mergeCommitAllowed: false
 branchProtectionRules:
-  - pattern: main
-    isAdminEnforced: true
-    requiredApprovingReviewCount: 1
-    requiresCodeOwnerReviews: true
-    requiresStrictStatusChecks: false
-    requiredStatusCheckContexts:
-      - "ci/kokoro: Samples test"
-      - "ci/kokoro: System test"
-      - docs
-      - lint
-      - test (12)
-      - test (14)
-      - test (16)
-      - cla/google
-      - windows
-      - OwlBot Post Processor
+- pattern: main
+  isAdminEnforced: true
+  requiredStatusCheckContexts:
+    - 'changeFinder'
+    - 'finale'
+    - 'cla/google'
+  requiredApprovingReviewCount: 1
+  requiresCodeOwnerReviews: true
+  requiresStrictStatusChecks: true
+permissionRules:
+  - team: Googlers
+    permission: pull
+  - team: github-automation
+    permission: push
+  - team: yoshi-admins
+    permission: admin


### PR DESCRIPTION
Reverts googleapis/repo-automation-bots#3443

We don't want to use the same branch protection as our other nodejs libraries