### PR TITLE
fix(build): use newer npm for publication

### DIFF
--- a/.kokoro/release/publish.cfg
+++ b/.kokoro/release/publish.cfg
@@ -47,7 +47,7 @@ build_file: "repo-automation-bots/.kokoro/trampoline_v2.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/node:12-user"
+  value: "gcr.io/cloud-devrel-kokoro-resources/node:16-user"
 }
 
 env_vars: {


### PR DESCRIPTION
Using v16 LTS should pull in a version of npm compatible with v2 of lockfile.