### PR TITLE
fix: bump bazel-bot timeout to 3 hours

### DIFF
--- a/packages/bazel-bot/cloudbuild.yaml
+++ b/packages/bazel-bot/cloudbuild.yaml
@@ -34,7 +34,7 @@ steps:
     - "SOURCE_BRANCH=$_SOURCE_BRANCH"
     - "TARGET_BRANCH=$_TARGET_BRANCH"
 
-timeout: '7200s'
+timeout: '10800s'
 
 options:
   machineType: 'N1_HIGHCPU_8'


### PR DESCRIPTION
We are hitting an issue where we need to rebuild every API and it's taking over 2 hours