### PR TITLE
fix(owl-bot): bump scan-googleapis-gen-and-create-pull-requests timeout to 4h

### DIFF
--- a/packages/owl-bot/cloud-build/scan-googleapis-gen-and-create-pull-requests.yaml
+++ b/packages/owl-bot/cloud-build/scan-googleapis-gen-and-create-pull-requests.yaml
@@ -46,4 +46,4 @@ steps:
       - --firestore-project
       - ${_FIRESTORE_PROJECT}
 
-timeout: '7200s'
+timeout: '14400s'


### PR DESCRIPTION
It's getting stuck on google-cloud-ruby's single mono-repo PR.

Towards #3507
