### PR TITLE
feat: add timestamps to log statements

### DIFF
--- a/packages/owl-bot/src/cmd.ts
+++ b/packages/owl-bot/src/cmd.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as proc from 'child_process';
+import {Logger} from './logger';
 
 // Creates a function that first prints, then executes a shell command.
 export type Cmd = (
@@ -19,7 +20,7 @@ export type Cmd = (
   options?: proc.ExecSyncOptions | undefined
 ) => Buffer;
 
-export function newCmd(logger = console): Cmd {
+export function newCmd(logger: Logger = console): Cmd {
   const cmd = (
     command: string,
     options?: proc.ExecSyncOptions | undefined

--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -39,6 +39,7 @@ import {
 import {GithubRepo, githubRepoFromOwnerSlashName} from './github-repo';
 import {CopyStateStore} from './copy-state-store';
 import * as crypto from 'crypto';
+import {Logger} from './logger';
 
 // This code generally uses Sync functions because:
 // 1. None of our current designs including calling this code from a web
@@ -164,7 +165,7 @@ export async function copyCodeIntoCommit(
   yamlPaths: string[],
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reportError: (error: any, yamlPath: string) => Promise<void>,
-  logger = console
+  logger: Logger = console
 ): Promise<{yamlPath: string; yaml: OwlBotYaml; copyTag: string}[]> {
   const cmd = newCmd(logger);
 
@@ -267,7 +268,7 @@ export function branchNameForCopies(yamlPaths: string[]): string {
 async function findAndAppendPullRequest(
   params: WorkingCopyParams,
   yamlPaths: string[],
-  logger = console
+  logger: Logger = console
 ): Promise<boolean> {
   const cmd = newCmd(logger);
   const octokit = await params.octokitFactory.getShortLivedOctokit();
@@ -390,7 +391,7 @@ interface WorkingCopyParams extends CopyParams {
 export async function copyCodeAndAppendOrCreatePullRequest(
   params: CopyParams,
   yamlPaths: string[],
-  logger = console
+  logger: Logger = console
 ): Promise<void> {
   const workDir = tmp.dirSync().name;
   logger.info(`Working in ${workDir}`);
@@ -717,7 +718,7 @@ export async function loadOwlBotYaml(yamlPath: string): Promise<OwlBotYaml> {
 export function toLocalRepo(
   repo: string,
   workDir: string,
-  logger = console,
+  logger: Logger = console,
   depth = 100,
   accessToken = ''
 ): string {
@@ -813,7 +814,7 @@ export function copyDirs(
   sourceDir: string,
   destDir: string,
   yaml: OwlBotYaml,
-  logger = console
+  logger: Logger = console
 ): void {
   // Prepare to exclude paths.
   const excludes: RegExp[] = (yaml['deep-preserve-regex'] ?? []).map(x =>

--- a/packages/owl-bot/src/create-pr.ts
+++ b/packages/owl-bot/src/create-pr.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {newCmd} from './cmd';
+import {Logger} from './logger';
 import {OctokitType} from './octokit-util';
 
 // Limits imposed by Github.
@@ -119,7 +120,7 @@ export async function createPullRequestFromLastCommit(
   withRegenerateCheckbox = WithRegenerateCheckbox.No,
   apiName = '',
   forceFlag: Force = Force.No,
-  logger = console,
+  logger: Logger = console,
   commitMessage?: string
 ): Promise<string> {
   const cmd = newCmd(logger);

--- a/packages/owl-bot/src/logger.ts
+++ b/packages/owl-bot/src/logger.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/owl-bot/src/logger.ts
+++ b/packages/owl-bot/src/logger.ts
@@ -1,0 +1,57 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Wrapping the console which takes any params.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** A logging interface that's compatible with console. */
+export interface Logger {
+  log(msg: any, ...params: any[]): void;
+  error(msg: any, ...params: any[]): void;
+  warn(msg: any, ...params: any[]): void;
+  info(msg: any, ...params: any[]): void;
+}
+
+/** Insert a timestamp into a log function's arguments. */
+export function insertTimestamp(msg: any, ...params: any[]): [any, any[]] {
+  const dateString = new Date().toISOString();
+  if (typeof msg === 'string') {
+    return [`${dateString} ${msg}`, params];
+  } else {
+    return [dateString, [msg, ...params]];
+  }
+}
+
+export class LoggerWithTimestamp implements Logger {
+  inner: Logger;
+  constructor(inner: Logger) {
+    this.inner = inner;
+  }
+  log(msg: any, ...params: any[]): void {
+    const [innerMsg, innerParams] = insertTimestamp(msg, params);
+    this.inner.log(innerMsg, ...innerParams);
+  }
+  error(msg: any, ...params: any[]): void {
+    const [innerMsg, innerParams] = insertTimestamp(msg, params);
+    this.inner.error(innerMsg, ...innerParams);
+  }
+  warn(msg: any, ...params: any[]): void {
+    const [innerMsg, innerParams] = insertTimestamp(msg, params);
+    this.inner.warn(innerMsg, ...innerParams);
+  }
+  info(msg: any, ...params: any[]): void {
+    const [innerMsg, innerParams] = insertTimestamp(msg, params);
+    this.inner.info(innerMsg, ...innerParams);
+  }
+}

--- a/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
@@ -25,6 +25,7 @@ import {getFilesModifiedBySha} from '.';
 import {newCmd} from './cmd';
 import {CopyStateStore} from './copy-state-store';
 import {GithubRepo} from './github-repo';
+import {Logger, LoggerWithTimestamp} from './logger';
 
 interface Todo {
   repo: GithubRepo;
@@ -77,8 +78,9 @@ export async function scanGoogleapisGenAndCreatePullRequests(
   cloneDepth = 100,
   copyStateStore: CopyStateStore,
   combinePullsThreshold = Number.MAX_SAFE_INTEGER,
-  logger = console
+  logger: Logger = console
 ): Promise<number> {
+  logger = new LoggerWithTimestamp(logger);
   // Clone the source repo.
   const workDir = tmp.dirSync().name;
   // cloneDepth + 1 because the final commit in a shallow clone is grafted: it contains


### PR DESCRIPTION
to see where scan-googleapis-gen-and-create-pull-requests is using its time.
