### PR TITLE
build(serverless-scheduler-proxy): use scheduler-proxy service account

### DIFF
--- a/scripts/serverless-scheduler-proxy-deploy.sh
+++ b/scripts/serverless-scheduler-proxy-deploy.sh
@@ -32,4 +32,6 @@ gcloud beta run deploy \
             --platform managed \
             --region $REGION \
             --quiet \
+	    --service-account \
+	    scheduler-proxy@repo-automation-bots.iam.gserviceaccount.com \
             serverless-scheduler-proxy


### PR DESCRIPTION
fixes #3424 

Depends on an internal cl to get merged first.