### PR TITLE
build: create GCB test that ensures the image builds

### DIFF
--- a/serverless-scheduler-proxy/cloudbuild-test.yaml
+++ b/serverless-scheduler-proxy/cloudbuild-test.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    id: "serverless-scheduler-proxy-builder"
+    waitFor: ["-"]
+    args:
+      [
+        "build",
+        "-t",
+        "gcr.io/$PROJECT_ID/serverless-scheduler-proxy",
+        "-f",
+        "serverless-scheduler-proxy/Dockerfile",
+        "serverless-scheduler-proxy",
+      ]


### PR DESCRIPTION
Future PRs touching the serverless-scheduler-proxy directory will trigger this build as a presubmit
