### PR TITLE
fix(serverless-scheduler-proxy): use golang:1.18-alpine

### DIFF
--- a/serverless-scheduler-proxy/Dockerfile
+++ b/serverless-scheduler-proxy/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16-alpine AS build
+FROM golang:1.13-alpine AS build
 
 RUN apk add --no-cache git ca-certificates
 WORKDIR /src/serverless-scheduler-proxy

--- a/serverless-scheduler-proxy/Dockerfile
+++ b/serverless-scheduler-proxy/Dockerfile
@@ -9,15 +9,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12-alpine AS build
+FROM golang:1.16-alpine AS build
 
-RUN apk add --no-cache git ca-certificates 
-WORKDIR /src/serverless-scheduler-proxy 
-COPY . . 
-RUN go build -o /serverless-scheduler-proxy 
+RUN apk add --no-cache git ca-certificates
+WORKDIR /src/serverless-scheduler-proxy
+COPY . .
+RUN go build -o /serverless-scheduler-proxy
 
 FROM alpine
-RUN apk add --no-cache ca-certificates 
+RUN apk add --no-cache ca-certificates
 COPY --from=build /serverless-scheduler-proxy /serverless-scheduler-proxy
 
 ENTRYPOINT [ "/serverless-scheduler-proxy" ]

--- a/serverless-scheduler-proxy/Dockerfile
+++ b/serverless-scheduler-proxy/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13-alpine AS build
+FROM golang:1.18-alpine AS build
 
 RUN apk add --no-cache git ca-certificates
 WORKDIR /src/serverless-scheduler-proxy


### PR DESCRIPTION
The last few deployments failed.