### PR TITLE
chore: add googlemaps GitHub org to MOG allowlist

### DIFF
--- a/packages/merge-on-green/src/merge-on-green.ts
+++ b/packages/merge-on-green/src/merge-on-green.ts
@@ -40,6 +40,7 @@ handler.allowlist = [
   'googlecloudplatform',
   'google',
   'google-github-actions',
+  'googlemaps',
   'bcoe',
   'sofisl',
   'firebase',


### PR DESCRIPTION
Adds the https://github.com/googlemaps org to the merge on green allowlist.