### PR TITLE
fix: throw InvalidConfigurationFormat error on validation error

### DIFF
--- a/packages/bot-config-utils/src/bot-config-utils.ts
+++ b/packages/bot-config-utils/src/bot-config-utils.ts
@@ -275,6 +275,16 @@ const DEFAULT_GET_CONFIG_OPTIONS = {
   fallbackToOrgConfig: true,
 };
 
+export class InvalidConfigurationFormat extends Error {
+  readonly path: string;
+  constructor(path: string, validationMessage?: string) {
+    super(
+      `Failed to validate the config schema at '${path}': ${validationMessage}`
+    );
+    this.path = path;
+  }
+}
+
 /**
  * A function for fetching config file from the repo. It falls back to
  * `.github` repository by default.
@@ -327,10 +337,7 @@ export async function getConfig<ConfigType>(
       if (validateResult.config) {
         return validateResult.config;
       } else {
-        throw new Error(
-          `Failed to validate the config schema at '${path}' ` +
-            `:${validateResult.errorText}`
-        );
+        throw new InvalidConfigurationFormat(path, validateResult.errorText);
       }
     } else {
       // This should not happen.
@@ -368,10 +375,7 @@ export async function getConfig<ConfigType>(
         if (validateResult.config) {
           return validateResult.config;
         } else {
-          throw new Error(
-            `Failed to validate the config schema at '${path}' ` +
-              `:${validateResult.errorText}`
-          );
+          throw new InvalidConfigurationFormat(path, validateResult.errorText);
         }
       } else {
         // This should not happen.
@@ -442,10 +446,7 @@ export async function getConfigWithDefault<ConfigType>(
       if (validateResult.config) {
         return {...defaultConfig, ...validateResult.config};
       } else {
-        throw new Error(
-          `Failed to validate the config schema at '${path}' ` +
-            `:${validateResult.errorText}`
-        );
+        throw new InvalidConfigurationFormat(path, validateResult.errorText);
       }
     } else {
       // This should not happen.
@@ -482,10 +483,7 @@ export async function getConfigWithDefault<ConfigType>(
         if (validateResult.config) {
           return {...defaultConfig, ...validateResult.config};
         } else {
-          throw new Error(
-            `Failed to validate the config schema at '${path}' ` +
-              `:${validateResult.errorText}`
-          );
+          throw new InvalidConfigurationFormat(path, validateResult.errorText);
         }
       } else {
         // This should not happen.

--- a/packages/bot-config-utils/test/bot-config-utils.ts
+++ b/packages/bot-config-utils/test/bot-config-utils.ts
@@ -27,6 +27,7 @@ import {
   getConfig,
   getConfigWithDefault,
   ConfigChecker,
+  InvalidConfigurationFormat,
 } from '../src/bot-config-utils';
 import schema from './test-config-schema.json';
 import listSchema from './test-config-use-external-id.json';
@@ -522,7 +523,7 @@ describe('config', () => {
         getConfig<TestConfig>(octokit, owner, repo, filename, {
           schema: schema,
         }),
-        Error
+        InvalidConfigurationFormat
       );
 
       for (const scope of scopes) {
@@ -758,7 +759,7 @@ describe('config', () => {
           defaultConfig,
           {schema: schema}
         ),
-        Error
+        InvalidConfigurationFormat
       );
 
       for (const scope of scopes) {
@@ -847,7 +848,7 @@ describe('config', () => {
           defaultConfig,
           {schema: schema}
         ),
-        Error
+        InvalidConfigurationFormat
       );
 
       for (const scope of scopes) {


### PR DESCRIPTION
Towards #3647 

Instead of a generic `Error`, we now throw a custom `InvalidConfigurationFormat` error.
