### PR TITLE
fix: skip schema validation when trying to run release-please

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-automations/bot-config-utils": "^4.0.1",
+        "@google-automations/bot-config-utils": "^4.0.2",
         "@google-automations/label-utils": "^2.0.2",
         "@octokit/rest": "^18.12.0",
         "@octokit/webhooks": "^9.24.0",
@@ -266,12 +266,12 @@
       "dev": true
     },
     "node_modules/@google-automations/bot-config-utils": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@google-automations/bot-config-utils/-/bot-config-utils-4.0.1.tgz",
-      "integrity": "sha512-Ueeoq0WeX2+MNxeECREM4JdnnhHtuhj2wZWRUpiNURST7hAuj/vjHzWdOw3rlmnX/CLAOwgzH73Rv49XyQ67ew==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@google-automations/bot-config-utils/-/bot-config-utils-4.0.2.tgz",
+      "integrity": "sha512-wa03my3rTCUTccuIDxbAOlZdlIkYgbdhfWRhtohLpYA9csP9gn4wBgk+Jgnja200LB2T4bbbrCPN0Rp3Z6SN+w==",
       "dependencies": {
-        "ajv": "^8.8.2",
-        "gcf-utils": "^13.1.0",
+        "ajv": "^8.11.0",
+        "gcf-utils": "^13.5.2",
         "js-yaml": "^4.1.0"
       },
       "engines": {
@@ -9340,12 +9340,12 @@
       }
     },
     "@google-automations/bot-config-utils": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@google-automations/bot-config-utils/-/bot-config-utils-4.0.1.tgz",
-      "integrity": "sha512-Ueeoq0WeX2+MNxeECREM4JdnnhHtuhj2wZWRUpiNURST7hAuj/vjHzWdOw3rlmnX/CLAOwgzH73Rv49XyQ67ew==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@google-automations/bot-config-utils/-/bot-config-utils-4.0.2.tgz",
+      "integrity": "sha512-wa03my3rTCUTccuIDxbAOlZdlIkYgbdhfWRhtohLpYA9csP9gn4wBgk+Jgnja200LB2T4bbbrCPN0Rp3Z6SN+w==",
       "requires": {
-        "ajv": "^8.8.2",
-        "gcf-utils": "^13.1.0",
+        "ajv": "^8.11.0",
+        "gcf-utils": "^13.5.2",
         "js-yaml": "^4.1.0"
       }
     },

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -28,7 +28,7 @@
     "lint": "gts check"
   },
   "dependencies": {
-    "@google-automations/bot-config-utils": "^4.0.1",
+    "@google-automations/bot-config-utils": "^4.0.2",
     "@google-automations/label-utils": "^2.0.2",
     "@octokit/webhooks": "^9.24.0",
     "@octokit/rest": "^18.12.0",

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -146,7 +146,6 @@ async function getConfigWithDefaultBranch(
     owner,
     repo,
     WELL_KNOWN_CONFIGURATION_FILE,
-    {schema: schema}
   );
   if (config && !config.primaryBranch) {
     config.primaryBranch =
@@ -445,7 +444,6 @@ const handler = (app: Probot) => {
       owner,
       repo,
       WELL_KNOWN_CONFIGURATION_FILE,
-      {schema: schema}
     );
 
     // If no configuration is specified,
@@ -486,7 +484,6 @@ const handler = (app: Probot) => {
       owner,
       repo,
       WELL_KNOWN_CONFIGURATION_FILE,
-      {schema: schema}
     );
 
     // If no configuration is specified,
@@ -532,7 +529,6 @@ const handler = (app: Probot) => {
       owner,
       repo,
       WELL_KNOWN_CONFIGURATION_FILE,
-      {schema: schema}
     );
 
     // If no configuration is specified,

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -145,7 +145,7 @@ async function getConfigWithDefaultBranch(
     octokit,
     owner,
     repo,
-    WELL_KNOWN_CONFIGURATION_FILE,
+    WELL_KNOWN_CONFIGURATION_FILE
   );
   if (config && !config.primaryBranch) {
     config.primaryBranch =
@@ -443,7 +443,7 @@ const handler = (app: Probot) => {
       context.octokit,
       owner,
       repo,
-      WELL_KNOWN_CONFIGURATION_FILE,
+      WELL_KNOWN_CONFIGURATION_FILE
     );
 
     // If no configuration is specified,
@@ -483,7 +483,7 @@ const handler = (app: Probot) => {
       context.octokit,
       owner,
       repo,
-      WELL_KNOWN_CONFIGURATION_FILE,
+      WELL_KNOWN_CONFIGURATION_FILE
     );
 
     // If no configuration is specified,
@@ -528,7 +528,7 @@ const handler = (app: Probot) => {
       context.octokit,
       owner,
       repo,
-      WELL_KNOWN_CONFIGURATION_FILE,
+      WELL_KNOWN_CONFIGURATION_FILE
     );
 
     // If no configuration is specified,


### PR DESCRIPTION
We already have a presubmit check that verifies the config format on a pull request. If the error is something like an extra field, we should not prevent release-please from running.

Fixes #3647
