### PR TITLE
fix: handling misconfigured manifest repos

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -14,7 +14,7 @@
         "@octokit/rest": "^18.12.0",
         "@octokit/webhooks": "^9.24.0",
         "gcf-utils": "^13.5.2",
-        "release-please": "13.16.1"
+        "release-please": "13.16.2"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.1",
@@ -7448,9 +7448,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "13.16.1",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.16.1.tgz",
-      "integrity": "sha512-a8HXvyi0s4nfhCdTCh21/wZFBI6E898kRzkdKv/2dbdFWTpJyfpaihOE9IkBhD6KFC3hrqv+l6pF1R6S6Smqnw==",
+      "version": "13.16.2",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.16.2.tgz",
+      "integrity": "sha512-MheJswfNMvWvgKkJ9MpfqihUpbYcFfdSVQPq2kp1UoAvnQU8eyRXOjxUPaOnlw4eScQNrxoAAAOGvt53BxKr/w==",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",
@@ -14892,9 +14892,9 @@
       }
     },
     "release-please": {
-      "version": "13.16.1",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.16.1.tgz",
-      "integrity": "sha512-a8HXvyi0s4nfhCdTCh21/wZFBI6E898kRzkdKv/2dbdFWTpJyfpaihOE9IkBhD6KFC3hrqv+l6pF1R6S6Smqnw==",
+      "version": "13.16.2",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.16.2.tgz",
+      "integrity": "sha512-MheJswfNMvWvgKkJ9MpfqihUpbYcFfdSVQPq2kp1UoAvnQU8eyRXOjxUPaOnlw4eScQNrxoAAAOGvt53BxKr/w==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -33,7 +33,7 @@
     "@octokit/webhooks": "^9.24.0",
     "@octokit/rest": "^18.12.0",
     "gcf-utils": "^13.5.2",
-    "release-please": "13.16.1"
+    "release-please": "13.16.2"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/packages/release-please/test/release-please.ts
+++ b/packages/release-please/test/release-please.ts
@@ -638,6 +638,27 @@ describe('ReleasePleaseBot', () => {
         );
       });
     });
+
+    it('should handle a misconfigured repository', async () => {
+      const fromManifestStub = sandbox
+        .stub(Manifest, 'fromManifest')
+        .rejects(
+          new Errors.ConfigurationError(
+            'some error message',
+            'releaser-name',
+            'repo-name'
+          )
+        );
+      getConfigStub.resolves(loadConfig('manifest_handle_gh_release.yml'));
+      await probot.receive(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {name: 'push', payload: payload as any, id: 'abc123'}
+      );
+
+      sinon.assert.notCalled(createPullRequestsStub);
+      sinon.assert.notCalled(createReleasesStub);
+      sinon.assert.calledOnce(fromManifestStub);
+    });
   });
 
   describe('push to non-master branch', () => {


### PR DESCRIPTION
Fixes #3649

Rather than crashing with a missing file error, we will log the misconfiguration. In the future, we could opt to open an issue on the repository.