### PR TITLE
fix: run release-trigger on a schedule to catch failed webhooks

### DIFF
--- a/packages/release-trigger/src/bot.ts
+++ b/packages/release-trigger/src/bot.ts
@@ -310,4 +310,58 @@ export = (app: Probot) => {
       context.payload.pull_request.number
     );
   });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app.on('schedule.repository' as any, async context => {
+    const logger = getContextLogger(context);
+    const repository = context.payload.repository;
+    const repoUrl = repository.full_name;
+    const owner = repository.owner.login;
+    const repo = repository.name;
+
+    if (!ALLOWED_ORGANIZATIONS.includes(owner)) {
+      logger.info(`release-trigger not allowed for owner: ${owner}`);
+      return;
+    }
+
+    const remoteConfiguration = await getConfig<ConfigurationOptions>(
+      context.octokit,
+      owner,
+      repo,
+      WELL_KNOWN_CONFIGURATION_FILE,
+      {schema: schema}
+    );
+    if (!remoteConfiguration) {
+      logger.info(`release-trigger not configured for ${repoUrl}`);
+      return;
+    }
+    const configuration = {
+      ...DEFAULT_CONFIGURATION,
+      ...remoteConfiguration,
+    };
+    if (!configuration.enabled) {
+      logger.info(`release-trigger not enabled for ${repoUrl}`);
+      return;
+    }
+
+    const releasePullRequests = await findPendingReleasePullRequests(
+      context.octokit,
+      {owner: repository.owner.login, repo: repository.name}
+    );
+    const {token} = (await context.octokit.auth({type: 'installation'})) as {
+      token: string;
+    };
+    for (const pullRequest of releasePullRequests) {
+      if (
+        !pullRequest.labels.some(label => {
+          return label.name === TAGGED_LABEL;
+        })
+      ) {
+        logger.info('ignore pull non-tagged pull request');
+        continue;
+      }
+
+      await doTriggerWithLock(context.octokit, pullRequest, token, logger);
+    }
+  });
 };

--- a/packages/release-trigger/src/release-trigger.ts
+++ b/packages/release-trigger/src/release-trigger.ts
@@ -131,6 +131,7 @@ export async function findPendingReleasePullRequests(
       }
     }
   }
+  logger.debug(`Found ${found.length} release pull requests`);
   return found;
 }
 


### PR DESCRIPTION
chore: add logging for the number of found release pull requests

Towards #3734 
