### PR TITLE
build(canary-bot): target cloud run with cron

### DIFF
--- a/packages/canary-bot/cloudbuild.yaml
+++ b/packages/canary-bot/cloudbuild.yaml
@@ -43,6 +43,8 @@ steps:
     id: "cron-deploy"
     waitFor: ["-"]
     entrypoint: bash
+    env:
+      - "TARGET_TYPE=run"
     args:
       - "-e"
       - "./scripts/cron-deploy.sh"

--- a/packages/canary-bot/cloudbuild.yaml
+++ b/packages/canary-bot/cloudbuild.yaml
@@ -45,6 +45,7 @@ steps:
     entrypoint: bash
     env:
       - "TARGET_TYPE=run"
+      - "FUNCTION_NAME=canary-bot-cloud-run"
     args:
       - "-e"
       - "./scripts/cron-deploy.sh"

--- a/scripts/cron-deploy.sh
+++ b/scripts/cron-deploy.sh
@@ -37,7 +37,10 @@ fi
 npm i -g @google-automations/cron-utils
 
 pushd "${DIRECTORY}"
-FUNCTION_NAME=$(echo "${DIRECTORY}" | rev | cut -d/ -f1 | rev | tr '-' '_')
+
+if [[ -z "${FUNCTION_NAME}" ]]; then
+    FUNCTION_NAME=$(echo "${DIRECTORY}" | rev | cut -d/ -f1 | rev | tr '-' '_')
+fi
 
 cron-utils deploy \
   --scheduler-service-account="$SCHEDULER_SERVICE_ACCOUNT_EMAIL" \

--- a/serverless-scheduler-proxy/main.go
+++ b/serverless-scheduler-proxy/main.go
@@ -158,7 +158,7 @@ func rewriteBotURL(c botConfig, parser func([]byte) (string, string, string), re
 		if serviceIdentifier == "" {
 			log.Fatal("SERVICE_IDENTIFIER environment variable not specified")
 		}
-		newHost := fmt.Sprintf("%v-%v.a.run.app", botName, serviceIdentifier)
+		newHost := fmt.Sprintf("%v-%v-uc.a.run.app", botName, serviceIdentifier)
 		req.Host = newHost
 		req.URL.Host = newHost
 		req.URL.Path = "/"


### PR DESCRIPTION
See #2143
Unblock #3774 

fix: cloud run urls have `-uc` in them.
build: allow overriding the service name in the cron-deploy script
