### PR TITLE
build: fix cron scheduler job name

### DIFF
--- a/packages/release-trigger/cron.yaml
+++ b/packages/release-trigger/cron.yaml
@@ -1,5 +1,5 @@
 cron:
-  - name: release-trigger fallback
+  - name: release-trigger-fallback
     # run every other hour
     schedule: 0 */2 * * *
     description: trigger pending releases missed by webhooks


### PR DESCRIPTION
This name field is directly used as the name field for the scheduler task and cannot contain spaces