### PR TITLE
fix: bot name is underscored, Cloud Run URL is dasherized

### DIFF
--- a/packages/release-trigger/cloudbuild.yaml
+++ b/packages/release-trigger/cloudbuild.yaml
@@ -88,7 +88,7 @@ steps:
     entrypoint: bash
     env:
       - "TARGET_TYPE=run"
-      - "FUNCTION_NAME=release-trigger"
+      - "FUNCTION_NAME=release_trigger"
     args:
       - "-e"
       - "./scripts/cron-deploy.sh"

--- a/serverless-scheduler-proxy/main.go
+++ b/serverless-scheduler-proxy/main.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"strings"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"github.com/google/uuid"
@@ -158,7 +159,7 @@ func rewriteBotURL(c botConfig, parser func([]byte) (string, string, string), re
 		if serviceIdentifier == "" {
 			log.Fatal("SERVICE_IDENTIFIER environment variable not specified")
 		}
-		newHost := fmt.Sprintf("%v-%v-uc.a.run.app", botName, serviceIdentifier)
+		newHost := fmt.Sprintf("%v-%v-uc.a.run.app", strings.Replace(botName, "_", "-", -1), serviceIdentifier)
 		req.Host = newHost
 		req.URL.Host = newHost
 		req.URL.Path = "/"


### PR DESCRIPTION
Cron requests to the `release-trigger` Cloud Run service are failing because the proxy is looking for a secret with `release-trigger` when the actual secret is named `release_trigger` (it's using the `Name` field from the cron payload).

Canary bot for cloud run happened to work because we somehow have the bot secret twice (`canary-bot-cloud-run` and `canary_bot_cloud_run`).

This change make the `Name` in the cron payload `release_trigger` and makes the serverless proxy replace `_` with `-` when generating the Cloud Run URL.