### PR TITLE
deps: update releasetool to 1.8.5

### DIFF
--- a/packages/release-trigger/requirements.txt
+++ b/packages/release-trigger/requirements.txt
@@ -1,2 +1,2 @@
-gcp-releasetool==1.8.4
+gcp-releasetool==1.8.5
 keyrings.alt


### PR DESCRIPTION
This should pin the protobuf version so it can work again