### PR TITLE
fix: delay finding pending PRs on release event

### DIFF
--- a/packages/release-trigger/src/bot.ts
+++ b/packages/release-trigger/src/bot.ts
@@ -37,6 +37,7 @@ import {
   TAGGED_LABEL,
   cleanupPublished,
   isReleasePullRequest,
+  delay,
 } from './release-trigger';
 
 const TRIGGER_LOCK_ID = 'release-trigger';
@@ -386,7 +387,3 @@ export = (app: Probot) => {
     }
   });
 };
-
-function delay(ms: number): Promise<void> {
-  return new Promise( resolve => setTimeout(resolve, ms) );
-}

--- a/packages/release-trigger/src/bot.ts
+++ b/packages/release-trigger/src/bot.ts
@@ -173,6 +173,10 @@ export = (app: Probot) => {
       return;
     }
 
+    // release-please may take some time to add the tagged label - wait a
+    // few seconds to let it tag the release PR
+    await delay(10_000);
+
     const releasePullRequests = await findPendingReleasePullRequests(
       context.octokit,
       {owner: repository.owner.login, repo: repository.name}
@@ -382,3 +386,7 @@ export = (app: Probot) => {
     }
   });
 };
+
+function delay(ms: number): Promise<void> {
+  return new Promise( resolve => setTimeout(resolve, ms) );
+}

--- a/packages/release-trigger/src/release-trigger.ts
+++ b/packages/release-trigger/src/release-trigger.ts
@@ -212,3 +212,7 @@ export async function cleanupPublished(
   }
   return success;
 }
+
+export function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/release-trigger/test/bot.ts
+++ b/packages/release-trigger/test/bot.ts
@@ -84,6 +84,9 @@ describe('bot', () => {
   });
 
   describe('on release publish', () => {
+    beforeEach(() => {
+      sandbox.stub(releaseTriggerModule, 'delay').resolves();
+    });
     it('should trigger a kokoro job via releasetool', async () => {
       const payload = require(resolve(
         fixturesPath,


### PR DESCRIPTION
release-trigger is occasionally looking for tagged PRs before release-please has added the tagged label to the release PR.

Fixes #3734
