### PR TITLE
fix(release-trigger): specify number of CPUs

### DIFF
--- a/packages/release-trigger/cloudbuild.yaml
+++ b/packages/release-trigger/cloudbuild.yaml
@@ -37,6 +37,7 @@ steps:
       - "MEMORY=8G"
       - "SERVICE_NAME=release-trigger-backend"
       - "CONCURRENCY=32"
+      - "NUMBER_OF_CPU=4"
     args:
       - "-e"
       - "./scripts/publish-cloud-run.sh"

--- a/scripts/publish-cloud-run.sh
+++ b/scripts/publish-cloud-run.sh
@@ -112,6 +112,9 @@ fi
 if [ -n "${MEMORY}" ]; then
   deployArgs+=( "--memory" "${MEMORY}" )
 fi
+if [ -n "${NUMBER_OF_CPU}" ]; then
+  deployArgs+=( "--cpu" "${NUMBER_OF_CPU}" )
+fi
 echo "About to cloud run app ${SERVICE_NAME}"
 gcloud run deploy "${SERVICE_NAME}" "${deployArgs[@]}"
 


### PR DESCRIPTION
According to:
https://cloud.google.com/run/docs/configuring/memory-limits

For using 8GiB of memory we need miminum of 4 CPUs.
