### PR TITLE
fix: handle bad manifest configuration files

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -14,7 +14,7 @@
         "@octokit/rest": "^18.12.0",
         "@octokit/webhooks": "^9.24.0",
         "gcf-utils": "^13.5.3",
-        "release-please": "^13.18.0"
+        "release-please": "^13.18.3"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.1",
@@ -7567,9 +7567,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "13.18.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.18.0.tgz",
-      "integrity": "sha512-ehmdhPIth05JdWmbCrIvvxhhuY9/uGJ7GeQ6g4MZDkka3Yraw/FpdbMHrMJbStDu3kFlEshgttrUiRzdPXBSSQ==",
+      "version": "13.18.3",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.18.3.tgz",
+      "integrity": "sha512-tgPpmFfUvI85eQ6Jt9E5t7DqMDhXCgYqxrAlcEMP0d+eiLHAQjL+tHLwD46KUaWBI1ySk8pwmAFJHF0sWpXusg==",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",
@@ -15071,9 +15071,9 @@
       }
     },
     "release-please": {
-      "version": "13.18.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.18.0.tgz",
-      "integrity": "sha512-ehmdhPIth05JdWmbCrIvvxhhuY9/uGJ7GeQ6g4MZDkka3Yraw/FpdbMHrMJbStDu3kFlEshgttrUiRzdPXBSSQ==",
+      "version": "13.18.3",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-13.18.3.tgz",
+      "integrity": "sha512-tgPpmFfUvI85eQ6Jt9E5t7DqMDhXCgYqxrAlcEMP0d+eiLHAQjL+tHLwD46KUaWBI1ySk8pwmAFJHF0sWpXusg==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@iarna/toml": "^2.2.5",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -33,7 +33,7 @@
     "@octokit/rest": "^18.12.0",
     "@octokit/webhooks": "^9.24.0",
     "gcf-utils": "^13.5.3",
-    "release-please": "^13.18.0"
+    "release-please": "^13.18.3"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -228,6 +228,55 @@ async function buildManifest(
   );
 }
 
+async function runBranchConfigurationWithConfigurationHandling(
+  github: GitHub,
+  repoLanguage: string | null,
+  repoUrl: string,
+  branchConfiguration: BranchConfiguration,
+  octokit: Octokit,
+  logger: GCFLogger
+) {
+  try {
+    await runBranchConfiguration(
+      github,
+      repoLanguage,
+      repoUrl,
+      branchConfiguration,
+      octokit,
+      logger
+    );
+  } catch (e) {
+    if (e instanceof Errors.ConfigurationError) {
+      // In the future, this could raise an issue against the
+      // installed repository
+      logger.warn(e);
+      await addOrUpdateIssue(
+        octokit,
+        github.repository.owner,
+        github.repository.repo,
+        'Configuration error for release-please',
+        e.message,
+        ['release-please'],
+        logger
+      );
+    } else if (e instanceof BotConfigurationError) {
+      logger.warn(e);
+      await addOrUpdateIssue(
+        octokit,
+        github.repository.owner,
+        github.repository.repo,
+        'Configuration error for release-please',
+        e.message,
+        ['release-please'],
+        logger
+      );
+    } else {
+      // re-raise
+      throw e;
+    }
+  }
+}
+
 async function runBranchConfiguration(
   github: GitHub,
   repoLanguage: string | null,
@@ -271,28 +320,8 @@ async function runBranchConfiguration(
     }
   }
 
-  try {
-    logger.info(`creating pull request for (${repoUrl})`);
-    await Runner.createPullRequests(manifest);
-  } catch (e) {
-    if (e instanceof Errors.ConfigurationError) {
-      // In the future, this could raise an issue against the
-      // installed repository
-      logger.warn(e);
-      await addOrUpdateIssue(
-        octokit,
-        github.repository.owner,
-        github.repository.repo,
-        'Configuration error for release-please',
-        e.message,
-        ['release-please'],
-        logger
-      );
-    } else {
-      // re-raise
-      throw e;
-    }
-  }
+  logger.info(`creating pull request for (${repoUrl})`);
+  await Runner.createPullRequests(manifest);
 }
 
 const handler = (app: Probot) => {
@@ -341,37 +370,14 @@ const handler = (app: Probot) => {
 
     for (const branchConfiguration of branchConfigurations) {
       logger.debug(branchConfiguration);
-      try {
-        await runBranchConfiguration(
-          github,
-          repoLanguage,
-          repoUrl,
-          branchConfiguration,
-          context.octokit,
-          logger
-        );
-      } catch (e) {
-        if (e instanceof Errors.ConfigurationError) {
-          // Consider opening an issue on the repository in the future
-          logger.warn(
-            `Invalid configuration for ${owner}/${repo}/${branchConfiguration.branch}`
-          );
-          logger.warn(e);
-        } else if (e instanceof BotConfigurationError) {
-          logger.warn(e);
-          await addOrUpdateIssue(
-            context.octokit,
-            github.repository.owner,
-            github.repository.repo,
-            'Configuration error for release-please',
-            e.message,
-            ['release-please'],
-            logger
-          );
-        } else {
-          throw e;
-        }
-      }
+      await runBranchConfigurationWithConfigurationHandling(
+        github,
+        repoLanguage,
+        repoUrl,
+        branchConfiguration,
+        context.octokit,
+        logger
+      );
     }
   });
 
@@ -476,37 +482,14 @@ const handler = (app: Probot) => {
 
     for (const branchConfiguration of branchConfigurations) {
       logger.debug(branchConfiguration);
-      try {
-        await runBranchConfiguration(
-          github,
-          repoLanguage,
-          repoUrl,
-          branchConfiguration,
-          context.octokit,
-          logger
-        );
-      } catch (e) {
-        if (e instanceof Errors.ConfigurationError) {
-          // Consider opening an issue on the repository in the future
-          logger.warn(
-            `Invalid configuration for ${owner}/${repo}/${branchConfiguration.branch}`
-          );
-          logger.warn(e);
-        } else if (e instanceof BotConfigurationError) {
-          logger.warn(e);
-          await addOrUpdateIssue(
-            context.octokit,
-            github.repository.owner,
-            github.repository.repo,
-            'Configuration error for release-please',
-            e.message,
-            ['release-please'],
-            logger
-          );
-        } else {
-          throw e;
-        }
-      }
+      await runBranchConfigurationWithConfigurationHandling(
+        github,
+        repoLanguage,
+        repoUrl,
+        branchConfiguration,
+        context.octokit,
+        logger
+      );
     }
   });
 

--- a/packages/release-please/test/release-please.ts
+++ b/packages/release-please/test/release-please.ts
@@ -670,6 +670,9 @@ describe('ReleasePleaseBot', () => {
             'repo-name'
           )
         );
+      const addIssueStub = sandbox
+        .stub(errorHandlingModule, 'addOrUpdateIssue')
+        .resolves();
       getConfigStub.resolves(loadConfig('manifest_handle_gh_release.yml'));
       await probot.receive(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -679,6 +682,7 @@ describe('ReleasePleaseBot', () => {
       sinon.assert.notCalled(createPullRequestsStub);
       sinon.assert.notCalled(createReleasesStub);
       sinon.assert.calledOnce(fromManifestStub);
+      sinon.assert.calledOnce(addIssueStub);
     });
   });
 


### PR DESCRIPTION
Updates release-please to 13.18.3 which now handles:
* bad manifest JSON files throw a `ConfigurationError`
* bad factory options in manifests throw a `ConfigurationError`

The bot now catches `ConfigurationError`s globally and maintains an issue on the repository with the `ConfigurationError`'s message.

Fixes #3870 
Fixes #3867
