### PR TITLE
fix: also handle secondary rate limit errors from GitHub API

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -1161,6 +1161,7 @@ interface RateLimits {
 }
 const RATE_LIMIT_MESSAGE = 'API rate limit exceeded';
 const RATE_LIMIT_REGEX = new RegExp('API rate limit exceeded for user ID (d+)');
+const SECONDARY_RATE_LIMIT_MESSAGE = 'exceeded a secondary rate limit';
 function parseRateLimitError(e: Error): RateLimits | undefined {
   // If any of the aggregated errors are rate limit errors, then
   // this should be considered a rate limit error
@@ -1193,6 +1194,11 @@ function parseRateLimitError(e: Error): RateLimits | undefined {
       limit: parseInt(e.response.headers['x-ratelimit-limit']),
       resource:
         (e.response.headers['x-ratelimit-resource'] as string) || undefined,
+    };
+  } else if (e.message.includes(SECONDARY_RATE_LIMIT_MESSAGE)) {
+    // Secondary rate limit errors do not return remaining quotas
+    return {
+      resource: 'secondary',
     };
   }
 

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -515,6 +515,49 @@ describe('GCFBootstrapper', () => {
       assert.strictEqual(response.statusCode, 503);
     });
 
+    it('returns 503 on secondary rate limit errors', async () => {
+      await mockBootstrapper(undefined, async app => {
+        app.on('issues', async _ => {
+          throw new RequestError(
+            'You have exceeded a secondary rate limit. Please wait a few minutes before you try again.',
+            403,
+            {
+              response: {
+                headers: {},
+                status: 403,
+                url: '',
+                data: '',
+              },
+              request: {
+                headers: {},
+                method: 'POST',
+                url: '',
+              },
+            }
+          );
+        });
+      });
+      req.body = {
+        installation: {id: 1},
+      };
+      req.headers = {};
+      req.headers['x-github-event'] = 'issues';
+      req.headers['x-github-delivery'] = '123';
+      req.headers['x-cloudtasks-taskname'] = 'my-task';
+
+      await handler(req, response);
+
+      sinon.assert.calledOnce(configStub);
+      sinon.assert.notCalled(issueSpy);
+      sinon.assert.notCalled(repositoryCronSpy);
+      sinon.assert.notCalled(installationCronSpy);
+      sinon.assert.notCalled(globalCronSpy);
+      sinon.assert.notCalled(sendStatusStub);
+      sinon.assert.called(sendStub);
+
+      assert.strictEqual(response.statusCode, 503);
+    });
+
     it('ensures that task is enqueued when called by scheduler for one repo', async () => {
       await mockBootstrapper();
       req.body = {


### PR DESCRIPTION
Also catch GitHub API errors for secondary rate limits and return 503s

Towards #3878
