### PR TITLE
deps(release-trigger): use gcf-utils 13.8.0

### DIFF
--- a/packages/release-trigger/package-lock.json
+++ b/packages/release-trigger/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-automations/bot-config-utils": "^4.0.2",
         "@google-automations/datastore-lock": "^3.2.0",
-        "gcf-utils": "^13.7.0"
+        "gcf-utils": "^13.8.0"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.1",
@@ -3697,9 +3697,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.7.0.tgz",
-      "integrity": "sha512-Y7fYUwgAUNvS/9Hy+BoPMxUq9Y0I2YG7Jw9XPgmk0y6CEcqVwKQG3WixOQ8pyoy2KiQgZstCMAv89/bJV1A2rQ==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.8.0.tgz",
+      "integrity": "sha512-ufrWvRcXX7v+260fAjS1zsgHlbBlPD0Ua2KniMyQdNvLYslpqumk40LMECy1gAL2fiG9jFDFNNbEO83o9xJx5w==",
       "dependencies": {
         "@google-cloud/kms": "^2.4.2",
         "@google-cloud/secret-manager": "^3.7.3",
@@ -11073,9 +11073,9 @@
       }
     },
     "gcf-utils": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.7.0.tgz",
-      "integrity": "sha512-Y7fYUwgAUNvS/9Hy+BoPMxUq9Y0I2YG7Jw9XPgmk0y6CEcqVwKQG3WixOQ8pyoy2KiQgZstCMAv89/bJV1A2rQ==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.8.0.tgz",
+      "integrity": "sha512-ufrWvRcXX7v+260fAjS1zsgHlbBlPD0Ua2KniMyQdNvLYslpqumk40LMECy1gAL2fiG9jFDFNNbEO83o9xJx5w==",
       "requires": {
         "@google-cloud/kms": "^2.4.2",
         "@google-cloud/secret-manager": "^3.7.3",

--- a/packages/release-trigger/package.json
+++ b/packages/release-trigger/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@google-automations/bot-config-utils": "^4.0.2",
     "@google-automations/datastore-lock": "^3.2.0",
-    "gcf-utils": "^13.7.0"
+    "gcf-utils": "^13.8.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",


### PR DESCRIPTION
gcf-utils 13.8.0 has faster flow control by default

Testing canary bot with #3887