### PR TITLE
deps: update gcf-utils for quota throttling

### DIFF
--- a/packages/flakybot/package-lock.json
+++ b/packages/flakybot/package-lock.json
@@ -14,7 +14,7 @@
         "@google-automations/label-utils": "^2.0.2",
         "@octokit/openapi-types": "^12.0.0",
         "@octokit/types": "^6.34.0",
-        "gcf-utils": "^13.5.3",
+        "gcf-utils": "^13.8.0",
         "probot": "^12.2.4",
         "xml-js": "^1.6.11"
       },
@@ -3691,9 +3691,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.5.3.tgz",
-      "integrity": "sha512-sEfzdwY9Vbwg1y0575z8SLK7kTcPrz7Ug9GK6iiC5Dq7L2WmBbCK0YjRrNCerMnOuZpPKKrbVnjzlaQS016IFg==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.8.0.tgz",
+      "integrity": "sha512-ufrWvRcXX7v+260fAjS1zsgHlbBlPD0Ua2KniMyQdNvLYslpqumk40LMECy1gAL2fiG9jFDFNNbEO83o9xJx5w==",
       "dependencies": {
         "@google-cloud/kms": "^2.4.2",
         "@google-cloud/secret-manager": "^3.7.3",
@@ -3718,7 +3718,7 @@
         "get-stream": "^6.0.1",
         "into-stream": "^6.0.0",
         "octokit-auth-probot": "^1.2.6",
-        "pino": "^6.11.3",
+        "pino": "^8.0.0",
         "probot": "^12.1.0",
         "tmp": "^0.2.1",
         "uuid": "^8.3.2",
@@ -3730,6 +3730,37 @@
       "engines": {
         "node": ">= 12.18.2"
       }
+    },
+    "node_modules/gcf-utils/node_modules/pino": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.0.0.tgz",
+      "integrity": "sha512-EvZh9ZUoLGkrhqhoF9UBxw2/ZiAhXHUKlGrI4WUT/wLu0sfu8Wr3NJaZ6lxcy/S51W0PMSon5KE7ujPAhc/G6g==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^1.0.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^5.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^3.0.0",
+        "thread-stream": "^1.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/gcf-utils/node_modules/pino-std-serializers": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.5.0.tgz",
+      "integrity": "sha512-nfUj7JpkLStgTGdeq20KsNDZMsZoAcTlOKXxoSQBKQTcBbVAFTYUdkw7NADlEeFadqpnKN4w2fWHbpGLsdQXIg=="
+    },
+    "node_modules/gcf-utils/node_modules/process-warning": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
     },
     "node_modules/gcp-metadata": {
       "version": "5.0.0",
@@ -5826,6 +5857,11 @@
         "@octokit/core": ">=3.2"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-1.0.0.tgz",
+      "integrity": "sha512-Ve8ubhrXRdnuCJ5bQSQpP3uaV43K1PMcOfSRC1pqHgRZommXCgsXwh08jVC5NpjwScE23BPDwDvVg4cov3mwjw=="
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -6081,6 +6117,15 @@
       },
       "bin": {
         "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dependencies": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
       }
     },
     "node_modules/pino-http": {
@@ -6740,6 +6785,14 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -7005,6 +7058,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -7615,6 +7676,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "node_modules/thread-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-1.0.0.tgz",
+      "integrity": "sha512-2Sw29jWubQWOcVa7MhLHJ51wjksUD/GHN4Fy3hP9w9DYTujifoZGSKBl54CMLRXWoD5h2pD707kY3fAdzhcwAg==",
+      "dependencies": {
+        "real-require": "^0.1.0"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -11151,9 +11220,9 @@
       }
     },
     "gcf-utils": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.5.3.tgz",
-      "integrity": "sha512-sEfzdwY9Vbwg1y0575z8SLK7kTcPrz7Ug9GK6iiC5Dq7L2WmBbCK0YjRrNCerMnOuZpPKKrbVnjzlaQS016IFg==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.8.0.tgz",
+      "integrity": "sha512-ufrWvRcXX7v+260fAjS1zsgHlbBlPD0Ua2KniMyQdNvLYslpqumk40LMECy1gAL2fiG9jFDFNNbEO83o9xJx5w==",
       "requires": {
         "@google-cloud/kms": "^2.4.2",
         "@google-cloud/secret-manager": "^3.7.3",
@@ -11178,11 +11247,41 @@
         "get-stream": "^6.0.1",
         "into-stream": "^6.0.0",
         "octokit-auth-probot": "^1.2.6",
-        "pino": "^6.11.3",
+        "pino": "^8.0.0",
         "probot": "^12.1.0",
         "tmp": "^0.2.1",
         "uuid": "^8.3.2",
         "yargs": "^16.0.0"
+      },
+      "dependencies": {
+        "pino": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-8.0.0.tgz",
+          "integrity": "sha512-EvZh9ZUoLGkrhqhoF9UBxw2/ZiAhXHUKlGrI4WUT/wLu0sfu8Wr3NJaZ6lxcy/S51W0PMSon5KE7ujPAhc/G6g==",
+          "requires": {
+            "atomic-sleep": "^1.0.0",
+            "fast-redact": "^3.0.0",
+            "on-exit-leak-free": "^1.0.0",
+            "pino-abstract-transport": "v0.5.0",
+            "pino-std-serializers": "^5.0.0",
+            "process-warning": "^2.0.0",
+            "quick-format-unescaped": "^4.0.3",
+            "real-require": "^0.1.0",
+            "safe-stable-stringify": "^2.1.0",
+            "sonic-boom": "^3.0.0",
+            "thread-stream": "^1.0.0"
+          }
+        },
+        "pino-std-serializers": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.5.0.tgz",
+          "integrity": "sha512-nfUj7JpkLStgTGdeq20KsNDZMsZoAcTlOKXxoSQBKQTcBbVAFTYUdkw7NADlEeFadqpnKN4w2fWHbpGLsdQXIg=="
+        },
+        "process-warning": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+          "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
+        }
       }
     },
     "gcp-metadata": {
@@ -12760,6 +12859,11 @@
         "@octokit/types": "^6.1.1"
       }
     },
+    "on-exit-leak-free": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-1.0.0.tgz",
+      "integrity": "sha512-Ve8ubhrXRdnuCJ5bQSQpP3uaV43K1PMcOfSRC1pqHgRZommXCgsXwh08jVC5NpjwScE23BPDwDvVg4cov3mwjw=="
+    },
     "on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -12950,6 +13054,15 @@
             "flatstr": "^1.0.12"
           }
         }
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "requires": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
       }
     },
     "pino-http": {
@@ -13460,6 +13573,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -13630,6 +13748,11 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -14114,6 +14237,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "thread-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-1.0.0.tgz",
+      "integrity": "sha512-2Sw29jWubQWOcVa7MhLHJ51wjksUD/GHN4Fy3hP9w9DYTujifoZGSKBl54CMLRXWoD5h2pD707kY3fAdzhcwAg==",
+      "requires": {
+        "real-require": "^0.1.0"
+      }
     },
     "through": {
       "version": "2.3.8",

--- a/packages/flakybot/package.json
+++ b/packages/flakybot/package.json
@@ -32,7 +32,7 @@
     "@google-automations/label-utils": "^2.0.2",
     "@octokit/openapi-types": "^12.0.0",
     "@octokit/types": "^6.34.0",
-    "gcf-utils": "^13.5.3",
+    "gcf-utils": "^13.8.0",
     "probot": "^12.2.4",
     "xml-js": "^1.6.11"
   },


### PR DESCRIPTION
gcf-utils added the ability to return a 503 on quota errors to provide backpressure on Cloud Tasks to slow down retries.

Hopefully fixes #3773
