### PR TITLE
deps(blunderbuss): use gcf-utils 13.8.1

### DIFF
--- a/packages/blunderbuss/cloudbuild.yaml
+++ b/packages/blunderbuss/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs12"
+      - "nodejs14"
 
   - name: gcr.io/cloud-builders/npm
     id: "cron-deploy"

--- a/packages/blunderbuss/package-lock.json
+++ b/packages/blunderbuss/package-lock.json
@@ -12,7 +12,7 @@
         "@google-automations/bot-config-utils": "^4.0.2",
         "@google-automations/datastore-lock": "^3.2.0",
         "@google-automations/label-utils": "^2.0.2",
-        "gcf-utils": "^13.5.3"
+        "gcf-utils": "^13.8.1"
       },
       "devDependencies": {
         "@octokit/types": "^6.34.0",
@@ -310,14 +310,51 @@
       }
     },
     "node_modules/@google-cloud/kms": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-2.11.1.tgz",
-      "integrity": "sha512-rmRQ9MVlEeKySlTP4QAwP9CY5UZqQ1Mpdeqe0N3FW+2HjJ2uH0oOSawv7UKa8+nQEx6R4SJI2u0A9Le5Wrd72A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-3.0.0.tgz",
+      "integrity": "sha512-g9lzT/BtYF5zx9YjjGYSXbygIWdZoUKXN07ImW649gqZU+URcA78isS6KrgrLSW3IBqzb/8Gf7A+UZUp1UuyvQ==",
       "dependencies": {
-        "google-gax": "^2.24.1"
+        "google-gax": "^3.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/google-gax": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.1.1.tgz",
+      "integrity": "sha512-lLiv6s3Ax5i0Iqy/crHrIZuaU1AYZvTj/F8DCcdJvmDWDsFSVSh+KkCEkKGd7PHck3dVB58NnbC4FIiRpTq4WQ==",
+      "dependencies": {
+        "@grpc/grpc-js": "~1.6.0",
+        "@grpc/proto-loader": "^0.6.12",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "fast-text-encoding": "^1.0.3",
+        "google-auth-library": "^8.0.2",
+        "is-stream-ended": "^0.1.4",
+        "node-fetch": "^2.6.1",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^1.0.0",
+        "protobufjs": "6.11.3",
+        "retry-request": "^5.0.0"
+      },
+      "bin": {
+        "compileProtos": "build/tools/compileProtos.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@google-cloud/kms/node_modules/proto3-json-serializer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.0.1.tgz",
+      "integrity": "sha512-jtnGKL8EE1mTOl2qgMZJQXbS22dlb2K07i4b5vp8yMGMJ6mFSgBg4Ossu/g9NCuamdYXHjp3XxyWw4tJ0G/uKw==",
+      "dependencies": {
+        "protobufjs": "^6.11.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@google-cloud/paginator": {
@@ -360,9 +397,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.0.1.tgz",
-      "integrity": "sha512-52P3A8IpqISc2aeGxx/DQyqDmG0uP5wUW3dsns4ZPKZS5jbllFMy0V7qzY2vVv7GgpIULIKQ26yEWjSEA/pLng==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.1.0.tgz",
+      "integrity": "sha512-zqZwzpRWCJuPne7x9Vc2H79zANl0uh9bNPGis0xAuC88ZEvBXfQqYCAVyiL1YIxi7rf51l8wy9vBr1pONMfxxA==",
       "dependencies": {
         "@google-cloud/paginator": "^3.0.7",
         "@google-cloud/projectify": "^2.0.0",
@@ -398,20 +435,57 @@
       }
     },
     "node_modules/@google-cloud/tasks": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-2.6.0.tgz",
-      "integrity": "sha512-/9vooPWv+aOxExd1OZWvV8qCUHdoUFgkkpZQWgjZXFORhtyamlCZd/FWfZ4igChNm10lIpTIw13oxeDBMfbG2w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-3.0.0.tgz",
+      "integrity": "sha512-QGAA26IqTttWPbkOVhwlc0o4B189dOMxtNmNfAvYDjBzg1zHZ1XoWVV/3No+razTtP9UPMi58JTyT3QwfCx4fQ==",
       "dependencies": {
-        "google-gax": "^2.24.1"
+        "google-gax": "^3.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@google-cloud/tasks/node_modules/google-gax": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.1.1.tgz",
+      "integrity": "sha512-lLiv6s3Ax5i0Iqy/crHrIZuaU1AYZvTj/F8DCcdJvmDWDsFSVSh+KkCEkKGd7PHck3dVB58NnbC4FIiRpTq4WQ==",
+      "dependencies": {
+        "@grpc/grpc-js": "~1.6.0",
+        "@grpc/proto-loader": "^0.6.12",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "fast-text-encoding": "^1.0.3",
+        "google-auth-library": "^8.0.2",
+        "is-stream-ended": "^0.1.4",
+        "node-fetch": "^2.6.1",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^1.0.0",
+        "protobufjs": "6.11.3",
+        "retry-request": "^5.0.0"
+      },
+      "bin": {
+        "compileProtos": "build/tools/compileProtos.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@google-cloud/tasks/node_modules/proto3-json-serializer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.0.1.tgz",
+      "integrity": "sha512-jtnGKL8EE1mTOl2qgMZJQXbS22dlb2K07i4b5vp8yMGMJ6mFSgBg4Ossu/g9NCuamdYXHjp3XxyWw4tJ0G/uKw==",
+      "dependencies": {
+        "protobufjs": "^6.11.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@googleapis/run": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@googleapis/run/-/run-8.0.2.tgz",
-      "integrity": "sha512-QAu7YVgTyUB+wBVZ8cEH4GG1ICfKxwQCxL1Xdxmn5EKnxLoksmv4rJbzompIF8zbLr3LQLpmYFYblatQ1Pd4sw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/run/-/run-9.0.0.tgz",
+      "integrity": "sha512-c9QhEln5xmT5zv5vyne58vDoXPMz5UTG60DRLP0rNd97bN4KZC1NvHeqPoY2gnGYpNX21c1l0oI25k7GMwj+/Q==",
       "dependencies": {
         "googleapis-common": "^5.0.1"
       },
@@ -432,14 +506,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.12.tgz",
-      "integrity": "sha512-filTVbETFnxb9CyRX98zN18ilChTuf/C5scZ2xyaOTp0EHGq0/ufX8rjqXUcSb1Gpv7eZq4M2jDvbh9BogKnrg==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
+        "protobufjs": "^6.11.3",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -706,9 +780,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
-      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.1.0.tgz",
+      "integrity": "sha512-kQzJh3ZUv3lDpi6M+uekMRHULvf9DlWoI1XgKN6nPeGDzkSgtkhVq1MMz3bFKQ6H6GbdC3ZqG/a6VzKhIx0VeA=="
     },
     "node_modules/@octokit/plugin-enterprise-compatibility": {
       "version": "1.3.0",
@@ -720,11 +794,11 @@
       }
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
-      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.18.0.tgz",
+      "integrity": "sha512-n5/AzIoy5Wzp85gqzSbR+dWQDHlyHZrGijnDfLh452547Ynu0hCvszH7EfRE0eqM5ZjfkplO0k+q+P8AAIIJEA==",
       "dependencies": {
-        "@octokit/types": "^6.34.0"
+        "@octokit/types": "^6.35.0"
       },
       "peerDependencies": {
         "@octokit/core": ">=2"
@@ -739,11 +813,11 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
-      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.14.0.tgz",
+      "integrity": "sha512-MRnMs4Dcm1OSaz/g/RLr4YY9otgysS7vN5SUkHGd7t+R8323cHsHFoEWHYPSmgUC0BieHRhvnCRWb4i3Pl+Lgg==",
       "dependencies": {
-        "@octokit/types": "^6.34.0",
+        "@octokit/types": "^6.35.0",
         "deprecation": "^2.3.1"
       },
       "peerDependencies": {
@@ -806,21 +880,21 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
-      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.35.0.tgz",
+      "integrity": "sha512-DhLfdUuv3H37u6jBDfkwamypx3HflHg29b26nbA6iVFYkAlZ5cMEtu/9pQoihGnQE5M7jJFnNo25Rr1UwQNF8Q==",
       "dependencies": {
-        "@octokit/openapi-types": "^11.2.0"
+        "@octokit/openapi-types": "^12.1.0"
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.24.0.tgz",
-      "integrity": "sha512-s1nqplA+j4sP7Cz40jn/Q2ipkKRKJ7Gi+NzZiSnwNfisYNduLHEwMUJVBEKc5I0r6GMcZZRJOe6PJ2rJXYW66g==",
+      "version": "9.26.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.0.tgz",
+      "integrity": "sha512-foZlsgrTDwAmD5j2Czn6ji10lbWjGDVsUxTIydjG9KTkAWKJrFapXJgO5SbGxRwfPd3OJdhK3nA2YPqVhxLXqA==",
       "dependencies": {
         "@octokit/request-error": "^2.0.2",
         "@octokit/webhooks-methods": "^2.0.0",
-        "@octokit/webhooks-types": "5.6.0",
+        "@octokit/webhooks-types": "5.8.0",
         "aggregate-error": "^3.1.0"
       }
     },
@@ -830,9 +904,9 @@
       "integrity": "sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig=="
     },
     "node_modules/@octokit/webhooks-types": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.6.0.tgz",
-      "integrity": "sha512-y3MqE6N6Ksg1+YV0sXVpW2WP7Y24h7rUp2hDJuzoqWdKGr7owmRDyHC72INwfCYNzura/vsNPXvc6Xbfp4wGGw=="
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
+      "integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw=="
     },
     "node_modules/@probot/get-private-key": {
       "version": "1.1.1",
@@ -1136,9 +1210,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.28",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
-      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "version": "4.17.29",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
+      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1224,9 +1298,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.40.tgz",
-      "integrity": "sha512-UXdBxNGqTMtm7hCwh9HtncFVLrXoqA3oJW30j6XWp5BH/wu3mVeaxo7cq5benFdBw34HB3XDT2TRPI7rXZ+mDg=="
+      "version": "17.0.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.44.tgz",
+      "integrity": "sha512-gWYiOlu6Y4oyLYBvsJAPlwHbC8H4tX+tLsHy6Ee976wedwwZKrG2hFl3Y/HiH6bIyLTbDWQexQF/ohwKkOpUCg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -3800,15 +3874,15 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.5.3.tgz",
-      "integrity": "sha512-sEfzdwY9Vbwg1y0575z8SLK7kTcPrz7Ug9GK6iiC5Dq7L2WmBbCK0YjRrNCerMnOuZpPKKrbVnjzlaQS016IFg==",
+      "version": "13.8.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.8.1.tgz",
+      "integrity": "sha512-MQVIbmsYQFpCYjp6G6IVF1sv8FOfjlYRaUbccb4IUF7s4fe0np6kbr9tEXhw5tG06jnHhfrNxi+J7zQEqi23lg==",
       "dependencies": {
-        "@google-cloud/kms": "^2.4.2",
+        "@google-cloud/kms": "^3.0.0",
         "@google-cloud/secret-manager": "^3.7.3",
         "@google-cloud/storage": "^6.0.0",
-        "@google-cloud/tasks": "^2.3.4",
-        "@googleapis/run": "^8.0.0",
+        "@google-cloud/tasks": "^3.0.0",
+        "@googleapis/run": "^9.0.0",
         "@octokit/plugin-enterprise-compatibility": "1.3.0",
         "@octokit/rest": "^18.5.2",
         "@probot/octokit-plugin-config": "^1.0.0",
@@ -3827,7 +3901,7 @@
         "get-stream": "^6.0.1",
         "into-stream": "^6.0.0",
         "octokit-auth-probot": "^1.2.6",
-        "pino": "^6.11.3",
+        "pino": "^8.0.0",
         "probot": "^12.1.0",
         "tmp": "^0.2.1",
         "uuid": "^8.3.2",
@@ -3861,13 +3935,13 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5825,9 +5899,9 @@
       }
     },
     "node_modules/nock": {
-      "version": "13.2.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.6.tgz",
-      "integrity": "sha512-GbyeSwSEP0FYouzETZ0l/XNm5tNcDNcXJKw3LCAb+mx8bZSwg1wEEvdL0FAyg5TkBJYiWSCtw6ag4XfmBy60FA==",
+      "version": "13.2.7",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.7.tgz",
+      "integrity": "sha512-R6NUw7RIPtKwgK7jskuKoEi4VFMqIHtV2Uu9K/Uegc4TA5cqe+oNMYslZcUmnVNQCTG6wcSqUBaGTDd7sq5srg==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.0",
@@ -5972,6 +6046,11 @@
         "@octokit/core": ">=3.2"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-1.0.0.tgz",
+      "integrity": "sha512-Ve8ubhrXRdnuCJ5bQSQpP3uaV43K1PMcOfSRC1pqHgRZommXCgsXwh08jVC5NpjwScE23BPDwDvVg4cov3mwjw=="
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -6030,15 +6109,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-      "dev": true,
-      "dependencies": {
-        "url-parse": "^1.4.3"
       }
     },
     "node_modules/os-tmpdir": {
@@ -6231,6 +6301,46 @@
       }
     },
     "node_modules/pino": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.0.0.tgz",
+      "integrity": "sha512-EvZh9ZUoLGkrhqhoF9UBxw2/ZiAhXHUKlGrI4WUT/wLu0sfu8Wr3NJaZ6lxcy/S51W0PMSon5KE7ujPAhc/G6g==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^1.0.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^5.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^3.0.0",
+        "thread-stream": "^1.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dependencies": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-http": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.8.0.tgz",
+      "integrity": "sha512-YwXiyRb9y0WCD1P9PcxuJuh3Dc5qmXde/paJE86UGYRdiFOi828hR9iUGmk5gaw6NBT9gLtKANOHFimvh19U5w==",
+      "dependencies": {
+        "fast-url-parser": "^1.1.3",
+        "pino": "^6.13.0",
+        "pino-std-serializers": "^4.0.0"
+      }
+    },
+    "node_modules/pino-http/node_modules/pino": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
       "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
@@ -6247,20 +6357,29 @@
         "pino": "bin.js"
       }
     },
-    "node_modules/pino-http": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.8.0.tgz",
-      "integrity": "sha512-YwXiyRb9y0WCD1P9PcxuJuh3Dc5qmXde/paJE86UGYRdiFOi828hR9iUGmk5gaw6NBT9gLtKANOHFimvh19U5w==",
-      "dependencies": {
-        "fast-url-parser": "^1.1.3",
-        "pino": "^6.13.0",
-        "pino-std-serializers": "^4.0.0"
-      }
-    },
     "node_modules/pino-http/node_modules/pino-std-serializers": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
       "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
+    },
+    "node_modules/pino-http/node_modules/pino/node_modules/pino-std-serializers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+    },
+    "node_modules/pino-http/node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
+    "node_modules/pino-http/node_modules/sonic-boom": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
+      }
     },
     "node_modules/pino-pretty": {
       "version": "6.0.0",
@@ -6293,18 +6412,9 @@
       }
     },
     "node_modules/pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
-    },
-    "node_modules/pino/node_modules/sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
-      }
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.6.0.tgz",
+      "integrity": "sha512-VdUXCw8gO+xhir7sFuoYSjTnzB+TMDGxhAC/ph3YS3sdHnXNdsK0wMtADNUltfeGkn2KDxEM21fnjF3RwXyC8A=="
     },
     "node_modules/pkg-conf": {
       "version": "3.1.0",
@@ -6401,9 +6511,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.0.tgz",
+      "integrity": "sha512-nwoX4GMFgxoPC6diHvSwmK/4yU8FFH3V8XWtLQrbj4IBsK2pkYhG4kf/ljF/haaZ/aii+wNJqISrCDPgxGWDVQ==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -6506,15 +6616,51 @@
         "node": ">=10"
       }
     },
+    "node_modules/probot/node_modules/pino": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
+      "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
+      "dependencies": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.8",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^3.1.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "sonic-boom": "^1.0.2"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/probot/node_modules/pino-std-serializers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+    },
+    "node_modules/probot/node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
+    "node_modules/probot/node_modules/sonic-boom": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/process-warning": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -6628,12 +6774,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6733,7 +6873,7 @@
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6910,6 +7050,14 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6931,7 +7079,7 @@
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
       "engines": {
         "node": ">=4"
       }
@@ -6939,7 +7087,7 @@
     "node_modules/redis-parser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -6984,7 +7132,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6996,12 +7144,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -7031,7 +7173,7 @@
     "node_modules/responselike": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
       "dependencies": {
         "lowercase-keys": "^1.0.0"
       }
@@ -7058,9 +7200,9 @@
       }
     },
     "node_modules/retry-request": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.0.tgz",
-      "integrity": "sha512-vBZdBxUordje9253imlmGtppC5gdcwZmNz7JnU2ui+KKFPk25keR+0c020AVV20oesYxIFOI0Kh3HE88/59ieg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.1.tgz",
+      "integrity": "sha512-lxFKrlBt0OZzCWh/V0uPEN0vlr3OhdeXnpeY5OES+ckslm791Cb1D5P7lJUSnY7J5hiCjcyaUGmzCnIGDCUBig==",
       "dependencies": {
         "debug": "^4.1.1",
         "extend": "^3.0.2"
@@ -7181,6 +7323,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -7404,13 +7554,10 @@
       "dev": true
     },
     "node_modules/smee-client/node_modules/eventsource": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.1.tgz",
-      "integrity": "sha512-qV5ZC0h7jYIAOhArFJgSfdyz6rALJyb270714o7ZtNnw2WSJ+eexhKtE0O8LYPRsHZHf2osHKZBxGPvm3kPkCA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.2.tgz",
+      "integrity": "sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA==",
       "dev": true,
-      "dependencies": {
-        "original": "^1.0.0"
-      },
       "engines": {
         "node": ">=0.12.0"
       }
@@ -7632,7 +7779,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
@@ -7695,7 +7842,7 @@
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "engines": {
         "node": ">=4"
       }
@@ -7735,7 +7882,7 @@
     "node_modules/stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
     "node_modules/superagent": {
       "version": "7.1.6",
@@ -7875,13 +8022,21 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/thread-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-1.0.0.tgz",
+      "integrity": "sha512-2Sw29jWubQWOcVa7MhLHJ51wjksUD/GHN4Fy3hP9w9DYTujifoZGSKBl54CMLRXWoD5h2pD707kY3fAdzhcwAg==",
+      "dependencies": {
+        "real-require": "^0.1.0"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "node_modules/tmp": {
@@ -7926,7 +8081,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
@@ -8004,7 +8159,7 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -8028,9 +8183,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.15.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
-      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.0.tgz",
+      "integrity": "sha512-FEikl6bR30n0T3amyBh3LoiBdqHRy/f4H80+My34HOesOKyHfOsxAPAxOoqC0JUnC1amnO0IwkYC3sko51caSw==",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -8067,7 +8222,7 @@
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -8155,20 +8310,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
       "dependencies": {
         "prepend-http": "^2.0.0"
       },
@@ -8179,17 +8324,17 @@
     "node_modules/url-template": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -8244,7 +8389,7 @@
     "node_modules/variable-diff": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/variable-diff/-/variable-diff-1.1.0.tgz",
-      "integrity": "sha1-0r1cZtt2wTh52W5qMG7cmJ35eNo=",
+      "integrity": "sha512-0Jk/MsCNtL/fCuVIbsLxwXpABGZCzN57btcPbSsjOOAwkdHJ3Y58fo8BoUfG7jghnvglbwo+5Hk1KOJ2W2Ormw==",
       "dev": true,
       "dependencies": {
         "chalk": "^1.1.1",
@@ -8297,7 +8442,7 @@
     "node_modules/variable-diff/node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -8309,7 +8454,7 @@
     "node_modules/variable-diff/node_modules/supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -8318,7 +8463,7 @@
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -8326,12 +8471,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -8375,7 +8520,7 @@
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/workerpool": {
       "version": "6.2.1",
@@ -8402,7 +8547,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -8744,11 +8889,41 @@
       }
     },
     "@google-cloud/kms": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-2.11.1.tgz",
-      "integrity": "sha512-rmRQ9MVlEeKySlTP4QAwP9CY5UZqQ1Mpdeqe0N3FW+2HjJ2uH0oOSawv7UKa8+nQEx6R4SJI2u0A9Le5Wrd72A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-3.0.0.tgz",
+      "integrity": "sha512-g9lzT/BtYF5zx9YjjGYSXbygIWdZoUKXN07ImW649gqZU+URcA78isS6KrgrLSW3IBqzb/8Gf7A+UZUp1UuyvQ==",
       "requires": {
-        "google-gax": "^2.24.1"
+        "google-gax": "^3.0.1"
+      },
+      "dependencies": {
+        "google-gax": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.1.1.tgz",
+          "integrity": "sha512-lLiv6s3Ax5i0Iqy/crHrIZuaU1AYZvTj/F8DCcdJvmDWDsFSVSh+KkCEkKGd7PHck3dVB58NnbC4FIiRpTq4WQ==",
+          "requires": {
+            "@grpc/grpc-js": "~1.6.0",
+            "@grpc/proto-loader": "^0.6.12",
+            "@types/long": "^4.0.0",
+            "abort-controller": "^3.0.0",
+            "duplexify": "^4.0.0",
+            "fast-text-encoding": "^1.0.3",
+            "google-auth-library": "^8.0.2",
+            "is-stream-ended": "^0.1.4",
+            "node-fetch": "^2.6.1",
+            "object-hash": "^3.0.0",
+            "proto3-json-serializer": "^1.0.0",
+            "protobufjs": "6.11.3",
+            "retry-request": "^5.0.0"
+          }
+        },
+        "proto3-json-serializer": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.0.1.tgz",
+          "integrity": "sha512-jtnGKL8EE1mTOl2qgMZJQXbS22dlb2K07i4b5vp8yMGMJ6mFSgBg4Ossu/g9NCuamdYXHjp3XxyWw4tJ0G/uKw==",
+          "requires": {
+            "protobufjs": "^6.11.3"
+          }
+        }
       }
     },
     "@google-cloud/paginator": {
@@ -8779,9 +8954,9 @@
       }
     },
     "@google-cloud/storage": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.0.1.tgz",
-      "integrity": "sha512-52P3A8IpqISc2aeGxx/DQyqDmG0uP5wUW3dsns4ZPKZS5jbllFMy0V7qzY2vVv7GgpIULIKQ26yEWjSEA/pLng==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.1.0.tgz",
+      "integrity": "sha512-zqZwzpRWCJuPne7x9Vc2H79zANl0uh9bNPGis0xAuC88ZEvBXfQqYCAVyiL1YIxi7rf51l8wy9vBr1pONMfxxA==",
       "requires": {
         "@google-cloud/paginator": "^3.0.7",
         "@google-cloud/projectify": "^2.0.0",
@@ -8813,17 +8988,47 @@
       }
     },
     "@google-cloud/tasks": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-2.6.0.tgz",
-      "integrity": "sha512-/9vooPWv+aOxExd1OZWvV8qCUHdoUFgkkpZQWgjZXFORhtyamlCZd/FWfZ4igChNm10lIpTIw13oxeDBMfbG2w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-3.0.0.tgz",
+      "integrity": "sha512-QGAA26IqTttWPbkOVhwlc0o4B189dOMxtNmNfAvYDjBzg1zHZ1XoWVV/3No+razTtP9UPMi58JTyT3QwfCx4fQ==",
       "requires": {
-        "google-gax": "^2.24.1"
+        "google-gax": "^3.0.1"
+      },
+      "dependencies": {
+        "google-gax": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.1.1.tgz",
+          "integrity": "sha512-lLiv6s3Ax5i0Iqy/crHrIZuaU1AYZvTj/F8DCcdJvmDWDsFSVSh+KkCEkKGd7PHck3dVB58NnbC4FIiRpTq4WQ==",
+          "requires": {
+            "@grpc/grpc-js": "~1.6.0",
+            "@grpc/proto-loader": "^0.6.12",
+            "@types/long": "^4.0.0",
+            "abort-controller": "^3.0.0",
+            "duplexify": "^4.0.0",
+            "fast-text-encoding": "^1.0.3",
+            "google-auth-library": "^8.0.2",
+            "is-stream-ended": "^0.1.4",
+            "node-fetch": "^2.6.1",
+            "object-hash": "^3.0.0",
+            "proto3-json-serializer": "^1.0.0",
+            "protobufjs": "6.11.3",
+            "retry-request": "^5.0.0"
+          }
+        },
+        "proto3-json-serializer": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.0.1.tgz",
+          "integrity": "sha512-jtnGKL8EE1mTOl2qgMZJQXbS22dlb2K07i4b5vp8yMGMJ6mFSgBg4Ossu/g9NCuamdYXHjp3XxyWw4tJ0G/uKw==",
+          "requires": {
+            "protobufjs": "^6.11.3"
+          }
+        }
       }
     },
     "@googleapis/run": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@googleapis/run/-/run-8.0.2.tgz",
-      "integrity": "sha512-QAu7YVgTyUB+wBVZ8cEH4GG1ICfKxwQCxL1Xdxmn5EKnxLoksmv4rJbzompIF8zbLr3LQLpmYFYblatQ1Pd4sw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/run/-/run-9.0.0.tgz",
+      "integrity": "sha512-c9QhEln5xmT5zv5vyne58vDoXPMz5UTG60DRLP0rNd97bN4KZC1NvHeqPoY2gnGYpNX21c1l0oI25k7GMwj+/Q==",
       "requires": {
         "googleapis-common": "^5.0.1"
       }
@@ -8838,14 +9043,14 @@
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.12.tgz",
-      "integrity": "sha512-filTVbETFnxb9CyRX98zN18ilChTuf/C5scZ2xyaOTp0EHGq0/ufX8rjqXUcSb1Gpv7eZq4M2jDvbh9BogKnrg==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
+        "protobufjs": "^6.11.3",
         "yargs": "^16.2.0"
       }
     },
@@ -9081,9 +9286,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
-      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.1.0.tgz",
+      "integrity": "sha512-kQzJh3ZUv3lDpi6M+uekMRHULvf9DlWoI1XgKN6nPeGDzkSgtkhVq1MMz3bFKQ6H6GbdC3ZqG/a6VzKhIx0VeA=="
     },
     "@octokit/plugin-enterprise-compatibility": {
       "version": "1.3.0",
@@ -9095,11 +9300,11 @@
       }
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
-      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.18.0.tgz",
+      "integrity": "sha512-n5/AzIoy5Wzp85gqzSbR+dWQDHlyHZrGijnDfLh452547Ynu0hCvszH7EfRE0eqM5ZjfkplO0k+q+P8AAIIJEA==",
       "requires": {
-        "@octokit/types": "^6.34.0"
+        "@octokit/types": "^6.35.0"
       }
     },
     "@octokit/plugin-request-log": {
@@ -9109,11 +9314,11 @@
       "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
-      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.14.0.tgz",
+      "integrity": "sha512-MRnMs4Dcm1OSaz/g/RLr4YY9otgysS7vN5SUkHGd7t+R8323cHsHFoEWHYPSmgUC0BieHRhvnCRWb4i3Pl+Lgg==",
       "requires": {
-        "@octokit/types": "^6.34.0",
+        "@octokit/types": "^6.35.0",
         "deprecation": "^2.3.1"
       }
     },
@@ -9170,21 +9375,21 @@
       }
     },
     "@octokit/types": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
-      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.35.0.tgz",
+      "integrity": "sha512-DhLfdUuv3H37u6jBDfkwamypx3HflHg29b26nbA6iVFYkAlZ5cMEtu/9pQoihGnQE5M7jJFnNo25Rr1UwQNF8Q==",
       "requires": {
-        "@octokit/openapi-types": "^11.2.0"
+        "@octokit/openapi-types": "^12.1.0"
       }
     },
     "@octokit/webhooks": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.24.0.tgz",
-      "integrity": "sha512-s1nqplA+j4sP7Cz40jn/Q2ipkKRKJ7Gi+NzZiSnwNfisYNduLHEwMUJVBEKc5I0r6GMcZZRJOe6PJ2rJXYW66g==",
+      "version": "9.26.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.0.tgz",
+      "integrity": "sha512-foZlsgrTDwAmD5j2Czn6ji10lbWjGDVsUxTIydjG9KTkAWKJrFapXJgO5SbGxRwfPd3OJdhK3nA2YPqVhxLXqA==",
       "requires": {
         "@octokit/request-error": "^2.0.2",
         "@octokit/webhooks-methods": "^2.0.0",
-        "@octokit/webhooks-types": "5.6.0",
+        "@octokit/webhooks-types": "5.8.0",
         "aggregate-error": "^3.1.0"
       }
     },
@@ -9194,9 +9399,9 @@
       "integrity": "sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig=="
     },
     "@octokit/webhooks-types": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.6.0.tgz",
-      "integrity": "sha512-y3MqE6N6Ksg1+YV0sXVpW2WP7Y24h7rUp2hDJuzoqWdKGr7owmRDyHC72INwfCYNzura/vsNPXvc6Xbfp4wGGw=="
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
+      "integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw=="
     },
     "@probot/get-private-key": {
       "version": "1.1.1",
@@ -9466,9 +9671,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.28",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
-      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "version": "4.17.29",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
+      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -9552,9 +9757,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.40.tgz",
-      "integrity": "sha512-UXdBxNGqTMtm7hCwh9HtncFVLrXoqA3oJW30j6XWp5BH/wu3mVeaxo7cq5benFdBw34HB3XDT2TRPI7rXZ+mDg=="
+      "version": "17.0.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.44.tgz",
+      "integrity": "sha512-gWYiOlu6Y4oyLYBvsJAPlwHbC8H4tX+tLsHy6Ee976wedwwZKrG2hFl3Y/HiH6bIyLTbDWQexQF/ohwKkOpUCg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -11511,15 +11716,15 @@
       }
     },
     "gcf-utils": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.5.3.tgz",
-      "integrity": "sha512-sEfzdwY9Vbwg1y0575z8SLK7kTcPrz7Ug9GK6iiC5Dq7L2WmBbCK0YjRrNCerMnOuZpPKKrbVnjzlaQS016IFg==",
+      "version": "13.8.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-13.8.1.tgz",
+      "integrity": "sha512-MQVIbmsYQFpCYjp6G6IVF1sv8FOfjlYRaUbccb4IUF7s4fe0np6kbr9tEXhw5tG06jnHhfrNxi+J7zQEqi23lg==",
       "requires": {
-        "@google-cloud/kms": "^2.4.2",
+        "@google-cloud/kms": "^3.0.0",
         "@google-cloud/secret-manager": "^3.7.3",
         "@google-cloud/storage": "^6.0.0",
-        "@google-cloud/tasks": "^2.3.4",
-        "@googleapis/run": "^8.0.0",
+        "@google-cloud/tasks": "^3.0.0",
+        "@googleapis/run": "^9.0.0",
         "@octokit/plugin-enterprise-compatibility": "1.3.0",
         "@octokit/rest": "^18.5.2",
         "@probot/octokit-plugin-config": "^1.0.0",
@@ -11538,7 +11743,7 @@
         "get-stream": "^6.0.1",
         "into-stream": "^6.0.0",
         "octokit-auth-probot": "^1.2.6",
-        "pino": "^6.11.3",
+        "pino": "^8.0.0",
         "probot": "^12.1.0",
         "tmp": "^0.2.1",
         "uuid": "^8.3.2",
@@ -11560,13 +11765,13 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
     },
     "get-stream": {
@@ -13050,9 +13255,9 @@
       }
     },
     "nock": {
-      "version": "13.2.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.6.tgz",
-      "integrity": "sha512-GbyeSwSEP0FYouzETZ0l/XNm5tNcDNcXJKw3LCAb+mx8bZSwg1wEEvdL0FAyg5TkBJYiWSCtw6ag4XfmBy60FA==",
+      "version": "13.2.7",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.7.tgz",
+      "integrity": "sha512-R6NUw7RIPtKwgK7jskuKoEi4VFMqIHtV2Uu9K/Uegc4TA5cqe+oNMYslZcUmnVNQCTG6wcSqUBaGTDd7sq5srg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -13150,6 +13355,11 @@
         "@octokit/types": "^6.1.1"
       }
     },
+    "on-exit-leak-free": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-1.0.0.tgz",
+      "integrity": "sha512-Ve8ubhrXRdnuCJ5bQSQpP3uaV43K1PMcOfSRC1pqHgRZommXCgsXwh08jVC5NpjwScE23BPDwDvVg4cov3mwjw=="
+    },
     "on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -13193,15 +13403,6 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
-      }
-    },
-    "original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-      "dev": true,
-      "requires": {
-        "url-parse": "^1.4.3"
       }
     },
     "os-tmpdir": {
@@ -13333,28 +13534,30 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
     "pino": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
-      "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.0.0.tgz",
+      "integrity": "sha512-EvZh9ZUoLGkrhqhoF9UBxw2/ZiAhXHUKlGrI4WUT/wLu0sfu8Wr3NJaZ6lxcy/S51W0PMSon5KE7ujPAhc/G6g==",
       "requires": {
+        "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.8",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
-        "process-warning": "^1.0.0",
+        "on-exit-leak-free": "^1.0.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^5.0.0",
+        "process-warning": "^2.0.0",
         "quick-format-unescaped": "^4.0.3",
-        "sonic-boom": "^1.0.2"
-      },
-      "dependencies": {
-        "sonic-boom": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-          "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-          "requires": {
-            "atomic-sleep": "^1.0.0",
-            "flatstr": "^1.0.12"
-          }
-        }
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^3.0.0",
+        "thread-stream": "^1.0.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "requires": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
       }
     },
     "pino-http": {
@@ -13367,10 +13570,45 @@
         "pino-std-serializers": "^4.0.0"
       },
       "dependencies": {
+        "pino": {
+          "version": "6.14.0",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
+          "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
+          "requires": {
+            "fast-redact": "^3.0.0",
+            "fast-safe-stringify": "^2.0.8",
+            "flatstr": "^1.0.12",
+            "pino-std-serializers": "^3.1.0",
+            "process-warning": "^1.0.0",
+            "quick-format-unescaped": "^4.0.3",
+            "sonic-boom": "^1.0.2"
+          },
+          "dependencies": {
+            "pino-std-serializers": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+              "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+            }
+          }
+        },
         "pino-std-serializers": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
           "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
+        },
+        "process-warning": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+          "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+        },
+        "sonic-boom": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+          "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+          "requires": {
+            "atomic-sleep": "^1.0.0",
+            "flatstr": "^1.0.12"
+          }
         }
       }
     },
@@ -13404,9 +13642,9 @@
       }
     },
     "pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.6.0.tgz",
+      "integrity": "sha512-VdUXCw8gO+xhir7sFuoYSjTnzB+TMDGxhAC/ph3YS3sdHnXNdsK0wMtADNUltfeGkn2KDxEM21fnjF3RwXyC8A=="
     },
     "pkg-conf": {
       "version": "3.1.0",
@@ -13475,9 +13713,9 @@
       "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA=="
     },
     "prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.0.tgz",
+      "integrity": "sha512-nwoX4GMFgxoPC6diHvSwmK/4yU8FFH3V8XWtLQrbj4IBsK2pkYhG4kf/ljF/haaZ/aii+wNJqISrCDPgxGWDVQ==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -13555,6 +13793,39 @@
           "requires": {
             "yallist": "^4.0.0"
           }
+        },
+        "pino": {
+          "version": "6.14.0",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
+          "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
+          "requires": {
+            "fast-redact": "^3.0.0",
+            "fast-safe-stringify": "^2.0.8",
+            "flatstr": "^1.0.12",
+            "pino-std-serializers": "^3.1.0",
+            "process-warning": "^1.0.0",
+            "quick-format-unescaped": "^4.0.3",
+            "sonic-boom": "^1.0.2"
+          }
+        },
+        "pino-std-serializers": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+          "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+        },
+        "process-warning": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+          "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+        },
+        "sonic-boom": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+          "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+          "requires": {
+            "atomic-sleep": "^1.0.0",
+            "flatstr": "^1.0.12"
+          }
         }
       }
     },
@@ -13564,9 +13835,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "process-warning": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
     },
     "progress": {
       "version": "2.0.3",
@@ -13657,12 +13928,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -13736,7 +14001,7 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
         }
       }
     },
@@ -13871,6 +14136,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -13889,12 +14159,12 @@
     "redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
     },
     "redis-parser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
       "requires": {
         "redis-errors": "^1.0.0"
       }
@@ -13924,18 +14194,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
     },
     "resolve": {
       "version": "1.22.0",
@@ -13956,7 +14220,7 @@
     "responselike": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
@@ -13977,9 +14241,9 @@
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "retry-request": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.0.tgz",
-      "integrity": "sha512-vBZdBxUordje9253imlmGtppC5gdcwZmNz7JnU2ui+KKFPk25keR+0c020AVV20oesYxIFOI0Kh3HE88/59ieg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.1.tgz",
+      "integrity": "sha512-lxFKrlBt0OZzCWh/V0uPEN0vlr3OhdeXnpeY5OES+ckslm791Cb1D5P7lJUSnY7J5hiCjcyaUGmzCnIGDCUBig==",
       "requires": {
         "debug": "^4.1.1",
         "extend": "^3.0.2"
@@ -14047,6 +14311,11 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -14224,13 +14493,10 @@
           "dev": true
         },
         "eventsource": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.1.tgz",
-          "integrity": "sha512-qV5ZC0h7jYIAOhArFJgSfdyz6rALJyb270714o7ZtNnw2WSJ+eexhKtE0O8LYPRsHZHf2osHKZBxGPvm3kPkCA==",
-          "dev": true,
-          "requires": {
-            "original": "^1.0.0"
-          }
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.2.tgz",
+          "integrity": "sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA==",
+          "dev": true
         }
       }
     },
@@ -14416,7 +14682,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "standard-as-callback": {
       "version": "2.1.0",
@@ -14470,7 +14736,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -14495,7 +14761,7 @@
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
     "superagent": {
       "version": "7.1.6",
@@ -14596,13 +14862,21 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "thread-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-1.0.0.tgz",
+      "integrity": "sha512-2Sw29jWubQWOcVa7MhLHJ51wjksUD/GHN4Fy3hP9w9DYTujifoZGSKBl54CMLRXWoD5h2pD707kY3fAdzhcwAg==",
+      "requires": {
+        "real-require": "^0.1.0"
+      }
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "tmp": {
@@ -14635,7 +14909,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "trim-newlines": {
       "version": "3.0.1",
@@ -14689,7 +14963,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -14706,9 +14980,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.15.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
-      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.0.tgz",
+      "integrity": "sha512-FEikl6bR30n0T3amyBh3LoiBdqHRy/f4H80+My34HOesOKyHfOsxAPAxOoqC0JUnC1amnO0IwkYC3sko51caSw==",
       "optional": true
     },
     "unique-string": {
@@ -14736,7 +15010,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "update-dotenv": {
       "version": "1.1.1",
@@ -14802,20 +15076,10 @@
         }
       }
     },
-    "url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
       "requires": {
         "prepend-http": "^2.0.0"
       }
@@ -14823,17 +15087,17 @@
     "url-template": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
       "version": "8.3.2",
@@ -14876,7 +15140,7 @@
     "variable-diff": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/variable-diff/-/variable-diff-1.1.0.tgz",
-      "integrity": "sha1-0r1cZtt2wTh52W5qMG7cmJ35eNo=",
+      "integrity": "sha512-0Jk/MsCNtL/fCuVIbsLxwXpABGZCzN57btcPbSsjOOAwkdHJ3Y58fo8BoUfG7jghnvglbwo+5Hk1KOJ2W2Ormw==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.1",
@@ -14917,7 +15181,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -14926,7 +15190,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
           "dev": true
         }
       }
@@ -14934,17 +15198,17 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -14976,7 +15240,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "workerpool": {
       "version": "6.2.1",
@@ -14997,7 +15261,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/packages/blunderbuss/package.json
+++ b/packages/blunderbuss/package.json
@@ -31,7 +31,7 @@
     "@google-automations/bot-config-utils": "^4.0.2",
     "@google-automations/datastore-lock": "^3.2.0",
     "@google-automations/label-utils": "^2.0.2",
-    "gcf-utils": "^13.5.3"
+    "gcf-utils": "^13.8.1"
   },
   "devDependencies": {
     "@octokit/webhooks": "^9.24.0",


### PR DESCRIPTION
This version introduced flow control for scheduler jobs.
Also (I think) nodejs14 is required for our recent dependencies.
