### PR TITLE
feat(blunderbuss): allow ignoring issues and prs by some authors

### DIFF
--- a/packages/blunderbuss/README.md
+++ b/packages/blunderbuss/README.md
@@ -26,6 +26,9 @@ assign_issues_by:
 assign_prs:
   - pr_assignee_1
   - pr_assignee_2
+ignore_authors:
+  - dependabot
+  - renovate
 ```
 
 Blunderbuss can also be manually triggered by attaching a "blunderbuss: assign" label to either an

--- a/packages/blunderbuss/src/blunderbuss.ts
+++ b/packages/blunderbuss/src/blunderbuss.ts
@@ -91,6 +91,17 @@ export = (app: Probot) => {
         return;
       }
 
+      let user: string;
+      if (isIssue(context.payload)) {
+        user = context.payload.issue.user.login;
+      } else {
+        user = context.payload.pull_request.user.login;
+      }
+
+      if (config.ignore_authors?.includes(user)) {
+        return;
+      }
+
       let lockTarget: string;
       if (isIssue(context.payload)) {
         lockTarget = context.payload.issue.url;

--- a/packages/blunderbuss/src/blunderbuss.ts
+++ b/packages/blunderbuss/src/blunderbuss.ts
@@ -91,26 +91,26 @@ export = (app: Probot) => {
         return;
       }
 
+      let url: string;
       let user: string;
+
       if (isIssue(context.payload)) {
+        url = context.payload.issue.url;
         user = context.payload.issue.user.login;
       } else {
+        url = context.payload.pull_request.url;
         user = context.payload.pull_request.user.login;
       }
 
       if (config.ignore_authors?.includes(user)) {
+        logger.info(
+          `Skipping ${url} because ${user} is on the ignore_authors list.`
+        );
         return;
       }
 
-      let lockTarget: string;
-      if (isIssue(context.payload)) {
-        lockTarget = context.payload.issue.url;
-      } else {
-        lockTarget = context.payload.pull_request.url;
-      }
-
       // Acquire the lock.
-      const lock = new DatastoreLock('blunderbuss', lockTarget);
+      const lock = new DatastoreLock('blunderbuss', url);
       const lockResult = await lock.acquire();
       if (!lockResult) {
         throw new Error('Failed to acquire a lock for ${lockTarget}');

--- a/packages/blunderbuss/src/config-schema.json
+++ b/packages/blunderbuss/src/config-schema.json
@@ -46,6 +46,13 @@
 	    "type": "array",
 	    "items": {"$ref": "#/definitions/ByConfig"},
 	    "default": []
+	},
+	"ignore_authors": {
+		"type": "array",
+		"items": {
+		    "type": "string"
+		},
+		"default": []
 	}
     }
 }

--- a/packages/blunderbuss/src/config.ts
+++ b/packages/blunderbuss/src/config.ts
@@ -24,4 +24,5 @@ export interface Configuration {
   assign_issues_by?: ByConfig[];
   assign_prs?: string[];
   assign_prs_by?: ByConfig[];
+  ignore_authors?: string[];
 }

--- a/packages/blunderbuss/test/blunderbuss.ts
+++ b/packages/blunderbuss/test/blunderbuss.ts
@@ -437,6 +437,18 @@ describe('Blunderbuss', () => {
       await probot.receive({name: 'issues', payload, id: 'abc123'});
       scopes.forEach(s => s.done());
     });
+
+    it('ignores issue when configured to ignore', async () => {
+      const payload = require(resolve(
+        fixturesPath,
+        'events',
+        'issue_opened_no_assignees'
+      ));
+
+      getConfigWithDefaultStub.resolves(loadConfig('ignore.yml'));
+
+      await probot.receive({name: 'issues', payload, id: 'abc123'});
+    });
   });
 
   describe('pr tests', () => {
@@ -665,6 +677,20 @@ describe('Blunderbuss', () => {
         id: 'abc123',
       });
       requests.done();
+    });
+
+    it('ignores PR when user ignored', async () => {
+      const payload = require(resolve(
+        fixturesPath,
+        'events',
+        'pull_request_opened_no_assignees.json'
+      ));
+      getConfigWithDefaultStub.resolves(loadConfig('ignore.yml'));
+      await probot.receive({
+        name: 'pull_request',
+        payload,
+        id: 'abc123',
+      });
     });
   });
 });

--- a/packages/blunderbuss/test/fixtures/config/ignore.yml
+++ b/packages/blunderbuss/test/fixtures/config/ignore.yml
@@ -1,0 +1,6 @@
+assign_issues:
+  - issues1
+assign_prs:
+  - prs1
+ignore_authors:
+  - testuser2


### PR DESCRIPTION
This adds support to ignore some prs/issues based on the author. 

- Not sure what the best config name would be. 
- Also could split issues and prs.

Fixes #4023