### PR TITLE
fix(owlbot-bootstrapper): add Copy-Tag logic in commit as well

### DIFF
--- a/packages/owlbot-bootstrapper/common-container/__snapshots__/utils.test.js
+++ b/packages/owlbot-bootstrapper/common-container/__snapshots__/utils.test.js
@@ -2,7 +2,7 @@ exports['common utils tests opens a PR against the main branch 1'] = {
   head: 'specialName',
   base: 'main',
   title: 'feat: add initial files for google.cloud.kms.v1',
-  body: '- [x] Regenerate this pull request now.\nSource-Link: https://googleapis/googleapis-gen@6dcb09b5b57875f334f61aebed695e2e4193db5e\nCopy-Tag:\neyJwIjoicGFja2FnZXMvZ29vZ2xlLWNsb3VkLWttcy8uT3dsQm90LnlhbWwiLCJoIjoiNmRjYjA5YjViNTc4NzVmMzM0ZjYxYWViZWQ2OTVlMmU0MTkzZGI1ZSJ9',
+  body: '- [x] Regenerate this pull request now.\nSource-Link: https://googleapis/googleapis-gen@6dcb09b5b57875f334f61aebed695e2e4193db5e\nCopy-Tag: eyJwIjoicGFja2FnZXMvZ29vZ2xlLWNsb3VkLWttcy8uZ2l0aHViLy5Pd2xCb3QueWFtbCIsImgiOiI2ZGNiMDliNWI1Nzg3NWYzMzRmNjFhZWJlZDY5NWUyZTQxOTNkYjVlIn0=',
 };
 
 exports[

--- a/packages/owlbot-bootstrapper/common-container/mono-repo.ts
+++ b/packages/owlbot-bootstrapper/common-container/mono-repo.ts
@@ -119,7 +119,6 @@ export class MonoRepo {
       directoryPath,
       INTER_CONTAINER_VARS_FILE
     );
-    console.log(interContainerVars);
     const latestSha = await getLatestShaGoogleapisGen(this.octokit);
     const copyTagText = getCopyTagText(
       latestSha,

--- a/packages/owlbot-bootstrapper/common-container/split-repo.ts
+++ b/packages/owlbot-bootstrapper/common-container/split-repo.ts
@@ -23,6 +23,8 @@ import {
   checkIfGitIsInstalled,
   ORG,
   INTER_CONTAINER_VARS_FILE,
+  getLatestShaGoogleapisGen,
+  getCopyTagText,
 } from './utils';
 
 export const BRANCH_NAME_PREFIX = 'owlbot-bootstrapper-initial-PR';
@@ -152,10 +154,11 @@ export class SplitRepo {
     directoryPath: string,
     apiId: string,
     branchName: string,
-    owlbotYamlPath: string
+    latestSha: string,
+    copyTagText: string
   ) {
     await openABranch(repoName, directoryPath);
-    await openAPR(octokit, branchName, repoName, apiId, owlbotYamlPath);
+    await openAPR(octokit, branchName, repoName, apiId, latestSha, copyTagText);
   }
 
   /**
@@ -181,6 +184,11 @@ export class SplitRepo {
       directoryPath,
       INTER_CONTAINER_VARS_FILE
     );
+    const latestSha = await getLatestShaGoogleapisGen(this.octokit);
+    const copyTagText = getCopyTagText(
+      latestSha,
+      interContainerVars.owlbotYamlPath
+    );
     await this._commitAndPushToMain(
       this.repoName,
       directoryPath,
@@ -193,7 +201,8 @@ export class SplitRepo {
       directoryPath,
       this.apiId,
       interContainerVars.branchName,
-      interContainerVars.owlbotYamlPath
+      latestSha,
+      copyTagText
     );
   }
 }

--- a/packages/owlbot-bootstrapper/common-container/test/mono-repo.test.ts
+++ b/packages/owlbot-bootstrapper/common-container/test/mono-repo.test.ts
@@ -100,8 +100,6 @@ describe('MonoRepo class', async () => {
 
   it('opens a PR against the main branch', async () => {
     const scope = nock('https://api.github.com')
-      .get('/repos/googleapis/googleapis-gen/commits')
-      .reply(201, {sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e'})
       .post('/repos/googleapis/nodejs-kms/pulls')
       .reply(201);
 
@@ -110,7 +108,8 @@ describe('MonoRepo class', async () => {
       'specialName',
       'nodejs-kms',
       'google.cloud.kms.v1',
-      directoryPath
+      '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+      'Copy-Tag: eyJwIjoicGFja2FnZXMvZ29vZ2xlLWNsb3VkLWttcy8uZ2l0aHViLy5Pd2xCb3QueWFtbCIsImgiOiI2ZGNiMDliNWI1Nzg3NWYzMzRmNjFhZWJlZDY5NWUyZTQxOTNkYjVlIn0='
     );
     scope.done();
   });
@@ -126,15 +125,17 @@ describe('MonoRepo class', async () => {
 
     await monoRepo._cloneRepo('ab123', repoToClonePath, directoryPath);
     await utils.openABranch(FAKE_REPO_NAME, directoryPath);
-    const branchName = await utils.getWellKnownFileContents(
+    const branchName = utils.getWellKnownFileContents(
       directoryPath,
       utils.INTER_CONTAINER_VARS_FILE
     ).branchName;
+    console.log(branchName);
     fs.writeFileSync(`${directoryPath}/${FAKE_REPO_NAME}/README.md`, 'hello!');
     await monoRepo._commitAndPushToBranch(
       branchName,
       FAKE_REPO_NAME,
-      directoryPath
+      directoryPath,
+      'Copy-Tag: eyJwIjoicGFja2FnZXMvZ29vZ2xlLWNsb3VkLWttcy8uZ2l0aHViLy5Pd2xCb3QueWFtbCIsImgiOiI2ZGNiMDliNWI1Nzg3NWYzMzRmNjFhZWJlZDY5NWUyZTQxOTNkYjVlIn0='
     );
 
     const stdoutBranch = execSync('git branch', {
@@ -151,7 +152,18 @@ describe('MonoRepo class', async () => {
     );
 
     assert.ok(stdoutBranch.includes(branchName));
-    assert.ok(stdoutCommit.includes('feat: initial generation of library'));
+    assert.ok(
+      stdoutCommit
+        .toString('utf-8')
+        .includes('feat: initial generation of library')
+    );
+    assert.ok(
+      stdoutCommit
+        .toString('utf8')
+        .includes(
+          'Copy-Tag: eyJwIjoicGFja2FnZXMvZ29vZ2xlLWNsb3VkLWttcy8uZ2l0aHViLy5Pd2xCb3QueWFtbCIsImgiOiI2ZGNiMDliNWI1Nzg3NWYzMzRmNjFhZWJlZDY5NWUyZTQxOTNkYjVlIn0='
+        )
+    );
     assert.ok(stdoutReadmeExists.includes('README exists'));
   });
 
@@ -163,7 +175,6 @@ describe('MonoRepo class', async () => {
       'google.cloud.kms.v1',
       octokit
     );
-
     const scope = nock('https://api.github.com')
       .get('/repos/googleapis/googleapis-gen/commits')
       .reply(201, {sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e'})
@@ -172,6 +183,16 @@ describe('MonoRepo class', async () => {
 
     monoRepo.repoName = FAKE_REPO_NAME;
     await monoRepo.cloneRepoAndOpenBranch(directoryPath);
+    const contents = utils.getWellKnownFileContents(
+      directoryPath,
+      utils.INTER_CONTAINER_VARS_FILE
+    );
+    contents.owlbotYamlPath = 'packages/google-cloud-kms/.github/.OwlBot.yaml';
+    fs.writeFileSync(
+      `${directoryPath}/${utils.INTER_CONTAINER_VARS_FILE}`,
+      JSON.stringify(contents, null, 4)
+    );
+
     fs.writeFileSync(`${directoryPath}/${FAKE_REPO_NAME}/README.md`, 'hello!');
     await monoRepo.pushToBranchAndOpenPR(directoryPath);
 
@@ -183,8 +204,21 @@ describe('MonoRepo class', async () => {
       cwd: `${directoryPath}/${FAKE_REPO_NAME}`,
     });
 
+    console.log('stdoutCommit');
+    console.log(stdoutCommit.toString('utf8'));
     assert.ok(stdoutBranch.includes('owlbot-bootstrapper-initial-PR'));
-    assert.ok(stdoutCommit.includes('feat: initial generation of library'));
+    assert.ok(
+      stdoutCommit
+        .toString('utf-8')
+        .includes('feat: initial generation of library')
+    );
+    assert.ok(
+      stdoutCommit
+        .toString('utf8')
+        .includes(
+          'Copy-Tag: eyJwIjoicGFja2FnZXMvZ29vZ2xlLWNsb3VkLWttcy8uZ2l0aHViLy5Pd2xCb3QueWFtbCIsImgiOiI2ZGNiMDliNWI1Nzg3NWYzMzRmNjFhZWJlZDY5NWUyZTQxOTNkYjVlIn0='
+        )
+    );
     scope.done();
   });
 });

--- a/packages/owlbot-bootstrapper/common-container/test/split-repo.test.ts
+++ b/packages/owlbot-bootstrapper/common-container/test/split-repo.test.ts
@@ -149,8 +149,6 @@ describe('SplitRepo class', async () => {
 
   it('should create an empty PR', async () => {
     const scope = nock('https://api.github.com')
-      .get('/repos/googleapis/googleapis-gen/commits')
-      .reply(201, {sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e'})
       .post('/repos/googleapis/fakeRepo/pulls')
       .reply(201);
 
@@ -169,7 +167,8 @@ describe('SplitRepo class', async () => {
       directoryPath,
       'google.cloud.kms.v1',
       'branchName',
-      'packages/google-cloud-kms/.OwlBot.yaml'
+      '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+      'Copy-Tag: eyJwIjoicGFja2FnZXMvZ29vZ2xlLWNsb3VkLWttcy8uZ2l0aHViLy5Pd2xCb3QueWFtbCIsImgiOiI2ZGNiMDliNWI1Nzg3NWYzMzRmNjFhZWJlZDY5NWUyZTQxOTNkYjVlIn0='
     );
 
     const stdoutBranch = execSync('git branch', {

--- a/packages/owlbot-bootstrapper/common-container/test/utils.test.ts
+++ b/packages/owlbot-bootstrapper/common-container/test/utils.test.ts
@@ -95,8 +95,6 @@ describe('common utils tests', async () => {
 
   it('opens a PR against the main branch', async () => {
     const scope = nock('https://api.github.com')
-      .get('/repos/googleapis/googleapis-gen/commits')
-      .reply(201, {sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e'})
       .post('/repos/googleapis/nodejs-kms/pulls', body => {
         snapshot(body);
         return true;
@@ -108,7 +106,8 @@ describe('common utils tests', async () => {
       'specialName',
       'nodejs-kms',
       'google.cloud.kms.v1',
-      'packages/google-cloud-kms/.OwlBot.yaml'
+      '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+      'Copy-Tag: eyJwIjoicGFja2FnZXMvZ29vZ2xlLWNsb3VkLWttcy8uZ2l0aHViLy5Pd2xCb3QueWFtbCIsImgiOiI2ZGNiMDliNWI1Nzg3NWYzMzRmNjFhZWJlZDY5NWUyZTQxOTNkYjVlIn0='
     );
     scope.done();
   });
@@ -126,18 +125,29 @@ describe('common utils tests', async () => {
     assert(sha, '6dcb09b5b57875f334f61aebed695e2e4193db5e');
   });
 
-  it('returns the PR text with copy tag text', async () => {
-    const scope = nock('https://api.github.com')
-      .get('/repos/googleapis/googleapis-gen/commits')
-      .reply(201, {sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e'});
+  it('gets the copy-tag text', () => {
+    const copyTagText = utils.getCopyTagText(
+      '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+      'packages/google-cloud-kms/.github/.OwlBot.yaml'
+    );
 
-    const prText = await utils.getPRText(octokit, directoryPath);
-    console.log(prText);
-    const expectation = `${REGENERATE_CHECKBOX_TEXT}\nCopy-Tag:\n${Buffer.from(
-      '{"p":"packages/google-cloud-kms/.OwlBot.yaml","h":"6dcb09b5b57875f334f61aebed695e2e4193db5e"}'
+    const expectation = `${REGENERATE_CHECKBOX_TEXT}\nCopy-Tag:${Buffer.from(
+      '{"p":"packages/google-cloud-kms/.github/.OwlBot.yaml","h":"6dcb09b5b57875f334f61aebed695e2e4193db5e"}'
+    ).toString('base64')}`;
+    assert(copyTagText, expectation);
+  });
+
+  it('returns the PR text with copy tag text', () => {
+    const prText = utils.getPRText(
+      '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+      `Copy-Tag:${Buffer.from(
+        '{"p":"packages/google-cloud-kms/.github/.OwlBot.yaml","h":"6dcb09b5b57875f334f61aebed695e2e4193db5e"}'
+      ).toString('base64')}`
+    );
+    const expectation = `${REGENERATE_CHECKBOX_TEXT}\nSource-Link: https://googleapis-gen@6dcb09b5b57875f334f61aebed695e2e4193db5e\nCopy-Tag:${Buffer.from(
+      '{"p":"packages/google-cloud-kms/.github/.OwlBot.yaml","h":"6dcb09b5b57875f334f61aebed695e2e4193db5e"}'
     ).toString('base64')}`;
     assert(prText, expectation);
-    scope.done();
   });
 
   it('should open a branch, then push that branch to origin', async () => {


### PR DESCRIPTION
Turns out, owlbot looks in the commit history for the copy tag info, see: https://github.com/googleapis/repo-automation-bots/blob/82f37f98169aa63c3fb2d5fd3ea8de3c45999da3/packages/owl-bot/src/copy-code.ts#L633

Confirmed with @SurferJeffAtGoogle

This PR only implements the copy-tag logic in the commit for mono-repos, not split repos. In looking at it more closely, I think I'm going to need to refactor the split repo process to mirror the mono-repo process a bit more. I will do this in a later PR.