### PR TITLE
chore: remove unused env variables

### DIFF
--- a/packages/owlbot-bootstrapper/common-container/post-process.ts
+++ b/packages/owlbot-bootstrapper/common-container/post-process.ts
@@ -51,7 +51,7 @@ export async function postProcess(argv: CliArgs) {
   try {
     if (isMonoRepository) {
       // Mono-repo post-process (after language specific-container)
-      logger.info(`${process.env.LANGUAGE} is a mono repo`);
+      logger.info(`${argv.language} is a mono repo`);
       const monoRepo = new MonoRepo(
         argv.language as Language,
         argv.repoToClone!,

--- a/packages/owlbot-bootstrapper/common-container/pre-process.ts
+++ b/packages/owlbot-bootstrapper/common-container/pre-process.ts
@@ -40,10 +40,6 @@ export async function preProcess(argv: CliArgs) {
 
   const octokit = await githubAuthenticator.authenticateOctokit(githubToken);
 
-  // Pass in a github token so that language-specific containers can
-  // Make calls to Github
-  process.env._GITHUB_TOKEN = githubToken;
-
   const isMonoRepository = isMonoRepo(argv.language as Language);
 
   if (argv.repoToClone === '' && isMonoRepository) {


### PR DESCRIPTION
Just cosmetic, we no longer use env variables (instead we use arguments and the interContainerVars file) and this cleans them up.