### PR TITLE
feat: implement owlbot:copy-code label

### DIFF
--- a/packages/owl-bot/cloud-build/copy-code-again.yaml
+++ b/packages/owl-bot/cloud-build/copy-code-again.yaml
@@ -62,10 +62,6 @@ steps:
   - name: 'gcr.io/repo-automation-bots/owlbot-cli'
     args:
       - copy-code-into-pull-request
-      - --source-repo-commit-hash
-      - ${_SOURCE_HASH}
-      - --owl-bot-yaml-path
-      - ${_OWL_BOT_YAML_PATH}
       - --dest-repo
       - ${_PR_OWNER}/${_REPOSITORY}
       - --dest-branch

--- a/packages/owl-bot/src/bin/commands/test-webhook.ts
+++ b/packages/owl-bot/src/bin/commands/test-webhook.ts
@@ -84,7 +84,10 @@ export const testWebhook: yargs.CommandModule<{}, Args> = {
           argv['app-id'],
           privateKey,
           argv.project,
-          argv.trigger,
+          {
+            regeneratePullRequest: argv.trigger,
+            runPostProcessor: argv.trigger,
+          },
           payload,
           octokit
         );

--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -541,24 +541,26 @@ command in a local clone of this repo:
   }
 }
 
+export type CopyCodeIntoPullRequestAction =
+  | 'regenerate' // Discard all current commits and regenerate.
+  | 'append'; // Copy code and into a new commit and append it to the PR.
+
 /**
- * Regenerates a pull request.
- * Uses `git push -f` to completely replace the existing contents of the branch.
+ * Appends or regenerates a pull request.
  *
- * This is quite complicated because the PR may have multiple open commits.
- * Regenerating the pull request will result in a single commit.  We need
- * to preserve the full history of all the commits.
- *
- * In time, this will completely replace copyCodeIntoPullRequest().
+ * Regenerating is quite complicated because the PR may have multiple open
+ * commits.  Regenerating the pull request will result in a single commit,
+ * but we need to preserve the full history of all the commits.
  *
  * @param sourceRepo: the source repository, either a local path or googleapis/googleapis-gen
  * @param destRepo: the destination repository, either a local path or a github path like googleapis/nodejs-vision.
  */
-export async function regeneratePullRequest(
+export async function copyCodeIntoPullRequest(
   sourceRepo: string,
   destRepo: GithubRepo,
   destBranch: string,
   octokitFactory: OctokitFactory,
+  action: CopyCodeIntoPullRequestAction = 'regenerate',
   logger = console
 ): Promise<void> {
   const workDir = tmp.dirSync().name;
@@ -612,7 +614,6 @@ export async function regeneratePullRequest(
   }
   const commitMsgFilePath = path.join(workDir, 'commit.txt');
   const commitMsg = commitMessages.join('\n\n');
-  fs.writeFileSync(commitMsgFilePath, commitMsg);
 
   // Find the corresponding pull request because we'll either have to update
   // its body or add a comment describing failure.
@@ -663,7 +664,20 @@ export async function regeneratePullRequest(
 
   const sourceRepoCommitHash = copyTags[0].h;
 
-  cmd(`git checkout -b ${destBranch}`, {cwd: destDir});
+  if (action === 'regenerate') {
+    // Use the combined commit message.
+    fs.writeFileSync(commitMsgFilePath, commitMsg);
+    // Create a new branch that replaces the old branch.
+    cmd(`git checkout -b ${destBranch}`, {cwd: destDir});
+  } else {
+    // Use a simple commit message.
+    fs.writeFileSync(
+      commitMsgFilePath,
+      `Owl Bot copied code from https://github.com/${sourceRepo}/commit/${sourceRepoCommitHash}`
+    );
+    // Check out the existing branch.
+    cmd(`git checkout -t origin/${destBranch}`, {cwd: destDir});
+  }
 
   const apiNames: string[] = [];
   const allSourcePaths = globGitRepo(sourceDir);
@@ -715,17 +729,19 @@ export async function regeneratePullRequest(
   cmd(`git remote set-url origin ${pushUrl}`, {cwd: destDir});
   cmd(`git push -f origin ${destBranch}`, {cwd: destDir});
 
-  // Update the PR body with the full commit history.
-  const {title, body} = resplit(commitMsg, WithRegenerateCheckbox.Yes);
+  if (action === 'regenerate') {
+    // Update the PR body with the full commit history.
+    const {title, body} = resplit(commitMsg, WithRegenerateCheckbox.Yes);
 
-  const apiList = abbreviateApiListForTitle(apiNames);
-  await octokit.pulls.update({
-    owner: destRepo.owner,
-    repo: destRepo.repo,
-    pull_number: pull.number,
-    title: insertApiName(title, apiList),
-    body,
-  });
+    const apiList = abbreviateApiListForTitle(apiNames);
+    await octokit.pulls.update({
+      owner: destRepo.owner,
+      repo: destRepo.repo,
+      pull_number: pull.number,
+      title: insertApiName(title, apiList),
+      body,
+    });
+  }
 }
 
 /**

--- a/packages/owl-bot/src/labels.ts
+++ b/packages/owl-bot/src/labels.ts
@@ -14,6 +14,7 @@
 
 export const OWLBOT_RUN_LABEL = 'owlbot:run';
 export const OWL_BOT_IGNORE = 'owlbot:ignore';
+export const OWL_BOT_COPY_COMMAND_LABEL = 'owlbot:copy-code';
 
 export const OWL_BOT_LABELS = [
   {
@@ -23,5 +24,11 @@ export const OWL_BOT_LABELS = [
   {
     name: OWL_BOT_IGNORE,
     description: 'instruct owl-bot to ignore a PR',
+  },
+  {
+    name: OWL_BOT_COPY_COMMAND_LABEL,
+    description:
+      'Instruct owl-bot to copy code from googleapis-gen.' +
+      '  The PR this label is applied to must have a copy tag.',
   },
 ];

--- a/packages/owl-bot/test/core.ts
+++ b/packages/owl-bot/test/core.ts
@@ -15,7 +15,6 @@
 import {CloudBuildClient} from '@google-cloud/cloudbuild';
 import * as assert from 'assert';
 import sinon from 'sinon';
-import {sourceLinkFrom, sourceLinkLineFrom} from '../src/copy-code';
 import {core, RegenerateArgs} from '../src/core';
 import {newFakeCloudBuildClient} from './fake-cloud-build-client';
 import {
@@ -36,26 +35,10 @@ describe('triggerPostProcessBuild()', () => {
     gcpProjectId: 'test-project',
     buildTriggerId: '42',
     owner: 'test-owner',
-    prBody:
-      'Nice pull request.\n' + sourceLinkLineFrom(sourceLinkFrom('abc123')),
     prNumber: 5,
     repo: 'nodejs-stapler',
+    action: 'regenerate',
   };
-
-  it('creates a comment on the pull request when the pull request body is missing a source commit hash', async () => {
-    const issues = new FakeIssues();
-    const octokit = newFakeOctokit(undefined, issues);
-    await core.triggerRegeneratePullRequest(newFakeOctokitFactory(octokit), {
-      ...args,
-      prBody: 'Nice pull request',
-    });
-    assert.strictEqual(issues.comments.length, 1);
-    const comment = issues.comments[0];
-    assert.strictEqual(comment.owner, 'test-owner');
-    assert.strictEqual(comment.repo, 'nodejs-stapler');
-    assert.strictEqual(comment.issue_number, 5);
-    assert.match(comment.body, /.*missing.*hash.*/);
-  });
 
   it('creates a comment reporting failure', async () => {
     const issues = new FakeIssues();
@@ -106,13 +89,12 @@ describe('triggerPostProcessBuild()', () => {
             projectId: 'test-project',
             branchName: 'main',
             substitutions: {
+              _ACTION: 'regenerate',
               _GITHUB_TOKEN: 'b3',
               _PR: '5',
               _PR_BRANCH: 'test-branch',
               _PR_OWNER: 'test-owner',
               _REPOSITORY: 'nodejs-stapler',
-              _SOURCE_HASH: 'abc123',
-              _OWL_BOT_YAML_PATH: '.github/.OwlBot.yaml',
             },
           },
         },


### PR DESCRIPTION
Owl Bot Bootstrapper labels a pull request with 'owlbot:copy-code' to request Owl Bot to copy the source code from googleapis-gen.  The pull request must have a copy tag.

While adding this feature, I removed the obsolete command line options source-repo-commit-hash and owl-bot-yaml-path.  Owl bot already inspects the copy-tag to learn these two details.  So they were obsolete before this pull request.  It was easier to remove them than to update them for the new code path.

Fixes #4072
