### PR TITLE
chore: cleanup warning logs from unnecessary default wrap option

### DIFF
--- a/packages/sync-repo-settings/src/app.ts
+++ b/packages/sync-repo-settings/src/app.ts
@@ -17,6 +17,5 @@ import {handler} from './bot';
 
 const bootstrap = new GCFBootstrapper();
 module.exports['sync_repo_settings'] = bootstrap.gcf(handler, {
-  background: true,
   logging: true,
 });


### PR DESCRIPTION
We are seeing tons of warning logs:
```
`background` option has been deprecated in favor of `maxRetries` and `maxCronRetries`
```

sync-repo-settings is setting `background=true` which is the default and deprecated -- so we will remove the option.
