### PR TITLE
fix(ccl): change the order of the error message

### DIFF
--- a/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
+++ b/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
@@ -5,7 +5,7 @@ exports['ConventionalCommitLint sets a "failure" context on PR, if commits fail 
   "output": {
     "title": "Commit message did not follow Conventional Commits",
     "summary": "Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nRun `git commit --amend` and edit your message to match Conventional Commit guidelines.",
-    "text": ":x: linting errors for \"*fix all the bugs*\"\n* subject may not be empty\n* type may not be empty\n\n\n"
+    "text": ":x: The following linting errors found:\n* subject may not be empty\n* type may not be empty\nfor the following input:\n\"*fix all the bugs*\"\n\n"
   }
 }
 
@@ -34,7 +34,7 @@ exports['ConventionalCommitLint PR With Multiple Commits has an invalid pull req
   "output": {
     "title": "Commit message did not follow Conventional Commits",
     "summary": "Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nedit your pull request title to match Conventional Commit guidelines.",
-    "text": ":x: linting errors for \"*this is not a conventional commit*\"\n* subject may not be empty\n* type may not be empty\n\n\n"
+    "text": ":x: The following linting errors found:\n* subject may not be empty\n* type may not be empty\nfor the following input:\n\"*this is not a conventional commit*\"\n\n"
   }
 }
 
@@ -57,7 +57,7 @@ exports['ConventionalCommitLint adds a comment when the commit message and the P
   "output": {
     "title": "Commit message did not follow Conventional Commits",
     "summary": "Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nRun `git commit --amend` and edit your message to match Conventional Commit guidelines.",
-    "text": ":x: linting errors for \"*fix all the bugs*\"\n* subject may not be empty\n* type may not be empty\n\n\n"
+    "text": ":x: The following linting errors found:\n* subject may not be empty\n* type may not be empty\nfor the following input:\n\"*fix all the bugs*\"\n\n"
   }
 }
 

--- a/packages/conventional-commit-lint/src/utils.ts
+++ b/packages/conventional-commit-lint/src/utils.ts
@@ -123,11 +123,11 @@ export async function scanPullRequest(
 
   if (result.valid === false) {
     lintError = true;
-    text += `:x: linting errors for "*${result.input}*"\n`;
+    text += `:x: The following linting errors found:\n`;
     result.errors.forEach(error => {
       text += `* ${error.message}\n`;
     });
-    text += '\n\n';
+    text += `for the following input:\n"*${result.input}*"\n\n`
 
     // And if there's only one commit and the commit message and the
     // PR title are not the same value, it's mostly because the PR

--- a/packages/conventional-commit-lint/src/utils.ts
+++ b/packages/conventional-commit-lint/src/utils.ts
@@ -123,11 +123,11 @@ export async function scanPullRequest(
 
   if (result.valid === false) {
     lintError = true;
-    text += `:x: The following linting errors found:\n`;
+    text += ':x: The following linting errors found:\n';
     result.errors.forEach(error => {
       text += `* ${error.message}\n`;
     });
-    text += `for the following input:\n"*${result.input}*"\n\n`
+    text += `for the following input:\n"*${result.input}*"\n\n`;
 
     // And if there's only one commit and the commit message and the
     // PR title are not the same value, it's mostly because the PR


### PR DESCRIPTION
Now the bot lists all the errors first, then add the input as a
reference.

fixes #3155