### PR TITLE
chore: cleanup warning logs from unnecessary default wrap option

### DIFF
--- a/packages/header-checker-lint/src/app.ts
+++ b/packages/header-checker-lint/src/app.ts
@@ -17,6 +17,5 @@ import appFn from './header-checker-lint';
 
 const bootstrap = new GCFBootstrapper();
 module.exports.header_checker_lint = bootstrap.gcf(appFn, {
-  background: true,
   logging: true,
 });


### PR DESCRIPTION
We are seeing tons of warning logs:
```
`background` option has been deprecated in favor of `maxRetries` and `maxCronRetries`
```

header-checker-lint is setting `background=true` which is the default and deprecated -- so we will remove the option.
