### PR TITLE
feat: add custom command for running arbitrary publish script

### DIFF
--- a/packages/mono-repo-publish/package-lock.json
+++ b/packages/mono-repo-publish/package-lock.json
@@ -14,7 +14,7 @@
         "yargs": "^17.5.1"
       },
       "bin": {
-        "mono-repo-publish": "bin/mono-repo-publish.js"
+        "mono-repo-publish": "build/src/bin/mono-repo-publish.js"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.1",

--- a/packages/mono-repo-publish/src/bin/mono-repo-publish.ts
+++ b/packages/mono-repo-publish/src/bin/mono-repo-publish.ts
@@ -16,10 +16,12 @@
 
 import * as yargs from 'yargs';
 import * as core from '../main';
-import {execSync} from 'child_process';
 
 interface CommonArgs {
   'pr-url': string;
+  'app-id-path'?: string;
+  'private-key-path'?: string;
+  'installation-id-path'?: string;
 }
 interface PublishArgs extends CommonArgs {
   'dry-run': boolean;
@@ -28,27 +30,57 @@ interface PublishCustomArgs extends CommonArgs {
   script: string;
 }
 
+function parseCommonArgs(yargs: yargs.Argv): yargs.Argv<CommonArgs> {
+  return yargs
+    .option('pr-url', {
+      describe:
+        'the URL of the GH PR for submodules you wish to publish, e.g., https://github.com/googleapis/release-please/pull/707',
+      type: 'string',
+      demand: true,
+    })
+    .option('app-id-path', {
+      describe: 'path to a file containing the GitHub application ID',
+      type: 'string',
+      default: (() => {
+        return process.env.APP_ID_PATH;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any,
+      demand: true,
+    })
+    .option('private-key-path', {
+      describe: 'path to a file containing the GitHub private key',
+      type: 'string',
+      default: (() => {
+        return process.env.GITHUB_PRIVATE_KEY_PATH;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any,
+      demand: true,
+    })
+    .option('installation-id-path', {
+      describe: 'path to a file containing the GitHub installation ID',
+      type: 'string',
+      default: (() => {
+        return process.env.INSTALLATION_ID_PATH;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any,
+      demand: true,
+    });
+}
+
 const publishCommand: yargs.CommandModule<{}, PublishArgs> = {
   command: '$0',
   describe: 'publish packages affected by a pull request',
   builder(yargs) {
-    return yargs
-      .option('pr-url', {
-        describe:
-          'the URL of the GH PR for submodules you wish to publish, e.g., https://github.com/googleapis/release-please/pull/707',
-        type: 'string',
-        demand: true,
-      })
-      .option('dry-run', {
-        describe: 'whether or not to publish in dry run',
-        type: 'boolean',
-        default: false,
-      });
+    return parseCommonArgs(yargs).option('dry-run', {
+      describe: 'whether or not to publish in dry run',
+      type: 'boolean',
+      default: false,
+    });
   },
   async handler(argv) {
-    const appIdPath = process.env.APP_ID_PATH;
-    const privateKeyPath = process.env.GITHUB_PRIVATE_KEY_PATH;
-    const installationIdPath = process.env.INSTALLATION_ID_PATH;
+    const appIdPath = argv['app-id-path'];
+    const privateKeyPath = argv['private-key-path'];
+    const installationIdPath = argv['installation-id-path'];
 
     if (!appIdPath || !privateKeyPath || !installationIdPath) {
       throw Error(
@@ -77,23 +109,16 @@ const publishCustomCommand: yargs.CommandModule<{}, PublishCustomArgs> = {
   command: 'custom',
   describe: 'publish packages affected by a pull request with custom script',
   builder(yargs) {
-    return yargs
-      .option('pr-url', {
-        describe:
-          'the URL of the GH PR for submodules you wish to publish, e.g., https://github.com/googleapis/release-please/pull/707',
-        type: 'string',
-        demand: true,
-      })
-      .option('script', {
-        describe: 'Path to script to run',
-        type: 'string',
-        demand: true,
-      });
+    return parseCommonArgs(yargs).option('script', {
+      describe: 'Path to script to run',
+      type: 'string',
+      demand: true,
+    });
   },
   async handler(argv) {
-    const appIdPath = process.env.APP_ID_PATH;
-    const privateKeyPath = process.env.GITHUB_PRIVATE_KEY_PATH;
-    const installationIdPath = process.env.INSTALLATION_ID_PATH;
+    const appIdPath = argv['app-id-path'];
+    const privateKeyPath = argv['private-key-path'];
+    const installationIdPath = argv['installation-id-path'];
 
     if (!appIdPath || !privateKeyPath || !installationIdPath) {
       throw Error(
@@ -111,23 +136,7 @@ const publishCustomCommand: yargs.CommandModule<{}, PublishCustomArgs> = {
     }
     const files = await core.getsPRFiles(pr, octokit);
     const submodules = core.listChangedSubmodules(files);
-    const errors = core.eachSubmodule(submodules, directory => {
-      try {
-        return {
-          output: execSync(argv['script'], {
-            cwd: directory,
-            encoding: 'utf-8',
-            stdio: 'inherit',
-          }),
-        };
-      } catch (err) {
-        console.error(err);
-        return {
-          output: '',
-          error: err as Error,
-        };
-      }
-    });
+    const errors = core.publishCustom(submodules, argv['script']);
     if (errors.length) {
       throw Error('some publications failed, see logs');
     }

--- a/packages/mono-repo-publish/src/main.ts
+++ b/packages/mono-repo-publish/src/main.ts
@@ -115,15 +115,15 @@ function publish(
     output.push(
       execSync(`npm ${installCommand} --registry=https://registry.npmjs.org`, {
         cwd: directory,
-        stdio: 'inherit',
         encoding: 'utf-8',
+        stdio: 'inherit',
       })
     );
     output.push(
       execSync(`npm publish --access=public${dryRun ? ' --dry-run' : ''}`, {
         cwd: directory,
-        stdio: 'inherit',
         encoding: 'utf-8',
+        stdio: 'inherit',
       })
     );
     rmSync(join(directory, 'node_modules'), {

--- a/packages/mono-repo-publish/test/cli.ts
+++ b/packages/mono-repo-publish/test/cli.ts
@@ -90,7 +90,10 @@ describe('CLI', () => {
     });
     it('uses executes a dry run', async () => {
       getOctokitStub.resolves(sandbox.spy());
-      getFilesStub.resolves(['packages/pkg1/package.json', 'packages/pkg1/package-lock.json']);
+      getFilesStub.resolves([
+        'packages/pkg1/package.json',
+        'packages/pkg1/package-lock.json',
+      ]);
       sandbox.stub(process, 'env').value({
         APP_ID_PATH: './test/fixtures/app-id',
         INSTALLATION_ID_PATH: './test/fixtures/installation-id',

--- a/packages/mono-repo-publish/test/cli.ts
+++ b/packages/mono-repo-publish/test/cli.ts
@@ -1,0 +1,171 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {parser} from '../src/bin/mono-repo-publish';
+import * as core from '../src/main';
+import {describe, it, afterEach, beforeEach} from 'mocha';
+import * as sinon from 'sinon';
+
+const sandbox = sinon.createSandbox();
+
+describe('CLI', () => {
+  let getOctokitStub: sinon.SinonStub;
+  let getFilesStub: sinon.SinonStub;
+  let execSync: sinon.SinonStub;
+  afterEach(() => {
+    sandbox.restore();
+  });
+  beforeEach(() => {
+    getOctokitStub = sandbox.stub(core, 'getOctokitInstance');
+    getFilesStub = sandbox.stub(core, 'getsPRFiles');
+    execSync = sandbox.stub(core.methodOverrides, 'execSyncOverride');
+  });
+  describe('default', () => {
+    it('handles explicit credentials', async () => {
+      getOctokitStub.resolves(sandbox.spy());
+      getFilesStub.resolves(['packages/pkg1/package.json']);
+      await parser.parseAsync(
+        '--pr-url=https://github.com/testOwner/testRepo/pull/1234 --app-id-path=./test/fixtures/app-id --installation-id-path=./test/fixtures/installation-id --private-key-path=./test/fixtures/private-key'
+      );
+
+      sinon.assert.calledOnceWithExactly(
+        getOctokitStub,
+        './test/fixtures/app-id',
+        './test/fixtures/private-key',
+        './test/fixtures/installation-id'
+      );
+      sinon.assert.calledOnce(getFilesStub);
+      sinon.assert.calledTwice(execSync);
+      sinon.assert.calledWith(
+        execSync.firstCall,
+        'npm i --registry=https://registry.npmjs.org',
+        sinon.match({cwd: 'packages/pkg1'})
+      );
+      sinon.assert.calledWith(
+        execSync.secondCall,
+        'npm publish --access=public',
+        sinon.match({cwd: 'packages/pkg1'})
+      );
+    });
+    it('handles credentials from the environment', async () => {
+      getOctokitStub.resolves(sandbox.spy());
+      getFilesStub.resolves(['packages/pkg1/package.json']);
+      sandbox.stub(process, 'env').value({
+        APP_ID_PATH: './test/fixtures/app-id',
+        INSTALLATION_ID_PATH: './test/fixtures/installation-id',
+        GITHUB_PRIVATE_KEY_PATH: './test/fixtures/private-key',
+      });
+      await parser.parseAsync(
+        '--pr-url=https://github.com/testOwner/testRepo/pull/1234'
+      );
+
+      sinon.assert.calledOnceWithExactly(
+        getOctokitStub,
+        './test/fixtures/app-id',
+        './test/fixtures/private-key',
+        './test/fixtures/installation-id'
+      );
+      sinon.assert.calledOnce(getFilesStub);
+      sinon.assert.calledWith(
+        execSync.firstCall,
+        'npm i --registry=https://registry.npmjs.org',
+        sinon.match({cwd: 'packages/pkg1'})
+      );
+      sinon.assert.calledWith(
+        execSync.secondCall,
+        'npm publish --access=public',
+        sinon.match({cwd: 'packages/pkg1'})
+      );
+    });
+    it('uses executes a dry run', async () => {
+      getOctokitStub.resolves(sandbox.spy());
+      getFilesStub.resolves(['packages/pkg1/package.json', 'packages/pkg1/package-lock.json']);
+      sandbox.stub(process, 'env').value({
+        APP_ID_PATH: './test/fixtures/app-id',
+        INSTALLATION_ID_PATH: './test/fixtures/installation-id',
+        GITHUB_PRIVATE_KEY_PATH: './test/fixtures/private-key',
+      });
+      await parser.parseAsync(
+        '--pr-url=https://github.com/testOwner/testRepo/pull/1234 --dry-run'
+      );
+
+      sinon.assert.calledOnceWithExactly(
+        getOctokitStub,
+        './test/fixtures/app-id',
+        './test/fixtures/private-key',
+        './test/fixtures/installation-id'
+      );
+      sinon.assert.calledOnce(getFilesStub);
+      sinon.assert.calledTwice(execSync);
+      sinon.assert.calledWith(
+        execSync.firstCall,
+        'npm i --registry=https://registry.npmjs.org',
+        sinon.match({cwd: 'packages/pkg1'})
+      );
+      sinon.assert.calledWith(
+        execSync.secondCall,
+        'npm publish --access=public --dry-run',
+        sinon.match({cwd: 'packages/pkg1'})
+      );
+    });
+  });
+
+  describe('custom', () => {
+    it('handles explicit credentials', async () => {
+      getOctokitStub.resolves(sandbox.spy());
+      getFilesStub.resolves(['packages/pkg1/package.json']);
+      await parser.parseAsync(
+        'custom --script=/path/to/script --pr-url=https://github.com/testOwner/testRepo/pull/1234 --app-id-path=./test/fixtures/app-id --installation-id-path=./test/fixtures/installation-id --private-key-path=./test/fixtures/private-key'
+      );
+
+      sinon.assert.calledOnceWithExactly(
+        getOctokitStub,
+        './test/fixtures/app-id',
+        './test/fixtures/private-key',
+        './test/fixtures/installation-id'
+      );
+      sinon.assert.calledOnce(getFilesStub);
+      sinon.assert.calledOnceWithExactly(
+        execSync,
+        '/path/to/script',
+        sinon.match({cwd: 'packages/pkg1'})
+      );
+    });
+    it('handles credentials from the environment', async () => {
+      getOctokitStub.resolves(sandbox.spy());
+      getFilesStub.resolves(['packages/pkg1/package.json']);
+      sandbox.stub(process, 'env').value({
+        APP_ID_PATH: './test/fixtures/app-id',
+        INSTALLATION_ID_PATH: './test/fixtures/installation-id',
+        GITHUB_PRIVATE_KEY_PATH: './test/fixtures/private-key',
+      });
+      await parser.parseAsync(
+        'custom --script=/path/to/script --pr-url=https://github.com/testOwner/testRepo/pull/1234'
+      );
+
+      sinon.assert.calledOnceWithExactly(
+        getOctokitStub,
+        './test/fixtures/app-id',
+        './test/fixtures/private-key',
+        './test/fixtures/installation-id'
+      );
+      sinon.assert.calledOnce(getFilesStub);
+      sinon.assert.calledOnceWithExactly(
+        execSync,
+        '/path/to/script',
+        sinon.match({cwd: 'packages/pkg1'})
+      );
+    });
+  });
+});

--- a/packages/mono-repo-publish/test/main.test.ts
+++ b/packages/mono-repo-publish/test/main.test.ts
@@ -101,7 +101,6 @@ describe('mono-repo publish', () => {
   });
 
   it('passes in --dry-run option', () => {
-    const execSync = (core.methodOverrides.execSyncOverride = sandbox.spy());
     core.publishSubmodules(['foo'], true);
     sandbox.assert.calledWith(
       execSync.firstCall,

--- a/packages/mono-repo-publish/test/main.test.ts
+++ b/packages/mono-repo-publish/test/main.test.ts
@@ -30,8 +30,14 @@ nock.disableNetConnect();
 // TODO: Add a system-test with a fixture directory with a few fake modules (and a fake PR) and confirm that
 // it tries to publish all the modules (end-to-end test)
 describe('mono-repo publish', () => {
+  let execSync: sinon.SinonStub;
+  let rmdirSync: sinon.SinonStub;
   afterEach(() => {
     sandbox.restore();
+  });
+  beforeEach(() => {
+    execSync = sandbox.stub(core.methodOverrides, 'execSyncOverride');
+    rmdirSync = sandbox.stub(core.methodOverrides, 'rmSyncOverride');
   });
 
   it('should parse owner, user, and number from the URL', () => {
@@ -83,8 +89,7 @@ describe('mono-repo publish', () => {
   });
 
   it('passes in the right arguments for npm publish', () => {
-    const execSync = sandbox.spy();
-    core.publishSubmodules(['foo'], false, execSync);
+    core.publishSubmodules(['foo'], false);
     sandbox.assert.calledWith(
       execSync.firstCall,
       'npm i --registry=https://registry.npmjs.org'
@@ -96,8 +101,8 @@ describe('mono-repo publish', () => {
   });
 
   it('passes in --dry-run option', () => {
-    const execSync = sandbox.spy();
-    core.publishSubmodules(['foo'], true, execSync);
+    const execSync = (core.methodOverrides.execSyncOverride = sandbox.spy());
+    core.publishSubmodules(['foo'], true);
     sandbox.assert.calledWith(
       execSync.firstCall,
       'npm i --registry=https://registry.npmjs.org'
@@ -111,9 +116,7 @@ describe('mono-repo publish', () => {
   // A node_modules folder existing in the root directory was preventing
   // google-api-nodejs-client from publishing.
   it('it removes node_modules after publish', () => {
-    const execSync = sandbox.spy();
-    const rmdirSync = sandbox.spy();
-    const errors = core.publishSubmodules(['foo'], true, execSync, rmdirSync);
+    const errors = core.publishSubmodules(['foo'], true);
     sandbox.assert.calledWith(
       execSync.firstCall,
       'npm i --registry=https://registry.npmjs.org'
@@ -130,8 +133,8 @@ describe('mono-repo publish', () => {
   });
 
   it('returns array of errors after attempting all publications', () => {
-    const execSync = sandbox.mock().throws(Error('publish fail'));
-    const errors = core.publishSubmodules(['foo'], true, execSync);
+    execSync.throws(Error('publish fail'));
+    const errors = core.publishSubmodules(['foo'], true);
     sandbox.assert.calledWith(
       execSync.firstCall,
       'npm i --registry=https://registry.npmjs.org'
@@ -140,8 +143,7 @@ describe('mono-repo publish', () => {
   });
 
   it('uses npm ci, if package-lock.json exists', () => {
-    const execSync = sandbox.spy();
-    core.publishSubmodules(['test/fixtures'], false, execSync);
+    core.publishSubmodules(['test/fixtures'], false);
     sandbox.assert.calledWith(
       execSync.firstCall,
       'npm ci --registry=https://registry.npmjs.org'


### PR DESCRIPTION
This allows you to run a custom publish script within each directory. Usage:

```bash
mono-repo-publish custom --pr-url=<github-url> --script=/path/to/publish/script.sh
```

This will allow maintainers to have their own logic about which command is run. `mono-repo-publish` will determine which folders it will need to run the script from within. For example, the custom publish script could publish to npm, then also build and publish documentation somewhere.

Additionally, we now allow providing the appId, privateKey and installationId paths via CLI arguments (can still provide via environment variables). We also added tests for the CLI parsing/argument handling.

Fixes #4096 
