### PR TITLE
Revert "chore: release main (#4100)"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,7 +5,7 @@
   "packages/gcf-utils": "13.8.4",
   "packages/issue-utils": "1.0.0",
   "packages/label-utils": "2.0.2",
-  "packages/mono-repo-publish": "1.4.0",
+  "packages/mono-repo-publish": "1.3.0",
   "packages/object-selector": "2.0.0",
   "packages/release-brancher": "1.3.3"
 }

--- a/packages/mono-repo-publish/CHANGELOG.md
+++ b/packages/mono-repo-publish/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [1.4.0](https://github.com/googleapis/repo-automation-bots/compare/mono-repo-publish-v1.3.0...mono-repo-publish-v1.4.0) (2022-08-02)
-
-
-### Features
-
-* add custom command for running arbitrary publish script ([#4099](https://github.com/googleapis/repo-automation-bots/issues/4099)) ([34b8777](https://github.com/googleapis/repo-automation-bots/commit/34b8777278f3071a0cdf5bfb671b3888263fae64))
-
 ## [1.3.0](https://github.com/googleapis/repo-automation-bots/compare/mono-repo-publish-v1.2.2...mono-repo-publish-v1.3.0) (2022-04-22)
 
 

--- a/packages/mono-repo-publish/package-lock.json
+++ b/packages/mono-repo-publish/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@google-cloud/mono-repo-publish",
-  "version": "1.4.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@google-cloud/mono-repo-publish",
-      "version": "1.4.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@octokit/auth-app": "^4.0.4",

--- a/packages/mono-repo-publish/package.json
+++ b/packages/mono-repo-publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/mono-repo-publish",
-  "version": "1.4.0",
+  "version": "1.3.0",
   "description": "publishes submodules based on the last merged release PR",
   "main": "build/src/main.js",
   "bin": "build/src/bin/mono-repo-publish.js",


### PR DESCRIPTION
This reverts commit 3866c91c56b494bcb5959062f85f3966cbdece30.

Attempt to fix broken finale test.

Fixes https://github.com/googleapis/repo-automation-bots/issues/4108