### PR TITLE
docs: fix description of header checker lint bot

### DIFF
--- a/packages/header-checker-lint/package.json
+++ b/packages/header-checker-lint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "header-checker-lint",
   "version": "1.2.0",
-  "description": "lint commit messages based on conventionalcommits.org",
+  "description": "lint headers for correct copyright information",
   "private": true,
   "author": "Google Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
This looks like some copy-pasta from the creation of the header lint bot that was never updated.
