### PR TITLE
feat(bot-config-utils): resolve false on invalid config files

### DIFF
--- a/packages/bot-config-utils/README.md
+++ b/packages/bot-config-utils/README.md
@@ -169,6 +169,8 @@ schema you provided. It will submit a failing status check if:
 - You are trying to add a broken config file, or the config file
   doesn't match the schema.
 
+`validateConfigChanges` resolves `false`, if the config file is invalid,
+and a failing check has been created.
 
 ## Fetch config from the PR head
 Probot's implementation of config always fetches the config from the

--- a/packages/bot-config-utils/src/bot-config-utils.ts
+++ b/packages/bot-config-utils/src/bot-config-utils.ts
@@ -314,7 +314,7 @@ export class MultiConfigChecker {
    * @param {number} prNumber - The number of the PR.
    * @param {GCFLogger} logger - Optional. Logger for debug output.
    *
-   * @return {Promise<void>}
+   * @return {Promise<boolean>} Returns 'true' if config is valid, 'false' if invalid.
    */
   public async validateConfigChanges(
     octokit: Octokit,
@@ -323,7 +323,7 @@ export class MultiConfigChecker {
     commitSha: string,
     prNumber: number,
     logger: GCFLogger = defaultLogger
-  ): Promise<void> {
+  ): Promise<boolean> {
     const errorTextByFile: Record<string, string[]> = {};
     function addError(file: string, message: string) {
       if (!errorTextByFile[file]) {
@@ -390,7 +390,8 @@ export class MultiConfigChecker {
       }
     }
 
-    for (const file in errorTextByFile) {
+    const files = Object.keys(errorTextByFile);
+    for (const file of files) {
       const errorText = errorTextByFile[file].join('\n');
       const checkParams = {
         owner: owner,
@@ -406,6 +407,8 @@ export class MultiConfigChecker {
       };
       await octokit.checks.create(checkParams);
     }
+    // Return false, if config is invalid, true if valid:
+    return files.length > 0 ? false : true;
   }
 }
 


### PR DESCRIPTION
validateConfigChanges will now resolve true or false depending on
whether the config file is valid.

Refs: https://github.com/googleapis/repo-automation-bots/pull/4115

---

This will allow automations that themselves create checks to short-circuit when a check has been created for a bad configuration file.
