### PR TITLE
feat(bot-config-utils)!: validateConfigChanges now resolve boolean for valid config

### DIFF
--- a/packages/bot-config-utils/src/bot-config-utils.ts
+++ b/packages/bot-config-utils/src/bot-config-utils.ts
@@ -231,7 +231,7 @@ export class ConfigChecker<ConfigType> {
    * @param {string} commitSha - The commit hash of the tip of the PR head.
    * @param {number} prNumber - The number of the PR.
    *
-   * @return {Promise<void>}
+   * @return {Promise<boolean>} Returns 'true' if config is valid, 'false' if invalid.
    */
   public async validateConfigChanges(
     octokit: Octokit,
@@ -240,8 +240,8 @@ export class ConfigChecker<ConfigType> {
     commitSha: string,
     prNumber: number,
     logger: GCFLogger = defaultLogger
-  ): Promise<void> {
-    await this.checker.validateConfigChanges(
+  ): Promise<boolean> {
+    return await this.checker.validateConfigChanges(
       octokit,
       owner,
       repo,


### PR DESCRIPTION
The `Checker` class had been updated, but not the public interface.

The method signature of the public interface changes, so calling this a breaking change.