### PR TITLE
fix(auto-label): throws an Error when installation id is not provided

### DIFF
--- a/packages/auto-label/src/auto-label.ts
+++ b/packages/auto-label/src/auto-label.ts
@@ -602,9 +602,15 @@ export function handler(app: Probot) {
     const repo = context.payload.repository.name;
     // First check the config schema for PR.
     const configChecker = new ConfigChecker<Config>(schema, CONFIG_FILE_NAME);
-    const octokit = await getAuthenticatedOctokit(
-      context.payload.installation!.id
-    );
+    let octokit: Octokit;
+    if (context.payload.installation && context.payload.installation.id) {
+      octokit = await getAuthenticatedOctokit(context.payload.installation.id);
+    } else {
+      throw new Error(
+        `Installation ID not provided in ${context.payload.action} event.` +
+          ' We cannot authenticate Octokit.'
+      );
+    }
     await configChecker.validateConfigChanges(
       octokit,
       owner,
@@ -640,9 +646,15 @@ export function handler(app: Probot) {
       return;
     }
 
-    const octokit = await getAuthenticatedOctokit(
-      context.payload.installation!.id
-    );
+    let octokit: Octokit;
+    if (context.payload.installation && context.payload.installation.id) {
+      octokit = await getAuthenticatedOctokit(context.payload.installation.id);
+    } else {
+      throw new Error(
+        `Installation ID not provided in ${context.payload.action} event.` +
+          ' We cannot authenticate Octokit.'
+      );
+    }
     for await (const repository of repositories) {
       const [owner, repo] = repository.full_name.split('/');
 


### PR DESCRIPTION
This is a followup on #4149
