### PR TITLE
chore: limit concurrency for link checking job

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -19,6 +19,8 @@ jobs:
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@4a5af7cd2958a2282cefbd9c10f63bdb89982d76
+        with:
+          args: --max-concurrency 5 './**/*.md'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
When I ran it manually, it resulted in many 429 errors.

Example run:
https://github.com/googleapis/repo-automation-bots/actions/runs/2915039381

According to https://github.com/lycheeverse/lychee-action/issues/97 we can fix it by limiting concurrency.