### PR TITLE
fix(owlbot-bootstrapper): push docker image to artifact registry

### DIFF
--- a/packages/owlbot-bootstrapper/common-container/cloudbuild-deploy-container.yaml
+++ b/packages/owlbot-bootstrapper/common-container/cloudbuild-deploy-container.yaml
@@ -31,13 +31,4 @@ steps:
       - "-t"
       - "us-docker.pkg.dev/owlbot-bootstrap-prod/owlbot-bootstrapper-images/owlbot-bootstrapper"
       - "."
-
-  - name: gcr.io/cloud-builders/docker
-    id: "push-docker"
-    waitFor: ["build-docker"]
-    args: ["push", "gcr.io/$PROJECT_ID/owlbot-bootstrapper"] 
-
-  - name: gcr.io/cloud-builders/docker
-    id: "push-docker"
-    waitFor: ["build-docker"]
-    args: ["push", "us-docker.pkg.dev/owlbot-bootstrap-prod/owlbot-bootstrapper-images/owlbot-bootstrapper"]
+  images: ["gcr.io/$PROJECT_ID/owlbot-bootstrapper", "us-docker.pkg.dev/owlbot-bootstrap-prod/owlbot-bootstrapper-images/owlbot-bootstrapper"]

--- a/packages/owlbot-bootstrapper/common-container/cloudbuild-deploy-container.yaml
+++ b/packages/owlbot-bootstrapper/common-container/cloudbuild-deploy-container.yaml
@@ -31,4 +31,4 @@ steps:
       - "-t"
       - "us-docker.pkg.dev/owlbot-bootstrap-prod/owlbot-bootstrapper-images/owlbot-bootstrapper"
       - "."
-  images: ["gcr.io/$PROJECT_ID/owlbot-bootstrapper", "us-docker.pkg.dev/owlbot-bootstrap-prod/owlbot-bootstrapper-images/owlbot-bootstrapper"]
+  images: ["gcr.io/$PROJECT_ID/owlbot-bootstrapper", "us-docker.pkg.dev/$PROJECT_ID/owlbot-bootstrapper-images/owlbot-bootstrapper"]

--- a/packages/owlbot-bootstrapper/common-container/cloudbuild-deploy-container.yaml
+++ b/packages/owlbot-bootstrapper/common-container/cloudbuild-deploy-container.yaml
@@ -35,4 +35,9 @@ steps:
   - name: gcr.io/cloud-builders/docker
     id: "push-docker"
     waitFor: ["build-docker"]
-    args: ["push", "gcr.io/$PROJECT_ID/owlbot-bootstrapper", "us-docker.pkg.dev/owlbot-bootstrap-prod/owlbot-bootstrapper-images/owlbot-bootstrapper"]
+    args: ["push", "gcr.io/$PROJECT_ID/owlbot-bootstrapper"] 
+
+  - name: gcr.io/cloud-builders/docker
+    id: "push-docker"
+    waitFor: ["build-docker"]
+    args: ["push", "us-docker.pkg.dev/owlbot-bootstrap-prod/owlbot-bootstrapper-images/owlbot-bootstrapper"]


### PR DESCRIPTION
Error from cloud build:
```
"docker push" requires exactly 1 argument.
See 'docker push --help'.

Usage:  docker push [OPTIONS] NAME[:TAG]
```