### PR TITLE
fix(snippet-bot): make formatBody resilient to an empty body

### DIFF
--- a/packages/snippet-bot/src/utils.ts
+++ b/packages/snippet-bot/src/utils.ts
@@ -54,7 +54,7 @@ export const formatBody = (
   addition: string
 ): string => {
   // First cut off if we already have the commentMark.
-  const markIndex = originalBody.indexOf(commentMark);
+  const markIndex = originalBody ? originalBody.indexOf(commentMark) : -1;
   if (markIndex >= 0) {
     originalBody = originalBody.substr(0, markIndex);
   }

--- a/packages/snippet-bot/test/utils.ts
+++ b/packages/snippet-bot/test/utils.ts
@@ -60,7 +60,11 @@ describe('formatBody', () => {
     );
   });
   it('should add contents to an empty body', () => {
-    const result = formatBody(undefined as unknown as string, commentMark, addition);
+    const result = formatBody(
+      undefined as unknown as string,
+      commentMark,
+      addition
+    );
     assert(result.includes(addition));
     assert(
       result.includes(

--- a/packages/snippet-bot/test/utils.ts
+++ b/packages/snippet-bot/test/utils.ts
@@ -59,6 +59,15 @@ describe('formatBody', () => {
       )
     );
   });
+  it('should add contents to an empty body', () => {
+    const result = formatBody(undefined as unknown as string, commentMark, addition);
+    assert(result.includes(addition));
+    assert(
+      result.includes(
+        'https://github.com/googleapis/repo-automation-bots/issues'
+      )
+    );
+  });
 });
 
 describe('formatExpandable', () => {


### PR DESCRIPTION
fixes #4251
