### PR TITLE
fix(snippet-bot): convert null value to an empty string

### DIFF
--- a/packages/snippet-bot/src/utils.ts
+++ b/packages/snippet-bot/src/utils.ts
@@ -54,7 +54,8 @@ export const formatBody = (
   addition: string
 ): string => {
   // First cut off if we already have the commentMark.
-  const markIndex = originalBody ? originalBody.indexOf(commentMark) : -1;
+  originalBody = originalBody ? originalBody : '';
+  const markIndex = originalBody.indexOf(commentMark);
   if (markIndex >= 0) {
     originalBody = originalBody.substr(0, markIndex);
   }

--- a/packages/snippet-bot/test/utils.ts
+++ b/packages/snippet-bot/test/utils.ts
@@ -71,6 +71,8 @@ describe('formatBody', () => {
         'https://github.com/googleapis/repo-automation-bots/issues'
       )
     );
+    // It should start with the commentMark.
+    assert(result.indexOf(commentMark) === 0);
   });
 });
 


### PR DESCRIPTION
fixes #4253
