### PR TITLE
chore: configure renovate to use commit hash for github actions

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -1,7 +1,7 @@
 permissions:
   contents: read
   issues: write
-  
+
 name: Links
 
 on:
@@ -18,7 +18,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@4a5af7cd2958a2282cefbd9c10f63bdb89982d76
+        uses: lycheeverse/lychee-action@4a5af7cd2958a2282cefbd9c10f63bdb89982d76 # tag=v1.5.1
         with:
           args: --exclude '(http://devrel/.*|https://github.com/googleapis/googleapis-gen)' --max-concurrency 3 --exclude-mail --exclude-all-private './**/README.md'
         env:
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@99b87c35610e986ad2034a7b0518a9b3ebea541b
+        uses: peter-evans/create-issue-from-file@99b87c35610e986ad2034a7b0518a9b3ebea541b # tag=v4.0.0
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "extends": [
     "config:base",
     "docker:disable",
-    ":disableDependencyDashboard"
+    ":disableDependencyDashboard",
+    "helpers:pinGitHubActionDigests"
   ],
   "pinVersions": false,
   "rebaseStalePrs": true,


### PR DESCRIPTION
also added version tag at the end of the current commit hashes

I think this PR will stop renovate to create PR like #4287 