### PR TITLE
feat(release-please): enable sentence-case for googleapis

### DIFF
--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -297,7 +297,11 @@ async function runBranchConfigurationWithConfigurationHandling(
 
 // TODO: Allow this functionality to be enabled via an
 // org level config in a .github repository:
-const ORG_SENTENCE_CASE_ENABLED = new Set<string>(['chingor13', 'bcoe']);
+const ORG_SENTENCE_CASE_ENABLED = new Set<string>([
+  'chingor13',
+  'bcoe',
+  'googleapis',
+]);
 function isSentenceCaseEnabled(repoUrl: string) {
   const [org] = repoUrl.split('/');
   return ORG_SENTENCE_CASE_ENABLED.has(org);


### PR DESCRIPTION
The sentence-case plugin has been tested, let's turn it on for googleapis.

_Example of it working:_

<img width="672" alt="Screen Shot 2022-09-01 at 3 20 31 PM" src="https://user-images.githubusercontent.com/194609/187995317-54f1979d-deca-48af-b251-edad65af3beb.png">
