### PR TITLE
feat: add @type to the error logs

### DIFF
--- a/packages/gcf-utils/test/gcf-logger.ts
+++ b/packages/gcf-utils/test/gcf-logger.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {logger} from '../src/gcf-utils';
-import {GCFLogger} from '../src/logging/gcf-logger';
+import {GCFLogger, ERROR_REPORTING_TYPE_NAME} from '../src/logging/gcf-logger';
 import {describe, beforeEach, it} from 'mocha';
 import {ObjectWritableMock} from 'stream-mock';
 import {validateLogs, LogLine, logLevels} from './test-helpers';
@@ -68,6 +68,19 @@ describe('GCFLogger', () => {
       }
     }
 
+    describe('error', () => {
+      it('populates @type field', () => {
+        logger.error('Error happened');
+        const loggedLines: LogLine[] = readLogsAsObjects(destination);
+        validateLogs(
+          loggedLines,
+          1,
+          [],
+          [{'@type': ERROR_REPORTING_TYPE_NAME}],
+          logLevels['error']
+        );
+      });
+    });
     describe('metric', () => {
       it('populates event, count, type, when single string argument provided', () => {
         logger.metric('release-created');


### PR DESCRIPTION
This is a trial for making error logs captured by Cloud Error Reporting as described below:

https://cloud.google.com/error-reporting/docs/formatting-error-messages#@type

Fixes #4061 
