### PR TITLE
chore: add parent directory to lock file update PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,7 @@
     }
   ],
   "lockFileMaintenance": {
+    "commitMessageAction": "[{{parentDir}}] Lock file maintenance",
     "enabled": true
   },
   "additionalBranchPrefix": "{{parentDir}}-",


### PR DESCRIPTION
Currently, all the lock file update PRs have the same title, even though they are grouped by parent directory. This should add context to the renovate lock file PRs.

The [docs](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance) do not mention if the `{{parentDir}}` macro is available, but it's worth a try.