### PR TITLE
deps(failurechecker): update gcf-utils to V14.2.0

### DIFF
--- a/packages/failurechecker/package-lock.json
+++ b/packages/failurechecker/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@google-automations/issue-utils": "^2.1.0",
-        "gcf-utils": "^14.1.1"
+        "gcf-utils": "^14.2.0"
       },
       "devDependencies": {
         "@octokit/types": "^7.2.0",
@@ -3742,9 +3742,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.1.1.tgz",
-      "integrity": "sha512-SPt85cgM74+S9fQEwSCf0HLxbIFhD5QrSqn0GfyiDcCdx6ohbi6PvpSQTLkbOr32R4TamNCFSP6K++OU79zh6Q==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
+      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
       "dependencies": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",
@@ -11207,9 +11207,9 @@
       }
     },
     "gcf-utils": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.1.1.tgz",
-      "integrity": "sha512-SPt85cgM74+S9fQEwSCf0HLxbIFhD5QrSqn0GfyiDcCdx6ohbi6PvpSQTLkbOr32R4TamNCFSP6K++OU79zh6Q==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
+      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
       "requires": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",

--- a/packages/failurechecker/package.json
+++ b/packages/failurechecker/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@google-automations/issue-utils": "^2.1.0",
-    "gcf-utils": "^14.1.1"
+    "gcf-utils": "^14.2.0"
   },
   "devDependencies": {
     "@octokit/types": "^7.2.0",


### PR DESCRIPTION
With this version, Cloud Error Reporting will capture unhandled errors.
