### PR TITLE
deps(conventional-commit-lint): update gcf-utils to V14.2.0

### DIFF
--- a/packages/conventional-commit-lint/package-lock.json
+++ b/packages/conventional-commit-lint/package-lock.json
@@ -14,7 +14,7 @@
         "@google-automations/bot-config-utils": "^6.1.0",
         "@octokit/openapi-types": "^13.8.0",
         "@octokit/webhooks-types": "^6.3.6",
-        "gcf-utils": "^14.1.1"
+        "gcf-utils": "^14.2.0"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.1",
@@ -3974,9 +3974,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.1.1.tgz",
-      "integrity": "sha512-SPt85cgM74+S9fQEwSCf0HLxbIFhD5QrSqn0GfyiDcCdx6ohbi6PvpSQTLkbOr32R4TamNCFSP6K++OU79zh6Q==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
+      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
       "dependencies": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",
@@ -11667,9 +11667,9 @@
       }
     },
     "gcf-utils": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.1.1.tgz",
-      "integrity": "sha512-SPt85cgM74+S9fQEwSCf0HLxbIFhD5QrSqn0GfyiDcCdx6ohbi6PvpSQTLkbOr32R4TamNCFSP6K++OU79zh6Q==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
+      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
       "requires": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",

--- a/packages/conventional-commit-lint/package.json
+++ b/packages/conventional-commit-lint/package.json
@@ -34,7 +34,7 @@
     "@google-automations/bot-config-utils": "^6.1.0",
     "@octokit/openapi-types": "^13.8.0",
     "@octokit/webhooks-types": "^6.3.6",
-    "gcf-utils": "^14.1.1"
+    "gcf-utils": "^14.2.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",


### PR DESCRIPTION
With this version, Cloud Error Reporting will capture unhandled errors.