### PR TITLE
deps(blunderbuss): update gcf-utils to V14.2.0

### DIFF
--- a/packages/blunderbuss/package-lock.json
+++ b/packages/blunderbuss/package-lock.json
@@ -12,7 +12,7 @@
         "@google-automations/bot-config-utils": "^6.1.0",
         "@google-automations/datastore-lock": "^4.0.0",
         "@google-automations/label-utils": "^3.0.0",
-        "gcf-utils": "^14.1.0"
+        "gcf-utils": "^14.2.0"
       },
       "devDependencies": {
         "@octokit/types": "^7.1.1",
@@ -3871,9 +3871,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.1.0.tgz",
-      "integrity": "sha512-pRLAj9CFJS1U//qB9NSL3ocO06RkPwQeEsy6nvL4j8t6vCMHk3RDU8AKw79L9V1CUsXWwF5hFMhefD2r7I9Umw==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
+      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
       "dependencies": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",
@@ -3904,13 +3904,38 @@
         "probot": "^12.2.7",
         "tmp": "^0.2.1",
         "uuid": "^9.0.0",
-        "yargs": "^16.0.0"
+        "yargs": "^17.0.0"
       },
       "bin": {
         "genkey": "build/src/bin/genkey.js"
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/gcf-utils/node_modules/yargs": {
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcf-utils/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/gcp-metadata": {
@@ -11458,9 +11483,9 @@
       }
     },
     "gcf-utils": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.1.0.tgz",
-      "integrity": "sha512-pRLAj9CFJS1U//qB9NSL3ocO06RkPwQeEsy6nvL4j8t6vCMHk3RDU8AKw79L9V1CUsXWwF5hFMhefD2r7I9Umw==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
+      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
       "requires": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",
@@ -11491,7 +11516,28 @@
         "probot": "^12.2.7",
         "tmp": "^0.2.1",
         "uuid": "^9.0.0",
-        "yargs": "^16.0.0"
+        "yargs": "^17.0.0"
+      },
+      "dependencies": {
+        "yargs": {
+          "version": "17.5.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+          "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+        }
       }
     },
     "gcp-metadata": {

--- a/packages/blunderbuss/package.json
+++ b/packages/blunderbuss/package.json
@@ -31,7 +31,7 @@
     "@google-automations/bot-config-utils": "^6.1.0",
     "@google-automations/datastore-lock": "^4.0.0",
     "@google-automations/label-utils": "^3.0.0",
-    "gcf-utils": "^14.1.0"
+    "gcf-utils": "^14.2.0"
   },
   "devDependencies": {
     "@octokit/types": "^7.1.1",


### PR DESCRIPTION
With this version, Cloud Error Reporting will capture unhandled errors.
