### PR TITLE
deps(repo-metadata-lint): update gcf-utils to V14.2.0

### DIFF
--- a/packages/repo-metadata-lint/package-lock.json
+++ b/packages/repo-metadata-lint/package-lock.json
@@ -13,7 +13,7 @@
         "@octokit/rest": "^19.0.4",
         "ajv": "^8.11.0",
         "gaxios": "^5.0.1",
-        "gcf-utils": "^14.1.1",
+        "gcf-utils": "^14.2.0",
         "jsonwebtoken": "^8.5.1",
         "yargs": "^17.5.1"
       },
@@ -3624,9 +3624,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.1.1.tgz",
-      "integrity": "sha512-SPt85cgM74+S9fQEwSCf0HLxbIFhD5QrSqn0GfyiDcCdx6ohbi6PvpSQTLkbOr32R4TamNCFSP6K++OU79zh6Q==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
+      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
       "dependencies": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",
@@ -10528,9 +10528,9 @@
       }
     },
     "gcf-utils": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.1.1.tgz",
-      "integrity": "sha512-SPt85cgM74+S9fQEwSCf0HLxbIFhD5QrSqn0GfyiDcCdx6ohbi6PvpSQTLkbOr32R4TamNCFSP6K++OU79zh6Q==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
+      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
       "requires": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",

--- a/packages/repo-metadata-lint/package.json
+++ b/packages/repo-metadata-lint/package.json
@@ -32,7 +32,7 @@
     "@octokit/rest": "^19.0.4",
     "ajv": "^8.11.0",
     "gaxios": "^5.0.1",
-    "gcf-utils": "^14.1.1",
+    "gcf-utils": "^14.2.0",
     "jsonwebtoken": "^8.5.1",
     "yargs": "^17.5.1"
   },


### PR DESCRIPTION
With this version, Cloud Error Reporting will capture unhandled errors.
