### PR TITLE
deps(canary-bot): update gcf-utils to V14.2.1

### DIFF
--- a/packages/canary-bot/package-lock.json
+++ b/packages/canary-bot/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dayjs": "^1.11.5",
-        "gcf-utils": "^14.2.0",
+        "gcf-utils": "^14.2.1",
         "lru-cache": "^7.14.0"
       },
       "devDependencies": {
@@ -3642,9 +3642,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
-      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.1.tgz",
+      "integrity": "sha512-zt7xF+/3hjtUyCj92s9O6XzPAETjPRDi6eN8LWV37fIlUAC7wMH+Bq/+XBXPeGhZh+5/3Nb6lFAaWhN+N8tMDQ==",
       "dependencies": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",
@@ -10703,9 +10703,9 @@
       }
     },
     "gcf-utils": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
-      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.1.tgz",
+      "integrity": "sha512-zt7xF+/3hjtUyCj92s9O6XzPAETjPRDi6eN8LWV37fIlUAC7wMH+Bq/+XBXPeGhZh+5/3Nb6lFAaWhN+N8tMDQ==",
       "requires": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",

--- a/packages/canary-bot/package.json
+++ b/packages/canary-bot/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "dayjs": "^1.11.5",
-    "gcf-utils": "^14.2.0",
+    "gcf-utils": "^14.2.1",
     "lru-cache": "^7.14.0"
   },
   "devDependencies": {


### PR DESCRIPTION
With this version, gcf-utils will cache Cloud Run URL.
