### PR TITLE
feat(gcf-utils): introduce ServiceUnavailable

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -613,7 +613,8 @@ export class GCFBootstrapper {
               let isServiceUnavailable = e instanceof ServiceUnavailable;
               let serviceUnavailableMessage =
                 e instanceof ServiceUnavailable ? e.message : '';
-              let serviceUnavailableStack = e instanceof ServiceUnavailable ? e.originalError.stack : '';
+              let serviceUnavailableStack =
+                e instanceof ServiceUnavailable ? e.originalError.stack : '';
               if (e instanceof AggregateError) {
                 for (const inner of e) {
                   if (inner instanceof ServiceUnavailable) {

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -91,6 +91,13 @@ interface EnqueueTaskParams {
   name: string;
 }
 
+/**
+ * Bot can throw this error to indicate it experienced some form of
+ * resource limitation.  GCFBootstrapper will catch this and return
+ * HTTP 503 to suggest Cloud Task adds backoff for the next attempt.
+ */
+export class ServiceUnavailable extends Error {}
+
 export interface WrapOptions {
   // Whether or not to enqueue direct GitHub webhooks in a Cloud Task
   // queue which provides a retry mechanism. Defaults to `true`.
@@ -596,7 +603,33 @@ export class GCFBootstrapper {
               });
               return;
             } else {
-              throw e;
+              // If a bot throws ServicceUnavailable, returns 503 for throttle task queue.
+              let isServiceUnavailable = e instanceof ServiceUnavailable;
+              let serviceUnavailableMessage =
+                e instanceof ServiceUnavailable ? e.message : '';
+              if (e instanceof AggregateError) {
+                for (const inner of e) {
+                  if (inner instanceof ServiceUnavailable) {
+                    isServiceUnavailable = true;
+                    serviceUnavailableMessage = inner.message;
+                  }
+                }
+              }
+              if (isServiceUnavailable) {
+                requestLogger.warn(
+                  'ServiceUnavailable',
+                  serviceUnavailableMessage
+                );
+                response.status(503).send({
+                  statusCode: 503,
+                  body: JSON.stringify({
+                    message: serviceUnavailableMessage,
+                  }),
+                });
+                return;
+              } else {
+                throw e;
+              }
             }
           }
         } else if (botRequest.triggerType === TriggerType.GITHUB) {

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -20,6 +20,7 @@ import {
   HandlerFunction,
   RequestWithRawBody,
   getContextLogger,
+  ServiceUnavailable,
 } from '../src/gcf-utils';
 import {describe, beforeEach, afterEach, it} from 'mocha';
 import {Octokit} from '@octokit/rest';
@@ -664,6 +665,33 @@ describe('GCFBootstrapper', () => {
               ],
             }
           );
+        });
+      });
+      req.body = {
+        installation: {id: 1},
+      };
+      req.headers = {};
+      req.headers['x-github-event'] = 'issues';
+      req.headers['x-github-delivery'] = '123';
+      req.headers['x-cloudtasks-taskname'] = 'my-task';
+
+      await handler(req, response);
+
+      sinon.assert.calledOnce(configStub);
+      sinon.assert.notCalled(issueSpy);
+      sinon.assert.notCalled(repositoryCronSpy);
+      sinon.assert.notCalled(installationCronSpy);
+      sinon.assert.notCalled(globalCronSpy);
+      sinon.assert.notCalled(sendStatusStub);
+      sinon.assert.called(sendStub);
+
+      assert.strictEqual(response.statusCode, 503);
+    });
+
+    it('returns 503 on ServiceUnavailable', async () => {
+      await mockBootstrapper(undefined, async app => {
+        app.on('issues', async () => {
+          throw new ServiceUnavailable();
         });
       });
       req.body = {

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -953,11 +953,11 @@ describe('GCFBootstrapper', () => {
         const lastScheduleTime = lastTask.task.scheduleTime.seconds;
         assert(
           lastScheduleTime - firstScheduleTime >
-          DEFAULT_FLOW_CONTROL_DELAY_IN_SECOND
+            DEFAULT_FLOW_CONTROL_DELAY_IN_SECOND
         );
         assert(
           lastScheduleTime - firstScheduleTime <
-          DEFAULT_FLOW_CONTROL_DELAY_IN_SECOND + 1
+            DEFAULT_FLOW_CONTROL_DELAY_IN_SECOND + 1
         );
         sinon.assert.notCalled(issueSpy);
         sinon.assert.notCalled(repositoryCronSpy);

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -691,7 +691,7 @@ describe('GCFBootstrapper', () => {
     it('returns 503 on ServiceUnavailable', async () => {
       await mockBootstrapper(undefined, async app => {
         app.on('issues', async () => {
-          throw new ServiceUnavailable();
+          throw new ServiceUnavailable('', new Error('An error happened'));
         });
       });
       req.body = {
@@ -953,11 +953,11 @@ describe('GCFBootstrapper', () => {
         const lastScheduleTime = lastTask.task.scheduleTime.seconds;
         assert(
           lastScheduleTime - firstScheduleTime >
-            DEFAULT_FLOW_CONTROL_DELAY_IN_SECOND
+          DEFAULT_FLOW_CONTROL_DELAY_IN_SECOND
         );
         assert(
           lastScheduleTime - firstScheduleTime <
-            DEFAULT_FLOW_CONTROL_DELAY_IN_SECOND + 1
+          DEFAULT_FLOW_CONTROL_DELAY_IN_SECOND + 1
         );
         sinon.assert.notCalled(issueSpy);
         sinon.assert.notCalled(repositoryCronSpy);


### PR DESCRIPTION
A bot can throw ServiceUnavailable when it experiences resource limitation. The next task attempt will be delayed with some backoff.

fixes #4495