### PR TITLE
deps: update release-please to 14.10.2

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/rest": "^19.0.4",
         "@octokit/webhooks": "^10.1.5",
         "gcf-utils": "^14.2.0",
-        "release-please": "^14.10.0"
+        "release-please": "^14.10.2"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.1",
@@ -7645,9 +7645,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "14.10.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.10.0.tgz",
-      "integrity": "sha512-EBBYcVuj0m+J5rFX+ayLm7rrjjNLsOpzTRqfss28zMNoHnakvT6AZdWw19ZZWiW3W0+94LyMvS8rYiUXDnUZPA==",
+      "version": "14.10.2",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.10.2.tgz",
+      "integrity": "sha512-bbJ50+8oY52l6GNKmaO1J3P8/77kNoawMpRJ/vTmLG5ZVIEYZNc/NM8XYzM9CWWe12UiMojWX0aiYfXfooHHQQ==",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^1.2.0",
@@ -15116,9 +15116,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "14.10.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.10.0.tgz",
-      "integrity": "sha512-EBBYcVuj0m+J5rFX+ayLm7rrjjNLsOpzTRqfss28zMNoHnakvT6AZdWw19ZZWiW3W0+94LyMvS8rYiUXDnUZPA==",
+      "version": "14.10.2",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.10.2.tgz",
+      "integrity": "sha512-bbJ50+8oY52l6GNKmaO1J3P8/77kNoawMpRJ/vTmLG5ZVIEYZNc/NM8XYzM9CWWe12UiMojWX0aiYfXfooHHQQ==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^1.2.0",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -34,7 +34,7 @@
     "@octokit/rest": "^19.0.4",
     "@octokit/webhooks": "^10.1.5",
     "gcf-utils": "^14.2.0",
-    "release-please": "^14.10.0"
+    "release-please": "^14.10.2"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",


### PR DESCRIPTION
Includes:
* fix for google-cloud-java's maven-workspace plugin
* fix for erroneously adding schema to versions manifest
