### PR TITLE
fix(snippet-bot): always ignore "owl-bot-staging"

### DIFF
--- a/packages/snippet-bot/src/configuration.ts
+++ b/packages/snippet-bot/src/configuration.ts
@@ -37,6 +37,8 @@ export class Configuration {
     this.minimatches = options.ignoreFiles.map(pattern => {
       return new minimatch.Minimatch(pattern);
     });
+    // Always ignore files under "owl-bot-staging"
+    this.minimatches.push(new minimatch.Minimatch('owl-bot-staging/**/*'));
   }
 
   ignoredFile(filename: string): boolean {

--- a/packages/snippet-bot/test/fixtures/diff-owl-bot.txt
+++ b/packages/snippet-bot/test/fixtures/diff-owl-bot.txt
@@ -1,0 +1,38 @@
+diff --git a/owl-bot-staging/test.py b/owl-bot-staging/test.py
+index 198d0257595..6048151ca9f 100644
+--- a/owl-bot-staging/test.py
++++ b/owl-bot-staging/test.py
+@@ -21,28 +21,28 @@
+
+
+ def incomplete_key(client):
+-    # [START datastore_incomplete_key]
++    # [START datastore_incomplete_key2]
+     key = client.key('Task')
+-    # [END datastore_incomplete_key]
++    # [END datastore_incomplete_key2]
+
+     return key
+
+
+ def named_key(client):
+-    # [START datastore_named_key]
++    # [START datastore_named_key2]
+     key = client.key('Task', 'sample_task')
+-    # [END datastore_named_key]
++    # [END datastore_named_key2]
+
+     return key
+
+
+ def key_with_parent(client):
+-    # [START untracked_region_tag]
++    # [START key_with_parent]
+     key = client.key('TaskList', 'default', 'Task', 'sample_task')
+     # Alternatively
+     parent_key = client.key('TaskList', 'default')
+     key = client.key('Task', 'sample_task', parent=parent_key)
+-    # [END untracked_region_tag]
++    # [END key_with_parent]
+
+     return key


### PR DESCRIPTION
I chose to hard code this. Ideally it's better to have it in default config, but currently we don't have a nice way to merge arrays in default config and the user config, also it's unlikely the directory will be used for other purpose.

part of #4520 