### PR TITLE
chore: exclude npmjs for link checking

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -20,7 +20,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@4a5af7cd2958a2282cefbd9c10f63bdb89982d76 # tag=v1.5.1
         with:
-          args: --exclude '(http://devrel/.*|https://github.com/googleapis/googleapis-gen)' --max-concurrency 3 --exclude-mail --exclude-all-private './**/README.md'
+          args: --exclude '(http://devrel/.*|https://github.com/googleapis/googleapis-gen|https://www.npmjs.com/)' --max-concurrency 3 --exclude-mail --exclude-all-private './**/README.md'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
Access to npmjs occationally fails with HTTP 429.
Example: #4554
