### PR TITLE
feat: add enabled flag to sync-repo-settings

### DIFF
--- a/packages/sync-repo-settings/src/schema.json
+++ b/packages/sync-repo-settings/src/schema.json
@@ -5,6 +5,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "enabled": {
+      "description": "Whether or not the sync-repo-settings bot is enabled.",
+      "type": "boolean"
+    },
     "squashMergeAllowed": {
       "description": "Whether or not squash-merging is enabled on this repository.",
       "type": "boolean"

--- a/packages/sync-repo-settings/src/sync-repo-settings.ts
+++ b/packages/sync-repo-settings/src/sync-repo-settings.ts
@@ -48,6 +48,7 @@ function deepFreeze(object: any) {
 const languageConfig: LanguageConfig = deepFreeze(checks);
 
 const repoConfigDefaults: RepoConfig = deepFreeze({
+  enabled: true,
   mergeCommitAllowed: false,
   squashMergeAllowed: true,
   rebaseMergeAllowed: true,
@@ -82,6 +83,10 @@ export class SyncRepoSettings {
     const logger = this.logger;
     const repo = options.repo;
     const [owner, name] = repo.split('/');
+    if (!config?.enabled) {
+      logger.info(`config is not enabled for repository ${repo}`);
+      return false;
+    }
     if (!config) {
       logger.info(`no local config found for ${repo}, checking global config`);
       // Fetch the list of languages used in this repository

--- a/packages/sync-repo-settings/src/sync-repo-settings.ts
+++ b/packages/sync-repo-settings/src/sync-repo-settings.ts
@@ -85,7 +85,7 @@ export class SyncRepoSettings {
     const [owner, name] = repo.split('/');
     if (!config?.enabled) {
       logger.info(`config is not enabled for repository ${repo}`);
-      return false;
+      return;
     }
     if (!config) {
       logger.info(`no local config found for ${repo}, checking global config`);

--- a/packages/sync-repo-settings/src/sync-repo-settings.ts
+++ b/packages/sync-repo-settings/src/sync-repo-settings.ts
@@ -83,7 +83,7 @@ export class SyncRepoSettings {
     const logger = this.logger;
     const repo = options.repo;
     const [owner, name] = repo.split('/');
-    if (!config?.enabled) {
+    if (config?.enabled === false) {
       logger.info(`config is not enabled for repository ${repo}`);
       return;
     }

--- a/packages/sync-repo-settings/src/types.ts
+++ b/packages/sync-repo-settings/src/types.ts
@@ -14,6 +14,10 @@
 
 export interface RepoConfig {
   /**
+   * Whether or not the sync-repo-settings bot is enabled.
+   */
+  enabled?: boolean;
+  /**
    * Whether or not squash-merging is enabled on this repository.
    */
   squashMergeAllowed?: boolean;


### PR DESCRIPTION
Adds an enabled flag to turn off the sync-repo-settings bot.

Workaround for #4617 
