### PR TITLE
deps: update release-please to 14.15.1

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/rest": "^19.0.4",
         "@octokit/webhooks": "^10.1.5",
         "gcf-utils": "^14.2.0",
-        "release-please": "^14.15.0"
+        "release-please": "^14.15.1"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
@@ -7661,9 +7661,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "14.15.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.15.0.tgz",
-      "integrity": "sha512-sXQCxmqTvvXlrl+QYsuLW0Ddp62Ze357NGsAape3iZPEpbsWXJk3OtG8VUk7y/Kx7eUpgcpmozRqIEA+lYAPzQ==",
+      "version": "14.15.1",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.15.1.tgz",
+      "integrity": "sha512-rh/M3o2kTnFpelnc2hcRxmazL0etPmjGeFCrLcWiUgt7m2rfd8+nKk/4KpbAmeNcVchu+dT+PB3odjs4dG2hiw==",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^1.2.0",
@@ -15107,9 +15107,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "14.15.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.15.0.tgz",
-      "integrity": "sha512-sXQCxmqTvvXlrl+QYsuLW0Ddp62Ze357NGsAape3iZPEpbsWXJk3OtG8VUk7y/Kx7eUpgcpmozRqIEA+lYAPzQ==",
+      "version": "14.15.1",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.15.1.tgz",
+      "integrity": "sha512-rh/M3o2kTnFpelnc2hcRxmazL0etPmjGeFCrLcWiUgt7m2rfd8+nKk/4KpbAmeNcVchu+dT+PB3odjs4dG2hiw==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^1.2.0",

--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/rest": "^19.0.4",
         "@octokit/webhooks": "^10.1.5",
         "gcf-utils": "^14.2.0",
-        "release-please": "^14.13.1"
+        "release-please": "^14.15.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
@@ -7661,9 +7661,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "14.13.1",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.13.1.tgz",
-      "integrity": "sha512-jFCrp0H3LqLr4bDkhIDylOfl9HAWVuwCMLGQbbqHWpa21+XTnX84pXAg7mmUE8xzZaFfO82uEE/5UIJfKJiZUg==",
+      "version": "14.15.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.15.0.tgz",
+      "integrity": "sha512-sXQCxmqTvvXlrl+QYsuLW0Ddp62Ze357NGsAape3iZPEpbsWXJk3OtG8VUk7y/Kx7eUpgcpmozRqIEA+lYAPzQ==",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^1.2.0",
@@ -7693,7 +7693,7 @@
         "node-html-parser": "^6.0.0",
         "parse-github-repo-url": "^1.4.1",
         "semver": "^7.0.0",
-        "type-fest": "^2.0.0",
+        "type-fest": "^3.0.0",
         "typescript": "^4.6.4",
         "unist-util-visit": "^2.0.3",
         "unist-util-visit-parents": "^3.1.1",
@@ -7721,11 +7721,11 @@
       }
     },
     "node_modules/release-please/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.1.0.tgz",
+      "integrity": "sha512-StmrZmK3eD9mDF9Vt7UhqthrDSk66O9iYl5t5a0TSoVkHjl0XZx/xuc/BRz4urAXXGHOY5OLsE0RdJFIApSFmw==",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15107,9 +15107,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "14.13.1",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.13.1.tgz",
-      "integrity": "sha512-jFCrp0H3LqLr4bDkhIDylOfl9HAWVuwCMLGQbbqHWpa21+XTnX84pXAg7mmUE8xzZaFfO82uEE/5UIJfKJiZUg==",
+      "version": "14.15.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.15.0.tgz",
+      "integrity": "sha512-sXQCxmqTvvXlrl+QYsuLW0Ddp62Ze357NGsAape3iZPEpbsWXJk3OtG8VUk7y/Kx7eUpgcpmozRqIEA+lYAPzQ==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^1.2.0",
@@ -15139,7 +15139,7 @@
         "node-html-parser": "^6.0.0",
         "parse-github-repo-url": "^1.4.1",
         "semver": "^7.0.0",
-        "type-fest": "^2.0.0",
+        "type-fest": "^3.0.0",
         "typescript": "^4.6.4",
         "unist-util-visit": "^2.0.3",
         "unist-util-visit-parents": "^3.1.1",
@@ -15158,9 +15158,9 @@
           }
         },
         "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.1.0.tgz",
+          "integrity": "sha512-StmrZmK3eD9mDF9Vt7UhqthrDSk66O9iYl5t5a0TSoVkHjl0XZx/xuc/BRz4urAXXGHOY5OLsE0RdJFIApSFmw=="
         },
         "yargs": {
           "version": "17.6.0",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -34,7 +34,7 @@
     "@octokit/rest": "^19.0.4",
     "@octokit/webhooks": "^10.1.5",
     "gcf-utils": "^14.2.0",
-    "release-please": "^14.15.0"
+    "release-please": "^14.15.1"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -34,7 +34,7 @@
     "@octokit/rest": "^19.0.4",
     "@octokit/webhooks": "^10.1.5",
     "gcf-utils": "^14.2.0",
-    "release-please": "^14.13.1"
+    "release-please": "^14.15.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",


### PR DESCRIPTION
## Features
* php-yoshi: Add "misc" as trigger, hide "chore" (https://github.com/googleapis/release-please/issues/1725) ([f7a9d09](https://github.com/googleapis/release-please/commit/f7a9d091670f0a70a13a1b641fbc6d07ec000da2))
* Extract and return the created release id (https://github.com/googleapis/release-please/issues/1719) ([ef1c156](https://github.com/googleapis/release-please/commit/ef1c156ab1d44969548b4cb30b412b2066568aa4))

## Bug Fixes

* deps: Update dependency type-fest to v3 (https://github.com/googleapis/release-please/issues/1649) ([d3c3a3e](https://github.com/googleapis/release-please/commit/d3c3a3eae6557994ad244c0bdd79e1782971d2c1))
* python: Version updater updates patch versions >= 10 (https://github.com/googleapis/release-please/issues/1708) ([80b3d4f](https://github.com/googleapis/release-please/commit/80b3d4fce7d494575b4f136e68bad1c508600ea0))
* maven-workspace: SNAPSHOT versions should not be included in the manifest (https://github.com/googleapis/release-please/issues/1727) ([d926c84](https://github.com/googleapis/release-please/commit/d926c840ec99de013a0b5cb198f9fb2700930cf7))