### PR TITLE
deps: update release-please to 14.15.2

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/rest": "^19.0.4",
         "@octokit/webhooks": "^10.1.5",
         "gcf-utils": "^14.2.0",
-        "release-please": "^14.15.1"
+        "release-please": "^14.15.2"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
@@ -7661,9 +7661,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "14.15.1",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.15.1.tgz",
-      "integrity": "sha512-rh/M3o2kTnFpelnc2hcRxmazL0etPmjGeFCrLcWiUgt7m2rfd8+nKk/4KpbAmeNcVchu+dT+PB3odjs4dG2hiw==",
+      "version": "14.15.2",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.15.2.tgz",
+      "integrity": "sha512-oz/gi7SVIuO4g4AlWbyazxYsrtAL7Fbr6RGUt8IT6/kA/V06jBMaPou2+PPqFJitge7hC/zj+b0yBQ0rnOYJJA==",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^1.2.0",
@@ -15107,9 +15107,9 @@
       "dev": true
     },
     "release-please": {
-      "version": "14.15.1",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.15.1.tgz",
-      "integrity": "sha512-rh/M3o2kTnFpelnc2hcRxmazL0etPmjGeFCrLcWiUgt7m2rfd8+nKk/4KpbAmeNcVchu+dT+PB3odjs4dG2hiw==",
+      "version": "14.15.2",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-14.15.2.tgz",
+      "integrity": "sha512-oz/gi7SVIuO4g4AlWbyazxYsrtAL7Fbr6RGUt8IT6/kA/V06jBMaPou2+PPqFJitge7hC/zj+b0yBQ0rnOYJJA==",
       "requires": {
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^1.2.0",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -34,7 +34,7 @@
     "@octokit/rest": "^19.0.4",
     "@octokit/webhooks": "^10.1.5",
     "gcf-utils": "^14.2.0",
-    "release-please": "^14.15.1"
+    "release-please": "^14.15.2"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",


### PR DESCRIPTION
## Bug Fixes
* Allow overlapping paths when splitting commits (https://github.com/googleapis/release-please/issues/1733) ([adcb99a](https://github.com/googleapis/release-please/commit/adcb99acdbff9ddeea527b673bc8820edff68f2a))
* cargo-workspace: Update target dependencies in Cargo workspace packages (https://github.com/googleapis/release-please/issues/1730) ([3ca3bbc](https://github.com/googleapis/release-please/commit/3ca3bbcef729a359805473fdc798b5af5ab22861))

Fixes #4632
