### PR TITLE
feat: add option to ignore year in license header bot

### DIFF
--- a/packages/header-checker-lint/README.md
+++ b/packages/header-checker-lint/README.md
@@ -18,6 +18,7 @@ define a JSON object with the following options:
 | `allowedCopyrightHolders` | List of allowed copyright holders | `string[]` | `[]` |
 | `allowedLicenses` | The allowed licenses. | `string[]` | `["Apache-2.0", "MIT", "BSD-3"]` |
 | `ignoreFiles` | List of files to ignore. These values will be treated as path globs | `string[]` | `[]` |
+| `ignoreLicenseYear` | Ignore license header year check | `boolean` | `false` |
 | `sourceFileExtensions` | List of file extensions that will be treated as source files | `string[]` | `["ts", "js", "java"]` |
 
 Here is the default configuration:

--- a/packages/header-checker-lint/__snapshots__/header-checker-lint.js
+++ b/packages/header-checker-lint/__snapshots__/header-checker-lint.js
@@ -195,3 +195,14 @@ exports['HeaderCheckerLint opened pull request ignores due to the config from th
     "text": "Header check successful"
   }
 }
+
+exports['HeaderCheckerLint updated pull request sets a "success" context on PR, on wrong year with ignore flag set 1'] = {
+  "name": "header-check",
+  "conclusion": "success",
+  "head_sha": "87139750cdcf551e8fe8d90c129527a4f358321c",
+  "output": {
+    "title": "Headercheck",
+    "summary": "Header check successful",
+    "text": "Header check successful"
+  }
+}

--- a/packages/header-checker-lint/src/config-schema.json
+++ b/packages/header-checker-lint/src/config-schema.json
@@ -27,6 +27,10 @@
 		"type": "string"
 	    }
 	},
+	"ignoreLicenseYear": {
+	    "description": "A boolean specifying whether to ignore license header year checks",
+	    "type": "boolean"
+	},
 	"sourceFileExtensions": {
 	    "description": "A list of file extensions",
 	    "type": "array",

--- a/packages/header-checker-lint/src/config.ts
+++ b/packages/header-checker-lint/src/config.ts
@@ -18,6 +18,7 @@ export interface ConfigurationOptions {
   allowedCopyrightHolders: string[];
   allowedLicenses: LicenseType[];
   ignoreFiles: string[];
+  ignoreLicenseYear: boolean;
   sourceFileExtensions: string[];
 }
 

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -36,6 +36,7 @@ const DEFAULT_CONFIGURATION: ConfigurationOptions = {
   allowedCopyrightHolders: ['Google LLC'],
   allowedLicenses: ['Apache-2.0', 'MIT', 'BSD-3'],
   ignoreFiles: [],
+  ignoreLicenseYear: false,
   sourceFileExtensions: ['ts', 'js', 'java'],
 };
 
@@ -59,6 +60,10 @@ class Configuration {
     return this.minimatches.some(mm => {
       return mm.match(filename);
     });
+  }
+
+  ignoreLicenseYear(): boolean {
+    return this.options.ignoreLicenseYear;
   }
 
   allowedLicense(license: LicenseType): boolean {
@@ -204,12 +209,16 @@ export = (app: Probot) => {
 
             // for new files, ensure the license year is the current year for new
             // files
-            const currentYear = new Date().getFullYear();
-            if (detectedLicense.year !== currentYear) {
-              lintError = true;
-              failureMessages.push(
-                `\`${file.filename}\` should have a copyright year of ${currentYear}`
-              );
+            if (
+              !configuration.ignoreLicenseYear()
+            ) {
+              const currentYear = new Date().getFullYear();
+              if (detectedLicense.year !== currentYear) {
+                lintError = true;
+                failureMessages.push(
+                  `\`${file.filename}\` should have a copyright year of ${currentYear}`
+                );
+              }
             }
           }
         }

--- a/packages/header-checker-lint/src/header-checker-lint.ts
+++ b/packages/header-checker-lint/src/header-checker-lint.ts
@@ -209,9 +209,7 @@ export = (app: Probot) => {
 
             // for new files, ensure the license year is the current year for new
             // files
-            if (
-              !configuration.ignoreLicenseYear()
-            ) {
+            if (!configuration.ignoreLicenseYear()) {
               const currentYear = new Date().getFullYear();
               if (detectedLicense.year !== currentYear) {
                 lintError = true;


### PR DESCRIPTION
There are scenarios in which it is helpful to ignore the license year check, such as migrating code across repos. This PR introduces a new option `ignoreLicenseYear` to `header-checker-lint`. The default setting is `false`, so there are no changes to the current behavior.

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/repo-automation-bots/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)
