### PR TITLE
fix(owlbot-bootstrapper): get correct default branch for bootstrapper

### DIFF
--- a/packages/owlbot-bootstrapper/common-container/__snapshots__/utils.test.js
+++ b/packages/owlbot-bootstrapper/common-container/__snapshots__/utils.test.js
@@ -1,4 +1,4 @@
-exports['common utils tests opens a PR against the main branch 1'] = {
+exports['common utils tests opens a PR against the default branch 1'] = {
   head: 'specialName',
   base: 'main',
   title: 'feat: add initial files for google.cloud.kms.v1',

--- a/packages/owlbot-bootstrapper/common-container/fetch-api-info.ts
+++ b/packages/owlbot-bootstrapper/common-container/fetch-api-info.ts
@@ -22,7 +22,7 @@ import {
 import {logger} from 'gcf-utils';
 export const BUCKET = 'devrel-prod-settings';
 export const DRIFT_APIS_FILE = 'apis.json';
-
+export const GOOGLEAPIS_DEFAULT_BRANCH = 'master';
 /**
  * Function that gets api information from a public DRIFT bucket
  * @param apiId the unique API ID
@@ -93,7 +93,11 @@ async function getApiProtoInformation(
   let yamlFile;
   try {
     yamlFilePath = (
-      await repositoryFileCache.findFilesByGlob('*_v*.yaml', 'main', apiPath)
+      await repositoryFileCache.findFilesByGlob(
+        '**/*_v*.yaml',
+        GOOGLEAPIS_DEFAULT_BRANCH,
+        apiPath
+      )
     )[0];
   } catch (e) {
     if (e instanceof FileNotFoundError) {
@@ -108,7 +112,7 @@ async function getApiProtoInformation(
     if (yamlFilePath) {
       yamlFile = await repositoryFileCache.getFileContents(
         yamlFilePath,
-        'main'
+        GOOGLEAPIS_DEFAULT_BRANCH
       );
     } else {
       logger.warn('service_config.yaml path was not found');

--- a/packages/owlbot-bootstrapper/common-container/fetch-api-info.ts
+++ b/packages/owlbot-bootstrapper/common-container/fetch-api-info.ts
@@ -111,7 +111,7 @@ async function getApiProtoInformation(
   try {
     if (yamlFilePath) {
       yamlFile = await repositoryFileCache.getFileContents(
-        yamlFilePath,
+        `${apiPath}/${yamlFilePath}`,
         GOOGLEAPIS_DEFAULT_BRANCH
       );
     } else {

--- a/packages/owlbot-bootstrapper/common-container/pre-process.ts
+++ b/packages/owlbot-bootstrapper/common-container/pre-process.ts
@@ -28,6 +28,7 @@ import {loadApiFields} from './fetch-api-info';
 import {Storage} from '@google-cloud/storage';
 import {RepositoryFileCache} from '@google-automations/git-file-utils';
 
+const GOOGLEAPIS_REPO_NAME = 'googleapis';
 export async function preProcess(argv: CliArgs) {
   logger.info(`Entering pre-process for ${argv.apiId}/${argv.language}`);
 
@@ -68,7 +69,7 @@ export async function preProcess(argv: CliArgs) {
     const apiFields = await loadApiFields(
       argv.apiId,
       new Storage(),
-      new RepositoryFileCache(octokit, {owner: ORG, repo: 'googleapis'})
+      new RepositoryFileCache(octokit, {owner: ORG, repo: GOOGLEAPIS_REPO_NAME})
     );
 
     writeToWellKnownFile(apiFields, argv.serviceConfigPath);

--- a/packages/owlbot-bootstrapper/common-container/test/mono-repo.test.ts
+++ b/packages/owlbot-bootstrapper/common-container/test/mono-repo.test.ts
@@ -113,6 +113,8 @@ describe('MonoRepo class', async () => {
 
   it('opens a PR against the main branch', async () => {
     const scope = nock('https://api.github.com')
+      .get('/repos/googleapis/nodejs-kms')
+      .reply(200, {default_branch: 'main'})
       .post('/repos/googleapis/nodejs-kms/pulls')
       .reply(201);
 
@@ -217,6 +219,8 @@ describe('MonoRepo class', async () => {
     const scope = nock('https://api.github.com')
       .get('/repos/googleapis/googleapis-gen/commits')
       .reply(201, {sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e'})
+      .get(`/repos/googleapis/${FAKE_REPO_NAME}`)
+      .reply(200, {default_branch: 'main'})
       .post(`/repos/googleapis/${FAKE_REPO_NAME}/pulls`)
       .reply(201, {number: 1})
       .post(`/repos/googleapis/${FAKE_REPO_NAME}/issues/1/labels`)

--- a/packages/owlbot-bootstrapper/common-container/test/utils.test.ts
+++ b/packages/owlbot-bootstrapper/common-container/test/utils.test.ts
@@ -94,8 +94,10 @@ describe('common utils tests', async () => {
     );
   });
 
-  it('opens a PR against the main branch', async () => {
+  it('opens a PR against the default branch', async () => {
     const scope = nock('https://api.github.com')
+      .get('/repos/googleapis/nodejs-kms')
+      .reply(200, {default_branch: 'main'})
       .post('/repos/googleapis/nodejs-kms/pulls', body => {
         snapshot(body);
         return true;

--- a/packages/owlbot-bootstrapper/common-container/utils.ts
+++ b/packages/owlbot-bootstrapper/common-container/utils.ts
@@ -124,11 +124,13 @@ export async function openAPR(
   copyTagText: string
 ): Promise<number> {
   try {
+    const defaultBranch = (await getRepoMetadata(ORG, repoName, octokit))
+      .default_branch;
     const pr = await octokit.rest.pulls.create({
       owner: ORG,
       repo: repoName,
       head: branchName,
-      base: 'main',
+      base: defaultBranch,
       title: `feat: add initial files for ${apiId}`,
       body: await getPRText(latestSha, copyTagText),
     });
@@ -197,6 +199,14 @@ export async function openAnIssue(
     logger.error(err.toString().replace(tokenRedaction, ''));
     throw err;
   }
+}
+
+export async function getRepoMetadata(
+  owner: string,
+  repo: string,
+  octokit: Octokit
+) {
+  return (await octokit.rest.repos.get({owner, repo})).data;
 }
 
 /**


### PR DESCRIPTION
Fixes #4675 

We were looking for the service_config.yaml file in 'main', but it should have been 'master'.

I also added a function to get the default branch for when we're creating PRs, since we don't know what each library has as their default branch. I didn't do this for requests against googleapis/googleapis though, since it will always be a constant, and it would be wasteful to grab that default branch each time.
