### PR TITLE
fix: logger.child() should preserve original bindings

### DIFF
--- a/packages/gcf-utils/src/logging/gcf-logger.ts
+++ b/packages/gcf-utils/src/logging/gcf-logger.ts
@@ -173,7 +173,10 @@ export class GCFLogger {
    */
   public child(properties: object): GCFLogger {
     const child = new GCFLogger(this.destination);
-    child.addBindings(properties);
+    child.addBindings({
+      ...this.getBindings(),
+      ...properties,
+    });
     return child;
   }
 


### PR DESCRIPTION
When creating a child GCFLogger, also include the current bindings (context attributes).

Fixes #4439 
