### PR TITLE
chore(snippet-bot): upgrade gcf-utils to 14.4.0

### DIFF
--- a/packages/snippet-bot/package-lock.json
+++ b/packages/snippet-bot/package-lock.json
@@ -14,7 +14,7 @@
         "@google-automations/label-utils": "^3.0.0",
         "@google-cloud/storage": "^6.4.2",
         "follow-redirects": "^1.15.1",
-        "gcf-utils": "^14.2.0",
+        "gcf-utils": "^14.4.0",
         "lru-cache": "^7.14.0",
         "minimatch": "^5.1.0",
         "parse-diff": "^0.9.0",
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
-      "integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
+      "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -452,9 +452,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.6.12",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.12.tgz",
-      "integrity": "sha512-JmvQ03OTSpVd9JTlj/K3IWHSz4Gk/JMLUTtW7Zb0KvO1LcOYGATh5cNuRYzCAeDR3O8wq+q8FZe97eO9MBrkUw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
+      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -464,9 +464,9 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.2.tgz",
-      "integrity": "sha512-jCdyLIT/tdQ1zhrbTQnJNK5nbDf0GoBpy5jVNywBzzMDF+Vs6uEaHnfz46dMtDxkvwrF2hzk5Z67goliceH0sA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.3.tgz",
+      "integrity": "sha512-5dAvoZwna2Py3Ef96Ux9jIkp3iZ62TUsV00p3wVBPNX5K178UbNi8Q7gQVqwXT1Yq9RejIGG9G2IPEo93T6RcA==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -883,15 +883,28 @@
       "integrity": "sha512-4EuKSk3N95UBWFau3Bz9b3pheQ8jQYbKmBL5+GSuY8YDPDwu03J4BjI+66yNi8aaX/3h1qDpb0mbBkLdr+cfGQ=="
     },
     "node_modules/@octokit/plugin-enterprise-compatibility": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-2.0.2.tgz",
-      "integrity": "sha512-SnQXvVqFu/y1DWb3cHVvy/pcXKTFgfhpPSgF29AcxBPhISAADkfylrtOz+Mm1iUmZsxf5sBwsREojP83uNWivA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-2.0.3.tgz",
+      "integrity": "sha512-RWe46TqOFJCJZw0Cqp/CD/vPSSF3bR0u79+KVFJzGOwx7hDvKhlTvyA+am0tGmJxkOvMwPCvi+reS3vewoZSDg==",
       "dependencies": {
         "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^7.0.0"
+        "@octokit/types": "^8.0.0"
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/plugin-enterprise-compatibility/node_modules/@octokit/openapi-types": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
+      "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
+    },
+    "node_modules/@octokit/plugin-enterprise-compatibility/node_modules/@octokit/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^14.0.0"
       }
     },
     "node_modules/@octokit/plugin-paginate-rest": {
@@ -4043,9 +4056,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
-      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.4.0.tgz",
+      "integrity": "sha512-pO5HNYY3PX6u66K8dX7ANPswWRiOUxpn14KyOj3on/xzdaN51hED2o42pIhQ5ITExpwKJ4u+XKqe3qoK8JnBEQ==",
       "dependencies": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",
@@ -4053,7 +4066,7 @@
         "@google-cloud/storage": "^6.4.1",
         "@google-cloud/tasks": "^3.0.2",
         "@octokit/auth-app": "^4.0.5",
-        "@octokit/plugin-enterprise-compatibility": "2.0.2",
+        "@octokit/plugin-enterprise-compatibility": "2.0.3",
         "@octokit/rest": "^19.0.4",
         "@probot/octokit-plugin-config": "^1.1.6",
         "@types/bunyan": "^1.8.8",
@@ -4069,7 +4082,7 @@
         "express": "^4.18.1",
         "gaxios": "^5.0.1",
         "get-stream": "^6.0.1",
-        "google-gax": "^3.3.1",
+        "google-gax": "^3.5.2",
         "into-stream": "^6.0.0",
         "octokit-auth-probot": "^1.2.8",
         "pino": "^8.4.2",
@@ -4279,11 +4292,11 @@
       }
     },
     "node_modules/google-gax": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.4.0.tgz",
-      "integrity": "sha512-BUum48Sc84kfvkmJx2R0+EBRM+bbjXk8Ckhn5reSNdjgeAbDPcOXyNcewmL/gIHPvuzqEW3fEjnTc0x/l3hdRw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.5.2.tgz",
+      "integrity": "sha512-AyP53w0gHcWlzxm+jSgqCR3Xu4Ld7EpSjhtNBnNhzwwWaIUyphH9kBGNIEH+i4UGkTUXOY29K/Re8EiAvkBRGw==",
       "dependencies": {
-        "@grpc/grpc-js": "~1.6.0",
+        "@grpc/grpc-js": "~1.7.0",
         "@grpc/proto-loader": "^0.7.0",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
@@ -4294,12 +4307,13 @@
         "node-fetch": "^2.6.1",
         "object-hash": "^3.0.0",
         "proto3-json-serializer": "^1.0.0",
-        "protobufjs": "7.1.0",
-        "protobufjs-cli": "1.0.1",
+        "protobufjs": "7.1.2",
+        "protobufjs-cli": "1.0.2",
         "retry-request": "^5.0.0"
       },
       "bin": {
-        "compileProtos": "build/tools/compileProtos.js"
+        "compileProtos": "build/tools/compileProtos.js",
+        "minifyProtoJson": "build/tools/minify.js"
       },
       "engines": {
         "node": ">=12"
@@ -5431,18 +5445,18 @@
       }
     },
     "node_modules/markdown-it-anchor": {
-      "version": "8.6.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz",
-      "integrity": "sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
+      "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
       "peerDependencies": {
         "@types/markdown-it": "*",
         "markdown-it": "*"
       }
     },
     "node_modules/marked": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
-      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.3.tgz",
+      "integrity": "sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -6844,9 +6858,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.0.tgz",
-      "integrity": "sha512-rCuxKlh0UQKSMjrpIcTLbR5TtGQ52cgs1a5nUoPBAKOccdPblN67BJtjrbtudUJK6HmBvUdsmymyYOzO7lxZEA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -6867,9 +6881,9 @@
       }
     },
     "node_modules/protobufjs-cli": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.0.1.tgz",
-      "integrity": "sha512-d7m/aaXimDTaVvvPdU0HFwzieKJqo3x+z6iVly79jqLFyg5EmY9tl3vGbBqdytcOzT/acriOhOtB4xj3Kqixmw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.0.2.tgz",
+      "integrity": "sha512-cz9Pq9p/Zs7okc6avH20W7QuyjTclwJPgqXG11jNaulfS3nbVisID8rC+prfgq0gbZE0w9LBFd1OKFF03kgFzg==",
       "dependencies": {
         "chalk": "^4.0.0",
         "escodegen": "^1.13.0",
@@ -7287,11 +7301,11 @@
       }
     },
     "node_modules/requizzle": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
       "dependencies": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/resolve": {
@@ -8314,9 +8328,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/universal-github-app-jwt": {
       "version": "1.1.0",
@@ -8771,9 +8785,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
-      "integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw=="
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
+      "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA=="
     },
     "@bahmutov/data-driven": {
       "version": "1.0.0",
@@ -9001,18 +9015,18 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.6.12",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.12.tgz",
-      "integrity": "sha512-JmvQ03OTSpVd9JTlj/K3IWHSz4Gk/JMLUTtW7Zb0KvO1LcOYGATh5cNuRYzCAeDR3O8wq+q8FZe97eO9MBrkUw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
+      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.2.tgz",
-      "integrity": "sha512-jCdyLIT/tdQ1zhrbTQnJNK5nbDf0GoBpy5jVNywBzzMDF+Vs6uEaHnfz46dMtDxkvwrF2hzk5Z67goliceH0sA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.3.tgz",
+      "integrity": "sha512-5dAvoZwna2Py3Ef96Ux9jIkp3iZ62TUsV00p3wVBPNX5K178UbNi8Q7gQVqwXT1Yq9RejIGG9G2IPEo93T6RcA==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -9359,12 +9373,27 @@
       "integrity": "sha512-4EuKSk3N95UBWFau3Bz9b3pheQ8jQYbKmBL5+GSuY8YDPDwu03J4BjI+66yNi8aaX/3h1qDpb0mbBkLdr+cfGQ=="
     },
     "@octokit/plugin-enterprise-compatibility": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-2.0.2.tgz",
-      "integrity": "sha512-SnQXvVqFu/y1DWb3cHVvy/pcXKTFgfhpPSgF29AcxBPhISAADkfylrtOz+Mm1iUmZsxf5sBwsREojP83uNWivA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-2.0.3.tgz",
+      "integrity": "sha512-RWe46TqOFJCJZw0Cqp/CD/vPSSF3bR0u79+KVFJzGOwx7hDvKhlTvyA+am0tGmJxkOvMwPCvi+reS3vewoZSDg==",
       "requires": {
         "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^7.0.0"
+        "@octokit/types": "^8.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
+          "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
+        },
+        "@octokit/types": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
+          "integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
+          "requires": {
+            "@octokit/openapi-types": "^14.0.0"
+          }
+        }
       }
     },
     "@octokit/plugin-paginate-rest": {
@@ -11825,9 +11854,9 @@
       }
     },
     "gcf-utils": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.2.0.tgz",
-      "integrity": "sha512-0R1cHp9XaNnnIAW1iHhNeZGt9QxCB++rjq8gyPwbhZP4g25k5g/lHimNUVjIbEcFCKVLpWSLqBvHukmqL8K5mA==",
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-14.4.0.tgz",
+      "integrity": "sha512-pO5HNYY3PX6u66K8dX7ANPswWRiOUxpn14KyOj3on/xzdaN51hED2o42pIhQ5ITExpwKJ4u+XKqe3qoK8JnBEQ==",
       "requires": {
         "@google-cloud/kms": "^3.0.1",
         "@google-cloud/run": "^0.2.2",
@@ -11835,7 +11864,7 @@
         "@google-cloud/storage": "^6.4.1",
         "@google-cloud/tasks": "^3.0.2",
         "@octokit/auth-app": "^4.0.5",
-        "@octokit/plugin-enterprise-compatibility": "2.0.2",
+        "@octokit/plugin-enterprise-compatibility": "2.0.3",
         "@octokit/rest": "^19.0.4",
         "@probot/octokit-plugin-config": "^1.1.6",
         "@types/bunyan": "^1.8.8",
@@ -11851,7 +11880,7 @@
         "express": "^4.18.1",
         "gaxios": "^5.0.1",
         "get-stream": "^6.0.1",
-        "google-gax": "^3.3.1",
+        "google-gax": "^3.5.2",
         "into-stream": "^6.0.0",
         "octokit-auth-probot": "^1.2.8",
         "pino": "^8.4.2",
@@ -12007,11 +12036,11 @@
       }
     },
     "google-gax": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.4.0.tgz",
-      "integrity": "sha512-BUum48Sc84kfvkmJx2R0+EBRM+bbjXk8Ckhn5reSNdjgeAbDPcOXyNcewmL/gIHPvuzqEW3fEjnTc0x/l3hdRw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.5.2.tgz",
+      "integrity": "sha512-AyP53w0gHcWlzxm+jSgqCR3Xu4Ld7EpSjhtNBnNhzwwWaIUyphH9kBGNIEH+i4UGkTUXOY29K/Re8EiAvkBRGw==",
       "requires": {
-        "@grpc/grpc-js": "~1.6.0",
+        "@grpc/grpc-js": "~1.7.0",
         "@grpc/proto-loader": "^0.7.0",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
@@ -12022,8 +12051,8 @@
         "node-fetch": "^2.6.1",
         "object-hash": "^3.0.0",
         "proto3-json-serializer": "^1.0.0",
-        "protobufjs": "7.1.0",
-        "protobufjs-cli": "1.0.1",
+        "protobufjs": "7.1.2",
+        "protobufjs-cli": "1.0.2",
         "retry-request": "^5.0.0"
       }
     },
@@ -12890,15 +12919,15 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "8.6.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz",
-      "integrity": "sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
+      "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
       "requires": {}
     },
     "marked": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
-      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.3.tgz",
+      "integrity": "sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw=="
     },
     "mdurl": {
       "version": "1.0.1",
@@ -14031,9 +14060,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.0.tgz",
-      "integrity": "sha512-rCuxKlh0UQKSMjrpIcTLbR5TtGQ52cgs1a5nUoPBAKOccdPblN67BJtjrbtudUJK6HmBvUdsmymyYOzO7lxZEA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -14057,9 +14086,9 @@
       }
     },
     "protobufjs-cli": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.0.1.tgz",
-      "integrity": "sha512-d7m/aaXimDTaVvvPdU0HFwzieKJqo3x+z6iVly79jqLFyg5EmY9tl3vGbBqdytcOzT/acriOhOtB4xj3Kqixmw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.0.2.tgz",
+      "integrity": "sha512-cz9Pq9p/Zs7okc6avH20W7QuyjTclwJPgqXG11jNaulfS3nbVisID8rC+prfgq0gbZE0w9LBFd1OKFF03kgFzg==",
       "requires": {
         "chalk": "^4.0.0",
         "escodegen": "^1.13.0",
@@ -14358,11 +14387,11 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "requizzle": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.21"
       }
     },
     "resolve": {
@@ -15138,9 +15167,9 @@
       "integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg=="
     },
     "underscore": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "universal-github-app-jwt": {
       "version": "1.1.0",

--- a/packages/snippet-bot/package.json
+++ b/packages/snippet-bot/package.json
@@ -34,7 +34,7 @@
     "@google-automations/label-utils": "^3.0.0",
     "@google-cloud/storage": "^6.4.2",
     "follow-redirects": "^1.15.1",
-    "gcf-utils": "^14.2.0",
+    "gcf-utils": "^14.4.0",
     "lru-cache": "^7.14.0",
     "minimatch": "^5.1.0",
     "parse-diff": "^0.9.0",


### PR DESCRIPTION
gcf-utils 14.4.0 starts to upload smaller payloads directly to Cloud Task.

Related: #4480

Let's monitor snippet-bot's behavior for a while and if it works ok, maybe we can wait for rennovate to update other bots.