### PR TITLE
feat(ccl): introduce `always_check_pr_title` config

### DIFF
--- a/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
+++ b/packages/conventional-commit-lint/__snapshots__/conventional-commit-lint.js
@@ -33,7 +33,7 @@ exports['ConventionalCommitLint PR With Multiple Commits has an invalid pull req
   "name": "conventionalcommits.org",
   "output": {
     "title": "Commit message did not follow Conventional Commits",
-    "summary": "Some of your commit messages failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nedit your pull request title to match Conventional Commit guidelines.",
+    "summary": "The PR title failed linting.\n\nVisit [conventionalcommits.org](https://conventionalcommits.org) to learn our conventions.\n\nedit your pull request title to match Conventional Commit guidelines.",
     "text": ":x: The following linting errors found:\n* subject may not be empty\n* type may not be empty\nfor the following input:\n\"*this is not a conventional commit*\"\n\n"
   }
 }

--- a/packages/conventional-commit-lint/src/conventional-commit-lint.ts
+++ b/packages/conventional-commit-lint/src/conventional-commit-lint.ts
@@ -31,6 +31,7 @@ import {scanPullRequest} from './utils';
 const CONFIGURATION_FILE = 'conventional-commit-lint.yaml';
 interface Configuration {
   enabled?: boolean;
+  always_check_pr_title?: boolean;
 }
 
 export = (app: Probot) => {
@@ -126,7 +127,8 @@ export = (app: Probot) => {
         context,
         context.payload.pull_request as PullRequest,
         logger,
-        octokit
+        octokit,
+        config?.always_check_pr_title
       );
     }
   );

--- a/packages/conventional-commit-lint/src/schema.json
+++ b/packages/conventional-commit-lint/src/schema.json
@@ -8,6 +8,10 @@
     "enabled": {
       "description": "Should the Conventional Commit Lint bot be enabled.",
       "type": "boolean"
+    },
+    "always_check_pr_title": {
+      "description": "If set to true, the bot will use the PR title",
+      "type": "boolean"
     }
   }
 }

--- a/packages/conventional-commit-lint/test/fixtures/config/always_check_pr_title.yaml
+++ b/packages/conventional-commit-lint/test/fixtures/config/always_check_pr_title.yaml
@@ -1,0 +1,2 @@
+enabled: true
+always_check_pr_title: true


### PR DESCRIPTION
When set to true, the bot will always use PR title for checking against conventional commit spec.

This new config defaults to false.

fixes #4769