### PR TITLE
fix(auto-approve): rethrow original request error

### DIFF
--- a/packages/auto-approve/src/get-pr-info.ts
+++ b/packages/auto-approve/src/get-pr-info.ts
@@ -55,9 +55,8 @@ export async function getChangedFiles(
       );
       return undefined;
     }
-    throw new Error(
-      `${err.status}, ${err.message} for ${owner}/${repo}/${prNumber}`
-    );
+    // rethrow original error with context
+    throw e;
   }
 }
 /**


### PR DESCRIPTION
There's no point in throwing a new Error with less context than the original error.

Fixes #4479
