### PR TITLE
feat: flag controls the maximum # of APIs to combine in one PR

### DIFF
--- a/packages/owl-bot/src/bin/commands/copy-code-and-create-pull-request.ts
+++ b/packages/owl-bot/src/bin/commands/copy-code-and-create-pull-request.ts
@@ -27,6 +27,7 @@ interface Args extends OctokitParams {
   'dest-repo': string;
   'dest-owlbot-yaml': string;
   'use-nested-commit-delimiters': boolean;
+  'max-yaml-count-per-pull-request': number;
 }
 
 export const copyCodeAndCreatePullRequestCommand: yargs.CommandModule<
@@ -83,6 +84,13 @@ export const copyCodeAndCreatePullRequestCommand: yargs.CommandModule<
         type: 'boolean',
         default: true,
         demand: false,
+      })
+      .option('max-yaml-count-per-pull-request', {
+        describe:
+          'maximum number of yamls (APIs) to combine in a single pull request',
+        type: 'number',
+        default: Number.MAX_SAFE_INTEGER,
+        demand: false,
       });
   },
   async handler(argv) {
@@ -95,6 +103,7 @@ export const copyCodeAndCreatePullRequestCommand: yargs.CommandModule<
       // and it shouldn't interfere with Owl Bot state.
       copyStateStore: new FakeCopyStateStore(),
       octokitFactory,
+      maxYamlCountPerPullRequest: argv['max-yaml-count-per-pull-request'],
     };
     await cc.copyCodeAndAppendOrCreatePullRequest(
       params,

--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -403,6 +403,8 @@ export interface CopyParams {
   /** where to record pull requests appended by this function */
   copyStateStore: CopyStateStore;
   octokitFactory: OctokitFactory;
+  /** maximum number of yamls (APIs) to combine in a single pull request */
+  maxYamlCountPerPullRequest: number;
 }
 
 interface WorkingCopyParams extends CopyParams {
@@ -445,8 +447,7 @@ export async function copyCodeAndAppendOrCreatePullRequest(
     .toString('utf-8')
     .trim();
 
-  // Examine all the yaml paths, looking for pull requests that are already
-  // open.
+  // Examine each yaml path, looking for an open pull request to append.
   const leftOvers: string[] = [];
   const wparams: WorkingCopyParams = {...params, destDir, workDir};
   for (const yamlPath of yamlPaths) {
@@ -464,6 +465,8 @@ export async function copyCodeAndAppendOrCreatePullRequest(
   if (leftOvers.length === 0) {
     return; // Nothing more to do.
   }
+  // Look for a single, open pull request with the same set of yaml paths.
+  // Append it.
   if (isDeepStrictEqual(yamlPaths, leftOvers)) {
     // Don't repeat exactly the same search
   } else {
@@ -480,26 +483,35 @@ export async function copyCodeAndAppendOrCreatePullRequest(
   }
 
   //////////////////////////////////////////////////////////////////
-  // Appended all the pull requests we could.  Create a pull request
+  // Appended all the pull requests we could.  Create pull requests
   // for the remaining yamls.
 
-  if (leftOvers.length === 0) {
-    return;
-  }
-  const destBranch = branchNameForCopies(leftOvers);
-  cmd(`git checkout ${defaultBranch}`, {cwd: destDir});
-  cmd(`git checkout -b ${destBranch}`, {cwd: destDir});
+  leftOvers.sort(); // To make the batches more predictable for humans.
+  for (
+    let i = 0;
+    i < leftOvers.length;
+    i += params.maxYamlCountPerPullRequest
+  ) {
+    // Split the left overs into batches no larger than maxYamlCount APIs.
+    const leftOverBatch = leftOvers.slice(
+      i,
+      i + params.maxYamlCountPerPullRequest
+    );
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const reportError = async (e: any, yamlPath: string) => {
-    console.error(`Error parsing ${yamlPath}: ${e}`);
-    const sourceLink = sourceLinkFrom(params.sourceRepoCommitHash);
-    const octokit = await params.octokitFactory.getShortLivedOctokit();
-    const issue = await octokit.issues.create({
-      owner: params.destRepo.owner,
-      repo: params.destRepo.repo,
-      title: `${yamlPath} is missing or defective`,
-      body: `While attempting to copy files from
+    const destBranch = branchNameForCopies(leftOverBatch);
+    cmd(`git checkout ${defaultBranch}`, {cwd: destDir});
+    cmd(`git checkout -b ${destBranch}`, {cwd: destDir});
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const reportError = async (e: any, yamlPath: string) => {
+      console.error(`Error parsing ${yamlPath}: ${e}`);
+      const sourceLink = sourceLinkFrom(params.sourceRepoCommitHash);
+      const octokit = await params.octokitFactory.getShortLivedOctokit();
+      const issue = await octokit.issues.create({
+        owner: params.destRepo.owner,
+        repo: params.destRepo.repo,
+        title: `${yamlPath} is missing or defective`,
+        body: `While attempting to copy files from
 ${sourceLink}
 
 After fixing ${yamlPath}, re-attempt this copy by running the following
@@ -508,54 +520,57 @@ command in a local clone of this repo:
   docker run -v /repo:$(pwd) -w /repo gcr.io/repo-automation-bots/owl-bot -- copy-code \
     --source-repo-commit-hash ${params.sourceRepoCommitHash}
 \`\`\``,
-    });
-    const copyTag = copyTagFrom(yamlPath, params.sourceRepoCommitHash);
-    console.log(`Created issue ${issue.data.html_url}`);
-    await params.copyStateStore.recordBuildForCopy(
-      params.destRepo,
-      copyTag,
-      issue.data.html_url
+      });
+      const copyTag = copyTagFrom(yamlPath, params.sourceRepoCommitHash);
+      console.log(`Created issue ${issue.data.html_url}`);
+      await params.copyStateStore.recordBuildForCopy(
+        params.destRepo,
+        copyTag,
+        issue.data.html_url
+      );
+    };
+
+    // Copy the code from googleapis-gen.
+    const copiedYamls = await copyCodeIntoCommit(
+      wparams,
+      leftOverBatch,
+      reportError,
+      logger
     );
-  };
 
-  // Copy the code from googleapis-gen.
-  const copiedYamls = await copyCodeIntoCommit(
-    wparams,
-    leftOvers,
-    reportError,
-    logger
-  );
+    if (copiedYamls.length === 0) {
+      continue; // Nothing was copied; don't create a pull request.
+    }
 
-  if (copiedYamls.length === 0) {
-    return; // Nothing was copied; don't create a pull request.
-  }
-
-  // Create a pull request.
-  const apiNames = copiedYamls.map(tag => tag.yaml['api-name']).filter(Boolean);
-  const apiList = abbreviateApiListForTitle(apiNames as string[]);
-  const token = await params.octokitFactory.getGitHubShortLivedAccessToken();
-  const pushUrl = params.destRepo.getCloneUrl(token);
-  const pull = await createPullRequestFromLastCommit(
-    params.destRepo.owner,
-    params.destRepo.repo,
-    destDir,
-    destBranch,
-    pushUrl,
-    [OWL_BOT_COPY],
-    await params.octokitFactory.getShortLivedOctokit(token),
-    WithRegenerateCheckbox.Yes,
-    apiList,
-    Force.Yes,
-    logger
-  );
-
-  // Record that we've copied the code.
-  for (const yaml of copiedYamls) {
-    await params.copyStateStore.recordBuildForCopy(
-      params.destRepo,
-      yaml.copyTag,
-      pull
+    // Create a pull request.
+    const apiNames = copiedYamls
+      .map(tag => tag.yaml['api-name'])
+      .filter(Boolean);
+    const apiList = abbreviateApiListForTitle(apiNames as string[]);
+    const token = await params.octokitFactory.getGitHubShortLivedAccessToken();
+    const pushUrl = params.destRepo.getCloneUrl(token);
+    const pull = await createPullRequestFromLastCommit(
+      params.destRepo.owner,
+      params.destRepo.repo,
+      destDir,
+      destBranch,
+      pushUrl,
+      [OWL_BOT_COPY],
+      await params.octokitFactory.getShortLivedOctokit(token),
+      WithRegenerateCheckbox.Yes,
+      apiList,
+      Force.Yes,
+      logger
     );
+
+    // Record that we've copied the code.
+    for (const yaml of copiedYamls) {
+      await params.copyStateStore.recordBuildForCopy(
+        params.destRepo,
+        yaml.copyTag,
+        pull
+      );
+    }
   }
 }
 

--- a/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
@@ -72,6 +72,8 @@ function isCommitHashTooOld(
  * @param combinePullsThreshold when the number of APIs (.OwlBot.yamls) affected
  *    by a single commit to googleapis-gen exceeds this threshold, combine
  *    the all the changes into a single pull request.
+ * @param maxYamlCountPerPullRequest maximum number of yamls (APIs) to combine
+ *    in a single pull request.
  */
 export async function scanGoogleapisGenAndCreatePullRequests(
   sourceRepo: string,
@@ -81,7 +83,8 @@ export async function scanGoogleapisGenAndCreatePullRequests(
   copyStateStore: CopyStateStore,
   combinePullsThreshold = Number.MAX_SAFE_INTEGER,
   logger: Logger = console,
-  withNestedCommitDelimiters: WithNestedCommitDelimiters = WithNestedCommitDelimiters.No
+  withNestedCommitDelimiters: WithNestedCommitDelimiters = WithNestedCommitDelimiters.No,
+  maxYamlCountPerPullRequest: number = Number.MAX_SAFE_INTEGER
 ): Promise<number> {
   logger = new LoggerWithTimestamp(logger);
   // Clone the source repo.
@@ -185,6 +188,7 @@ export async function scanGoogleapisGenAndCreatePullRequests(
       destRepo: todo.repo,
       copyStateStore,
       octokitFactory,
+      maxYamlCountPerPullRequest,
     };
     await copyCodeAndAppendOrCreatePullRequest(
       params,


### PR DESCRIPTION
The flag is initially set to infinity to preserve existing behavoir. After the code bakes for a few days, we'll set the flag to 20.

Step 1 of 2 towards fixing
https://github.com/googleapis/repo-automation-bots/issues/4763
