### PR TITLE
feat: detect MergeConflict errors and comment on PR on failure

### DIFF
--- a/packages/cherry-pick-bot/__snapshots__/cherry-pick.js
+++ b/packages/cherry-pick-bot/__snapshots__/cherry-pick.js
@@ -91,3 +91,41 @@ exports['cherryPickAsPullRequest opens a pull request with title preserved 2'] =
     title: 'title from original PR (cherry-pick #1234)',
     body: '\n\nCherry-picked commit message for abc123',
   };
+
+exports[
+  'cherryPickCommits should throw a MergeConflictError if there is a conflict 1'
+] = {
+  ref: 'refs/heads/temp-target-branch',
+  sha: 'devbranchsha',
+};
+
+exports[
+  'cherryPickCommits should throw a MergeConflictError if there is a conflict 2'
+] = {
+  author: {
+    name: 'author-name',
+    email: 'author@email.com',
+  },
+  committer: {
+    name: 'committer-name',
+    email: 'committer@email.com',
+  },
+  message: 'sibling of abc123',
+  parents: ['parentsha'],
+  tree: 'treesha',
+};
+
+exports[
+  'cherryPickCommits should throw a MergeConflictError if there is a conflict 3'
+] = {
+  force: true,
+  sha: 'newcommitsha',
+};
+
+exports[
+  'cherryPickCommits should throw a MergeConflictError if there is a conflict 4'
+] = {
+  base: 'temp-target-branch',
+  commit_message: 'Merge abc123 into temp-target-branch',
+  head: 'abc123',
+};

--- a/packages/cherry-pick-bot/src/cherry-pick.ts
+++ b/packages/cherry-pick-bot/src/cherry-pick.ts
@@ -222,19 +222,13 @@ export async function cherryPickCommits(
 
     // merge
     logger.debug(`merge ${sha} into ${temporaryRefName}`);
-    const {
-      data: {
-        commit: {
-          tree: {sha: mergedTree},
-        },
-      },
-    } = await octokit.repos.merge({
-      base: temporaryRefName,
-      commit_message: `Merge ${sha} into ${temporaryRefName}`,
-      head: sha,
+    const mergedTree = await mergeBranch(
+      octokit,
       owner,
       repo,
-    });
+      temporaryRefName,
+      sha
+    );
     logger.debug('creating commit with different tree');
     const newHeadSha = await createCommit(
       octokit,
@@ -273,6 +267,56 @@ export async function cherryPickCommits(
   });
 
   return newCommits;
+}
+
+/**
+ * Attempt to merge the provided SHA into the provided base branch.
+ *
+ * @param {OctokitType} octokit An authenticated Octokit instance
+ * @param {string} owner The repository owner
+ * @param {string} repo The repository name
+ * @param {string} baseBranchName The target branch
+ * @param {string} sha The SHA to merge into the base branch
+ * @throws {MergeConflictError} if there is a merge conflict
+ */
+export class MergeConflictError extends Error {
+  cause: Error;
+  constructor(baseBranchName: string, sha: string, cause: Error) {
+    super(`Merge error ${sha} into ${baseBranchName}`);
+    this.cause = cause;
+  }
+}
+
+async function mergeBranch(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  baseBranchName: string,
+  sha: string
+): Promise<string> {
+  try {
+    const {
+      data: {
+        commit: {
+          tree: {sha: mergedTree},
+        },
+      },
+    } = await octokit.repos.merge({
+      base: baseBranchName,
+      commit_message: `Merge ${sha} into ${baseBranchName}`,
+      head: sha,
+      owner,
+      repo,
+    });
+    return mergedTree;
+  } catch (e) {
+    if (e instanceof RequestError) {
+      if (e.status === 409) {
+        throw new MergeConflictError(baseBranchName, sha, e);
+      }
+    }
+    throw e;
+  }
 }
 
 /**

--- a/packages/cherry-pick-bot/test/cherry-pick.ts
+++ b/packages/cherry-pick-bot/test/cherry-pick.ts
@@ -21,6 +21,7 @@ import {
   parseCherryPickComment,
   cherryPickAsPullRequest,
   cherryPickCommits,
+  MergeConflictError,
 } from '../src/cherry-pick';
 import * as CherryPickModule from '../src/cherry-pick';
 import sinon from 'sinon';
@@ -130,6 +131,60 @@ describe('cherryPickCommits', () => {
     assert.strictEqual(newCommits.length, 1);
     assert.strictEqual(newCommits[0].message, 'commit message for abc123');
     assert.strictEqual(newCommits[0].sha, 'newcommitsha2');
+    req.done();
+  });
+
+  it('should throw a MergeConflictError if there is a conflict', async () => {
+    const req = nock('https://api.github.com')
+      .get('/repos/testOwner/testRepo/git/ref/heads%2Ftarget-branch')
+      .reply(200, {object: {sha: 'devbranchsha'}})
+      .post('/repos/testOwner/testRepo/git/refs', body => {
+        snapshot(body);
+        return true;
+      })
+      .reply(200)
+      .get('/repos/testOwner/testRepo/git/commits/devbranchsha')
+      .reply(200, {
+        tree: {
+          sha: 'treesha',
+        },
+      })
+      .get('/repos/testOwner/testRepo/git/commits/abc123')
+      .reply(200, {
+        message: 'commit message for abc123',
+        author: {name: 'author-name', email: 'author@email.com'},
+        committer: {name: 'committer-name', email: 'committer@email.com'},
+        parents: [{sha: 'parentsha'}],
+      })
+      .post('/repos/testOwner/testRepo/git/commits', body => {
+        snapshot(body);
+        return true;
+      })
+      .reply(200, {sha: 'newcommitsha'})
+      .patch(
+        '/repos/testOwner/testRepo/git/refs/heads%2Ftemp-target-branch',
+        body => {
+          snapshot(body);
+          return true;
+        }
+      )
+      .reply(200)
+      .post('/repos/testOwner/testRepo/merges', body => {
+        snapshot(body);
+        return true;
+      })
+      .reply(409, {message: 'Merge Conflict'});
+
+    const commits = ['abc123'];
+    await assert.rejects(async () => {
+      await cherryPickCommits(
+        octokit,
+        'testOwner',
+        'testRepo',
+        commits,
+        'target-branch'
+      );
+    }, MergeConflictError);
     req.done();
   });
 });


### PR DESCRIPTION
The cherry-pick logic will throw a new `MergeConflictError` if we receive a 409 response when attempting to merge branches. The bot catches this error and will comment on the PR being cherry-picked.

Fixes #4501
Fixes #4507
