### PR TITLE
fix: lock the version of typescript to 4.8.4

### DIFF
--- a/packages/gcf-utils/package-lock.json
+++ b/packages/gcf-utils/package-lock.json
@@ -63,7 +63,7 @@
         "snap-shot-it": "^7.9.6",
         "sonic-boom": "^3.2.0",
         "stream-mock": "^2.0.5",
-        "typescript": "~4.8.2"
+        "typescript": "4.8.4"
       },
       "engines": {
         "node": ">= 14"
@@ -7966,9 +7966,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -14533,9 +14533,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "uc.micro": {

--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -70,7 +70,7 @@
     "snap-shot-it": "^7.9.6",
     "sonic-boom": "^3.2.0",
     "stream-mock": "^2.0.5",
-    "typescript": "~4.8.2"
+    "typescript": "4.8.2"
   },
   "engines": {
     "node": ">= 14"

--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -70,7 +70,7 @@
     "snap-shot-it": "^7.9.6",
     "sonic-boom": "^3.2.0",
     "stream-mock": "^2.0.5",
-    "typescript": "4.8.2"
+    "typescript": "4.8.4"
   },
   "engines": {
     "node": ">= 14"


### PR DESCRIPTION
See https://github.com/googleapis/repo-automation-bots/pull/4799

4.9 chokes on a dependency.

```
node_modules/@types/node/globals.d.ts:72:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'AbortSignal' must be of type '{ new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds: number): AbortSignal; }', but here has type '{ new (): AbortSignal; prototype: AbortSignal; }'.

72 declare var AbortSignal: {
               ~~~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:2071:13
    2071 declare var AbortSignal: {
                     ~~~~~~~~~~~
    'AbortSignal' was also declared here.

Found 1 error in node_modules/@types/node/globals.d.ts:72
```
