### PR TITLE
fix: pin typescript to 4.8.4 for four more bots

### DIFF
--- a/packages/bot-config-utils/package-lock.json
+++ b/packages/bot-config-utils/package-lock.json
@@ -28,7 +28,7 @@
         "nock": "^13.2.9",
         "sinon": "^15.0.0",
         "snap-shot-it": "^7.9.6",
-        "typescript": "~4.8.2"
+        "typescript": "^4.8.4"
       },
       "engines": {
         "node": ">= 14"
@@ -7919,9 +7919,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -14531,9 +14531,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "uc.micro": {

--- a/packages/bot-config-utils/package.json
+++ b/packages/bot-config-utils/package.json
@@ -36,7 +36,7 @@
     "nock": "^13.2.9",
     "sinon": "^15.0.0",
     "snap-shot-it": "^7.9.6",
-    "typescript": "~4.8.2"
+    "typescript": "4.8.4"
   },
   "engines": {
     "node": ">= 14"

--- a/packages/cron-utils/package-lock.json
+++ b/packages/cron-utils/package-lock.json
@@ -33,7 +33,7 @@
         "nock": "^13.2.9",
         "sinon": "^15.0.0",
         "snap-shot-it": "^7.9.6",
-        "typescript": "~4.8.2"
+        "typescript": "^4.8.4"
       },
       "engines": {
         "node": ">= 14"
@@ -4910,9 +4910,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8894,9 +8894,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "uc.micro": {

--- a/packages/cron-utils/package.json
+++ b/packages/cron-utils/package.json
@@ -38,7 +38,7 @@
     "nock": "^13.2.9",
     "sinon": "^15.0.0",
     "snap-shot-it": "^7.9.6",
-    "typescript": "~4.8.2"
+    "typescript": "4.8.4"
   },
   "engines": {
     "node": ">= 14"

--- a/packages/datastore-lock/package-lock.json
+++ b/packages/datastore-lock/package-lock.json
@@ -26,7 +26,7 @@
         "mocha": "^10.0.0",
         "nock": "^13.2.9",
         "sinon": "^15.0.0",
-        "typescript": "~4.8.2"
+        "typescript": "^4.8.4"
       },
       "engines": {
         "node": ">= 14"
@@ -7820,9 +7820,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -14232,9 +14232,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "uc.micro": {

--- a/packages/datastore-lock/package.json
+++ b/packages/datastore-lock/package.json
@@ -32,7 +32,7 @@
     "mocha": "^10.0.0",
     "nock": "^13.2.9",
     "sinon": "^15.0.0",
-    "typescript": "~4.8.2"
+    "typescript": "4.8.4"
   },
   "engines": {
     "node": ">= 14"

--- a/packages/git-file-utils/package-lock.json
+++ b/packages/git-file-utils/package-lock.json
@@ -28,7 +28,7 @@
         "nock": "^13.2.9",
         "sinon": "^15.0.0",
         "snap-shot-it": "^7.9.6",
-        "typescript": "~4.8.2"
+        "typescript": "^4.8.4"
       },
       "engines": {
         "node": ">= 14"
@@ -4299,9 +4299,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7801,9 +7801,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "universal-user-agent": {

--- a/packages/git-file-utils/package.json
+++ b/packages/git-file-utils/package.json
@@ -36,7 +36,7 @@
     "nock": "^13.2.9",
     "sinon": "^15.0.0",
     "snap-shot-it": "^7.9.6",
-    "typescript": "~4.8.2"
+    "typescript": "4.8.4"
   },
   "engines": {
     "node": ">= 14"


### PR DESCRIPTION
Upgrading to typescript 4.9 results in the same error for all these bots:

```
node_modules/@types/node/globals.d.ts:72:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'AbortSignal' must be of type '{ new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds: number): AbortSignal; }', but here has type '{ new (): AbortSignal; prototype: AbortSignal; }'.

72 declare var AbortSignal: {
               ~~~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:2071:13
    2071 declare var AbortSignal: {
                     ~~~~~~~~~~~
    'AbortSignal' was also declared here.
```

After merging, I'll close the following PRs:
https://github.com/googleapis/repo-automation-bots/pull/4803 https://github.com/googleapis/repo-automation-bots/pull/4796 https://github.com/googleapis/repo-automation-bots/pull/4795 https://github.com/googleapis/repo-automation-bots/pull/4787
