### PR TITLE
fix(cherry-pick-bot): allow forward slash in branch name

### DIFF
--- a/packages/cherry-pick-bot/src/cherry-pick.ts
+++ b/packages/cherry-pick-bot/src/cherry-pick.ts
@@ -33,7 +33,7 @@ interface Commit {
   sha: string;
 }
 
-const COMMENT_REGEX = /^\/cherry-pick\s+(?<branch>\w[.-\w]*)/;
+const COMMENT_REGEX = /^\/cherry-pick\s+(?<branch>\w[./-\w]*)/;
 
 /**
  * Parse a comment string to see if it matches the expected cherry-pick

--- a/packages/cherry-pick-bot/test/cherry-pick.ts
+++ b/packages/cherry-pick-bot/test/cherry-pick.ts
@@ -45,6 +45,11 @@ describe('parseCherryPickComment', () => {
     const branch = parseCherryPickComment('\n/cherry-pick 2.1.x   ');
     assert.strictEqual(branch, '2.1.x');
   });
+
+  it('handles forward slash format', () => {
+    const branch = parseCherryPickComment('\n/cherry-pick release/2.1.x   ');
+    assert.strictEqual(branch, 'release/2.1.x');
+  });
 });
 
 describe('cherryPickCommits', () => {


### PR DESCRIPTION
Fixes #4851 🦕
