### PR TITLE
build(actions): switch output to use output file

### DIFF
--- a/.github/workflows/interrogate.js
+++ b/.github/workflows/interrogate.js
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 const {execSync} = require('child_process');
+const fs = require('fs');
 const baseRef = process.env.GITHUB_BASE_REF;
+const outputFile = process.env.GITHUB_OUTPUT;
 let status;
 
 if (baseRef) {
@@ -62,7 +64,7 @@ const requiredJobs = [
 ];
 
 function writeOutput(name, value) {
-  console.log(`::set-output name=${name}::${value}`);
+  fs.appendFileSync(outputFile, `${name}=${value}\n`);
 }
 
 console.log(nodePaths, '\n', goPaths, '\n', bashPaths, '\n', requiredJobs);

--- a/.github/workflows/interrogate.js
+++ b/.github/workflows/interrogate.js
@@ -14,8 +14,13 @@
 
 const {execSync} = require('child_process');
 const fs = require('fs');
-const baseRef = process.env.GITHUB_BASE_REF;
 const outputFile = process.env.GITHUB_OUTPUT;
+
+function writeOutput(name, value) {
+  fs.appendFileSync(outputFile, `${name}=${value}\n`);
+}
+
+const baseRef = process.env.GITHUB_BASE_REF;
 let status;
 
 if (baseRef) {
@@ -62,10 +67,6 @@ const requiredJobs = [
   ...goPaths.map(p => `go-test (${p})`),
   ...bashPaths.map(p => `bash-test (${p})`),
 ];
-
-function writeOutput(name, value) {
-  fs.appendFileSync(outputFile, `${name}=${value}\n`);
-}
 
 console.log(nodePaths, '\n', goPaths, '\n', bashPaths, '\n', requiredJobs);
 writeOutput('nodePaths', JSON.stringify(nodePaths));

--- a/.github/workflows/interrogate.js
+++ b/.github/workflows/interrogate.js
@@ -60,8 +60,13 @@ const requiredJobs = [
   ...goPaths.map(p => `go-test (${p})`),
   ...bashPaths.map(p => `bash-test (${p})`),
 ];
+
+function writeOutput(name, value) {
+  console.log(`::set-output name=${name}::${value}`);
+}
+
 console.log(nodePaths, '\n', goPaths, '\n', bashPaths, '\n', requiredJobs);
-console.log(`::set-output name=nodePaths::${JSON.stringify(nodePaths)}`);
-console.log(`::set-output name=goPaths::${JSON.stringify(goPaths)}`);
-console.log(`::set-output name=bashPaths::${JSON.stringify(bashPaths)}`);
-console.log(`::set-output name=requiredJobs::${JSON.stringify(requiredJobs)}`);
+writeOutput('nodePaths', JSON.stringify(nodePaths));
+writeOutput('goPaths', JSON.stringify(goPaths));
+writeOutput('bashPaths', JSON.stringify(bashPaths));
+writeOutput('requiredJobs', JSON.stringify(requiredJobs));

--- a/.github/workflows/list-node-paths-for-deps.js
+++ b/.github/workflows/list-node-paths-for-deps.js
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 const {execSync} = require('child_process');
+const fs = require('fs');
+const outputFile = process.env.GITHUB_OUTPUT;
+
+function writeOutput(name, value) {
+  fs.appendFileSync(outputFile, `${name}=${value}\n`);
+}
 
 // We want to match sub packages like owlbot-bootstrapper/cli
 const output = execSync(`find packages -type d -name node_modules -prune -o -name package-lock.json -print`, { encoding: 'utf-8' });
@@ -36,4 +42,4 @@ for (const package of packages) {
   }
 }
 
-console.log(`::set-output name=nodePaths::${JSON.stringify(Array.from(nodePaths))}`);
+writeOutput('nodePaths', JSON.stringify(Array.from(nodePaths)));

--- a/.github/workflows/list-node-paths.js
+++ b/.github/workflows/list-node-paths.js
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 const {execSync} = require('child_process');
+const fs = require('fs');
+const outputFile = process.env.GITHUB_OUTPUT;
+
+function writeOutput(name, value) {
+  fs.appendFileSync(outputFile, `${name}=${value}\n`);
+}
 
 const output = execSync(`ls packages/*/package-lock.json`, { encoding: 'utf-8' });
 const packages = output.split('\n');
@@ -21,4 +27,5 @@ const nodePaths = new Set();
 for (const package of packages) {
   nodePaths.add(package.split('/')[1]);
 }
-console.log(`::set-output name=nodePaths::${JSON.stringify(Array.from(nodePaths))}`);
+
+writeOutput('nodePaths', JSON.stringify(Array.from(nodePaths)));

--- a/packages/gcf-utils/README.md
+++ b/packages/gcf-utils/README.md
@@ -201,4 +201,3 @@ For more, check out the [Contributing Guide](../../CONTRIBUTING.md).
 ## License
 
 Apache 2.0 © 2019 Google Inc.
-

--- a/packages/gcf-utils/README.md
+++ b/packages/gcf-utils/README.md
@@ -201,3 +201,4 @@ For more, check out the [Contributing Guide](../../CONTRIBUTING.md).
 ## License
 
 Apache 2.0 © 2019 Google Inc.
+


### PR DESCRIPTION
To prevent potential leaking of output data: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Fixes #4855
