### PR TITLE
fix: handle empty repository as if it has no files

### DIFF
--- a/packages/git-file-utils/src/git-file-utils.ts
+++ b/packages/git-file-utils/src/git-file-utils.ts
@@ -15,6 +15,7 @@
 import {Octokit} from '@octokit/rest';
 import {basename, extname} from 'path';
 import {Minimatch} from 'minimatch';
+/* eslint-disable-next-line node/no-extraneous-import */
 import {RequestError} from '@octokit/request-error';
 
 export const DEFAULT_FILE_MODE = '100644';

--- a/packages/git-file-utils/test/git-file-utils.ts
+++ b/packages/git-file-utils/test/git-file-utils.ts
@@ -130,6 +130,18 @@ describe('BranchFileCache', () => {
       }, BranchNotFoundError);
       req.done();
     });
+
+    it('throws on empty repository', async () => {
+      const req = nock('https://api.github.com')
+        .get(
+          '/repos/testOwner/testRepo/git/trees/feature-branch?recursive=true'
+        )
+        .reply(409);
+      await assert.rejects(async () => {
+        await cache.getFileContents('missing-file');
+      }, FileNotFoundError);
+      req.done();
+    });
   });
 
   describe('with large repository', () => {


### PR DESCRIPTION
When a repository is uninitialized, GitHub throws a 409 error on file operations. In this library, we want to silently handle this scenario as if the repository has no files.

Towards #4474