### PR TITLE
fix: pass context logger to post-processor handlers

### DIFF
--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -15,7 +15,7 @@ import {exec} from 'child_process';
 import {promisify} from 'util';
 const execAsync = promisify(exec);
 import {load} from 'js-yaml';
-import {logger} from 'gcf-utils';
+import {logger as defaultLogger, GCFLogger} from 'gcf-utils';
 import {sign} from 'jsonwebtoken';
 import {request} from 'gaxios';
 import {CloudBuildClient} from '@google-cloud/cloudbuild';
@@ -87,7 +87,8 @@ export const OWL_BOT_COPY = 'owl-bot-copy';
 
 export async function triggerPostProcessBuild(
   args: BuildArgs,
-  octokit?: Octokit
+  octokit?: Octokit,
+  logger: GCFLogger = defaultLogger
 ): Promise<BuildResponse | null> {
   const token = await core.getGitHubShortLivedAccessToken(
     args.privateKey,
@@ -242,7 +243,11 @@ export async function getHeadCommit(
   return headCommit;
 }
 
-export async function createCheck(args: CheckArgs, octokit?: Octokit) {
+export async function createCheck(
+  args: CheckArgs,
+  octokit?: Octokit,
+  logger: GCFLogger = defaultLogger
+) {
   if (!octokit) {
     octokit = await core.getAuthenticatedOctokit({
       privateKey: args.privateKey,
@@ -587,7 +592,8 @@ async function updatePullRequestAfterPostProcessor(
   owner: string,
   repo: string,
   prNumber: number,
-  octokit: Octokit
+  octokit: Octokit,
+  logger: GCFLogger = defaultLogger
 ): Promise<void> {
   const {data: pull} = await octokit.pulls.get({
     owner,

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -601,7 +601,8 @@ const runPostProcessor = async (
         detailsURL:
           'https://github.com/googleapis/repo-automation-bots/tree/master/packages/owl-bot',
       },
-      octokit
+      octokit,
+      logger
     );
     return;
   }
@@ -619,7 +620,8 @@ const runPostProcessor = async (
         detailsURL:
           'https://github.com/googleapis/repo-automation-bots/tree/master/packages/owl-bot',
       },
-      octokit
+      octokit,
+      logger
     );
     return;
   }
@@ -636,7 +638,8 @@ const runPostProcessor = async (
         detailsURL:
           'https://github.com/googleapis/repo-automation-bots/tree/master/packages/owl-bot',
       },
-      octokit
+      octokit,
+      logger
     );
     return;
   }
@@ -655,7 +658,8 @@ const runPostProcessor = async (
         detailsURL:
           'https://github.com/googleapis/repo-automation-bots/blob/main/packages/owl-bot/README.md',
       },
-      octokit
+      octokit,
+      logger
     );
     return;
   }
@@ -678,7 +682,8 @@ const runPostProcessor = async (
         detailsURL:
           'https://github.com/googleapis/repo-automation-bots/tree/master/packages/owl-bot',
       },
-      octokit
+      octokit,
+      logger
     );
     return;
   }
@@ -696,7 +701,8 @@ const runPostProcessor = async (
       trigger,
       defaultBranch: opts.defaultBranch,
     },
-    octokit
+    octokit,
+    logger
   );
 
   if (null === buildStatus) {
@@ -711,7 +717,8 @@ const runPostProcessor = async (
         detailsURL:
           'https://github.com/googleapis/repo-automation-bots/blob/main/packages/owl-bot/README.md',
       },
-      octokit
+      octokit,
+      logger
     );
     return;
   }
@@ -726,14 +733,16 @@ const runPostProcessor = async (
       title: `🦉 OwlBot - ${buildStatus.summary}`,
       detailsURL: buildStatus.detailsURL,
     },
-    octokit
+    octokit,
+    logger
   );
 
   await core.updatePullRequestAfterPostProcessor(
     opts.owner,
     opts.repo,
     opts.prNumber,
-    octokit
+    octokit,
+    logger
   );
 };
 


### PR DESCRIPTION
While debugging #4946, I found that many logs are incorrectly attributed due to using importing the default GCFLogger rather than injecting an instance with request context. When we import the shared one, the context can be incorrect because the instance is shared between concurrent requests.
