### PR TITLE
fix: improve timeout error message

### DIFF
--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -160,15 +160,7 @@ export async function triggerPostProcessBuild(
     logger.error(`triggerPostProcessBuild: ${err.message}`, {
       stack: err.stack,
     });
-    if (err instanceof TimeoutError) {
-      return {
-        conclusion: 'failure',
-        summary: 'timed out waiting for build',
-        text: 'timed out waiting for build',
-        detailsURL,
-      };
-    }
-    return buildFailureFrom(detailsURL);
+    return buildFailureFrom(err, detailsURL);
   }
 }
 
@@ -198,13 +190,23 @@ function summarizeBuild(
   };
 }
 
-function buildFailureFrom(detailsUrl: string): BuildResponse {
-  return {
-    conclusion: 'failure',
-    summary: 'unknown build failure',
-    text: 'unknown build failure',
-    detailsURL: detailsUrl,
-  };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildFailureFrom(error: any, detailsUrl: string): BuildResponse {
+  if (typeof error.name === 'string' && typeof error.message === 'string') {
+    return {
+      conclusion: 'failure',
+      summary: error.name,
+      text: error.message,
+      detailsURL: detailsUrl,
+    };
+  } else {
+    return {
+      conclusion: 'failure',
+      summary: 'unknown build failure',
+      text: 'unknown build failure',
+      detailsURL: detailsUrl,
+    };
+  }
 }
 
 // Helper to build a link to the Cloud Build job, which peers in DPE

--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -209,10 +209,7 @@ function detailsUrlFrom(buildID: string, project: string): string {
 }
 
 class TimeoutError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = TimeoutError.name;
-  }
+  name = 'TimeoutError';
 }
 
 async function waitForBuild(


### PR DESCRIPTION
If the owlbot event handler times out waiting for the status of the post-processor GCB job, then return a better error status.

Towards #4946
