### PR TITLE
build: track flakybot in releases

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,7 @@
   "packages/bot-config-utils": "6.1.3",
   "packages/cron-utils": "3.2.2",
   "packages/datastore-lock": "4.0.4",
+  "packages/flakybot": "1.1.0",
   "packages/gcf-utils": "14.4.6",
   "packages/git-file-utils": "1.2.6",
   "packages/issue-utils": "2.1.2",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,6 +30,10 @@
     },
     "packages/datastore-lock": {
       "release-type": "node"
+    },
+    "packages/flakybot": {
+      "release-type": "go",
+      "component": "flakybot"
     }
   }
 }


### PR DESCRIPTION
Somehow, we never configured tagging flakybot binary releases.

We probably should move the binary to its own directory for releases separate from the webhook handler app.
