### PR TITLE
feat: add manual list of extra allowed api shortnames

### DIFF
--- a/packages/repo-metadata-lint/src/validate.ts
+++ b/packages/repo-metadata-lint/src/validate.ts
@@ -31,6 +31,11 @@ const API_LIBRARY_TYPES = [
   'GAPIC_COMBO',
 ];
 
+// Manually curated list of allowed api_shortname entries
+const EXTRA_ALLOWED_API_SHORTNAMES = [
+  'bigquery', // handwritten client that has no protos
+];
+
 interface ApiIndex {
   apis: {hostName: string}[];
 }
@@ -102,6 +107,9 @@ export class Validate {
   async validApiShortNames() {
     const apiIndex = await this.getApiIndex();
     const apiShortNames = new Set<string>();
+    for (const shortname of EXTRA_ALLOWED_API_SHORTNAMES) {
+      apiShortNames.add(shortname);
+    }
     for (const api of apiIndex.apis) {
       const match = api.hostName.match(/(?<service>[^.]+)/);
       if (match && match.groups) {


### PR DESCRIPTION
Going with the manually curated list of extra allowed api_shortname entries because this scenario is so rare. If we allow every product entry, we could get false negatives where we happen to match a "product" but we don't have protos for it.

Fixes #5036
