### PR TITLE
deps: update releasetool to 1.12.0

### DIFF
--- a/packages/release-trigger/requirements.in
+++ b/packages/release-trigger/requirements.in
@@ -1,2 +1,2 @@
-gcp-releasetool>=1.11.0
+gcp-releasetool>=1.12.0
 keyrings.alt

--- a/packages/release-trigger/requirements.txt
+++ b/packages/release-trigger/requirements.txt
@@ -115,9 +115,9 @@ cryptography==39.0.1 \
     # via
     #   gcp-releasetool
     #   secretstorage
-gcp-releasetool==1.11.0 \
-    --hash=sha256:615b1ccb3e489aff64ad73e0505a8692b90c66d9ce11351c5e775b51fb9b3f5b \
-    --hash=sha256:6be72ba34054fca74b65c59b54bf48a76ada9257d621313fe17d3501d56b28a7
+gcp-releasetool==1.12.0 \
+    --hash=sha256:056bd673ec788c06d9e8434ba0dd9e16cc60b59f19f2ea460864179e1d9a0ce9 \
+    --hash=sha256:0ce1d1dee78faf3de5a9f58380128d8a739fd3c876c1de6695f64dc15b5249f2
     # via -r requirements.in
 google-auth==2.15.0 \
     --hash=sha256:6897b93556d8d807ad70701bb89f000183aea366ca7ed94680828b37437a4994 \


### PR DESCRIPTION
Allows us to trigger the golang Kokoro jobs
