### PR TITLE
fix(auto-approve): update node dependency for mono repo migration

### DIFF
--- a/packages/auto-approve/README.md
+++ b/packages/auto-approve/README.md
@@ -83,8 +83,7 @@ Below is what each process checks for:
     - /package\.json$/
   - All files must: 
     - Match either these regexp:
-      - /^samples\/package.json$/
-      - /^\/package.json$/
+      - /\/package.json$/
     - Increase the non-major package version of a dependency
     - Only change one dependency
     - Change the dependency that was there previously, and that is on the title of the PR

--- a/packages/auto-approve/README.md
+++ b/packages/auto-approve/README.md
@@ -82,8 +82,8 @@ Below is what each process checks for:
   - Each file path must match one of these regexps:
     - /package\.json$/
   - All files must: 
-    - Match either these regexp:
-      - /\/package.json$/
+    - Match this regexp:
+      - /package.json$/
     - Increase the non-major package version of a dependency
     - Only change one dependency
     - Change the dependency that was there previously, and that is on the title of the PR

--- a/packages/auto-approve/README.md
+++ b/packages/auto-approve/README.md
@@ -77,7 +77,6 @@ Below is what each process checks for:
     - Change the dependency that was there previously, and that is on the title of the PR
     - Not match any regexes in the 'excluded' list
 * NodeDependency:
-  - Max 3 files changed in the PR
   - Checks that the author is 'renovate-bot'
   - Checks that the title of the PR matches the regexp: /^(fix|chore)\(deps\): update dependency (@?\S*) to v(\S*)$/
   - Each file path must match one of these regexps:

--- a/packages/auto-approve/test/additional-validation-for-versioning.test.ts
+++ b/packages/auto-approve/test/additional-validation-for-versioning.test.ts
@@ -467,8 +467,8 @@ describe('run additional versioning checks', () => {
       };
       const versions = getVersionsV2(
         PRFile,
-        fileRule.fileRules![1].oldVersion,
-        fileRule.fileRules![1].newVersion
+        fileRule.fileRules![0].oldVersion,
+        fileRule.fileRules![0].newVersion
       );
 
       assert.deepStrictEqual(versions, getVersionsExpectation);
@@ -498,8 +498,8 @@ describe('run additional versioning checks', () => {
 
       const versions = getVersionsV2(
         PRFile,
-        fileRule.fileRules![1].oldVersion,
-        fileRule.fileRules![1].newVersion
+        fileRule.fileRules![0].oldVersion,
+        fileRule.fileRules![0].newVersion
       );
       assert.strictEqual(versions, undefined);
     });
@@ -510,8 +510,8 @@ describe('run additional versioning checks', () => {
       assert.strictEqual(
         getVersionsV2(
           undefined,
-          fileRule.fileRules![1].oldVersion,
-          fileRule.fileRules![1].newVersion
+          fileRule.fileRules![0].oldVersion,
+          fileRule.fileRules![0].newVersion
         ),
         undefined
       );


### PR DESCRIPTION
In moving to the mono-repo, we no longer have package.json in one fixed spot; this PR updates the rules to reflect that. Also, we may have more than 3 files being changed, so this updates that rule.