### PR TITLE
fix: failed to fetch docker images' timestamps

### DIFF
--- a/packages/owl-bot/src/docker-api.ts
+++ b/packages/owl-bot/src/docker-api.ts
@@ -46,11 +46,11 @@ export async function fetchConfig(
   );
   const manifestUri = `https://${host}/v2/${image}/manifests/${digest}`;
   console.info(`fetching ${manifestUri}`);
-  const manifest = JSON.parse(await fetchURL(manifestUri)) as Manifest;
+  const manifest = JSON.parse(await fetchManifestJson(manifestUri)) as Manifest;
   const configDigest: string = manifest.config.digest;
   const configUri = `https://${host}/v2/${image}/blobs/${configDigest}`;
   console.info(`fetching ${configUri}`);
-  return JSON.parse(await fetchURL(configUri)) as Config;
+  return JSON.parse(await fetchManifestJson(configUri)) as Config;
 }
 
 /**
@@ -58,10 +58,14 @@ export async function fetchConfig(
  *
  * @param url It needs to be an https URL.
  */
-async function fetchURL(url: string): Promise<string> {
+async function fetchManifestJson(url: string): Promise<string> {
+  const headers = {
+    accept:
+      'application/vnd.docker.distribution.manifest.v2+json,application/json',
+  };
   return new Promise((resolve, reject) => {
     https
-      .get(url, response => {
+      .get(url, {headers}, response => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const chunks: any[] = [];
         response.on('data', chunk => {


### PR DESCRIPTION
Owl Bot was logging errors like this:
```
fetching https://gcr.io/v2/cloud-devrel-public-resources/owlbot-go/manifests/sha256:bd3adb7c0c9cfb8ead23d2abf351ee5935163096e5fb4af1bedf22b93023d058
Error: HTTP error, status code: 404
    at IncomingMessage.<anonymous> (/usr/src/app/build/src/docker-api.js:58:28)
    at IncomingMessage.emit (events.js:412:35)
    at IncomingMessage.emit (domain.js:475:12)
    at endReadableNT (internal/streams/readable.js:1333:12)
    at processTicksAndRejections (internal/process/task_queues.js:82:21)
```
which were not fatal.  But they were a distraction when I was trying to debug an issue.  Plus, the .OwlBot.lock.yaml file didn't get a timestamp which makes generated PRs easier to review.
