### PR TITLE
fix: set buffer size for copy-code-again flow

### DIFF
--- a/packages/owl-bot/cloud-build/copy-code-again.yaml
+++ b/packages/owl-bot/cloud-build/copy-code-again.yaml
@@ -58,6 +58,26 @@ steps:
       - 'GITHUB_TOKEN=$_GITHUB_TOKEN'
       - 'HOME=/workspace'
 
+  # TODO: remove when we find a better resolution.
+  # See: https://github.com/orgs/community/discussions/55820
+  - name: 'gcr.io/cloud-builders/git'
+    args:
+      - config
+      - --global
+      - http.postBuffer
+      - '157286400'
+    env:
+      - 'HOME=/workspace'
+
+  - name: 'gcr.io/cloud-builders/git'
+    args:
+      - config
+      - --global
+      - http.version
+      - 'HTTP/1.1'
+    env:
+      - 'HOME=/workspace'
+
   # Run Owl Bot to copy the code again from googleapis/googleapis-gen.
   - name: 'gcr.io/repo-automation-bots/owlbot-cli'
     args:


### PR DESCRIPTION
Related https://github.com/googleapis/repo-automation-bots/issues/5066
