### PR TITLE
feat: store validated .repo-metadata in table

### DIFF
--- a/packages/repo-metadata-lint/package-lock.json
+++ b/packages/repo-metadata-lint/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@google-automations/git-file-utils": "^1.2.5",
+        "@google-cloud/bigquery": "^6.2.0",
         "@octokit/rest": "^19.0.4",
         "ajv": "^8.11.0",
         "gaxios": "^5.0.1",
@@ -265,6 +266,74 @@
         "node": ">= 14"
       }
     },
+    "node_modules/@google-cloud/bigquery": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-6.2.0.tgz",
+      "integrity": "sha512-jkyu8n5WR5HoF4saVc/ukfAE8uEjqkWRu3Bn3+hhJ7RTNR8unloS9J6JKzsGtLlA8gS3gHSceRg/CpCl5WFg+g==",
+      "dependencies": {
+        "@google-cloud/common": "^4.0.0",
+        "@google-cloud/paginator": "^4.0.0",
+        "@google-cloud/precise-date": "^3.0.1",
+        "@google-cloud/promisify": "^3.0.0",
+        "arrify": "^2.0.1",
+        "big.js": "^6.0.0",
+        "duplexify": "^4.0.0",
+        "extend": "^3.0.2",
+        "is": "^3.3.0",
+        "p-event": "^4.1.0",
+        "readable-stream": "^4.0.0",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/@google-cloud/paginator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-4.0.1.tgz",
+      "integrity": "sha512-6G1ui6bWhNyHjmbYwavdN7mpVPRBtyDg/bfqBTAlwr413On2TnFNfDxc9UhTJctkgoCDgQXEKiRPLPR9USlkbQ==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/readable-stream": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
+      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@google-cloud/common": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-4.0.3.tgz",
+      "integrity": "sha512-fUoMo5b8iAKbrYpneIRV3z95AlxVJPrjpevxs4SKoclngWZvTXBSGpNisF5+x5m+oNGve7jfB1e6vNBZBUs7Fw==",
+      "dependencies": {
+        "@google-cloud/projectify": "^3.0.0",
+        "@google-cloud/promisify": "^3.0.0",
+        "arrify": "^2.0.1",
+        "duplexify": "^4.1.1",
+        "ent": "^2.2.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^8.0.2",
+        "retry-request": "^5.0.0",
+        "teeny-request": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@google-cloud/kms": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-3.2.0.tgz",
@@ -286,6 +355,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-3.0.1.tgz",
+      "integrity": "sha512-crK2rgNFfvLoSgcKJY7ZBOLW91IimVNmPfi1CL+kMTf78pTJYd29XqEVedAeBu4DwCJc0EDIp1MpctLgoPq+Uw==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@google-cloud/projectify": {
@@ -2075,6 +2152,18 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+    },
+    "node_modules/big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.1.1",
@@ -4390,6 +4479,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5613,6 +5710,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dependencies": {
+        "p-timeout": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-is-promise": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
@@ -5656,6 +5775,17 @@
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -8002,6 +8132,64 @@
         "minimatch": "^5.1.0"
       }
     },
+    "@google-cloud/bigquery": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-6.2.0.tgz",
+      "integrity": "sha512-jkyu8n5WR5HoF4saVc/ukfAE8uEjqkWRu3Bn3+hhJ7RTNR8unloS9J6JKzsGtLlA8gS3gHSceRg/CpCl5WFg+g==",
+      "requires": {
+        "@google-cloud/common": "^4.0.0",
+        "@google-cloud/paginator": "^4.0.0",
+        "@google-cloud/precise-date": "^3.0.1",
+        "@google-cloud/promisify": "^3.0.0",
+        "arrify": "^2.0.1",
+        "big.js": "^6.0.0",
+        "duplexify": "^4.0.0",
+        "extend": "^3.0.2",
+        "is": "^3.3.0",
+        "p-event": "^4.1.0",
+        "readable-stream": "^4.0.0",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "@google-cloud/paginator": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-4.0.1.tgz",
+          "integrity": "sha512-6G1ui6bWhNyHjmbYwavdN7mpVPRBtyDg/bfqBTAlwr413On2TnFNfDxc9UhTJctkgoCDgQXEKiRPLPR9USlkbQ==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "extend": "^3.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
+          "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10"
+          }
+        }
+      }
+    },
+    "@google-cloud/common": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-4.0.3.tgz",
+      "integrity": "sha512-fUoMo5b8iAKbrYpneIRV3z95AlxVJPrjpevxs4SKoclngWZvTXBSGpNisF5+x5m+oNGve7jfB1e6vNBZBUs7Fw==",
+      "requires": {
+        "@google-cloud/projectify": "^3.0.0",
+        "@google-cloud/promisify": "^3.0.0",
+        "arrify": "^2.0.1",
+        "duplexify": "^4.1.1",
+        "ent": "^2.2.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^8.0.2",
+        "retry-request": "^5.0.0",
+        "teeny-request": "^8.0.0"
+      }
+    },
     "@google-cloud/kms": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-3.2.0.tgz",
@@ -8018,6 +8206,11 @@
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
       }
+    },
+    "@google-cloud/precise-date": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-3.0.1.tgz",
+      "integrity": "sha512-crK2rgNFfvLoSgcKJY7ZBOLW91IimVNmPfi1CL+kMTf78pTJYd29XqEVedAeBu4DwCJc0EDIp1MpctLgoPq+Uw=="
     },
     "@google-cloud/projectify": {
       "version": "3.0.0",
@@ -9443,6 +9636,11 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+    },
+    "big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ=="
     },
     "bignumber.js": {
       "version": "9.1.1",
@@ -11178,6 +11376,11 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
+    "is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -12113,6 +12316,19 @@
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true
     },
+    "p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "requires": {
+        "p-timeout": "^3.1.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
+    },
     "p-is-promise": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
@@ -12139,6 +12355,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
     },
     "p-try": {
       "version": "2.2.0",

--- a/packages/repo-metadata-lint/package.json
+++ b/packages/repo-metadata-lint/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@google-automations/git-file-utils": "^1.2.5",
+    "@google-cloud/bigquery": "^6.2.0",
     "@octokit/rest": "^19.0.4",
     "ajv": "^8.11.0",
     "gaxios": "^5.0.1",

--- a/packages/repo-metadata-lint/src/store-metadata.ts
+++ b/packages/repo-metadata-lint/src/store-metadata.ts
@@ -1,0 +1,51 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import util from 'util';
+import {BigQuery} from '@google-cloud/bigquery';
+import {GCFLogger, logger as defaultLogger} from 'gcf-utils';
+
+const bigquery = new BigQuery();
+const datasetId = 'RepoMetadata';
+const tableId = 'RepoMetadata';
+
+interface Metadata {
+  api_service: string; // Format: bigquery.googleapis.com
+  language: string;
+  release_level: string;
+  repository: string; // Format: googleapis/bigquery.
+}
+
+/**
+ * Given metadata pulled from .repo-metadata and GitHub store
+ * an entry in BigQuery calculating coverage.
+ *
+ * @param result The Policy Result for a single repository
+ */
+export async function storeMetadata(
+  metadata: Metadata,
+  logger: GCFLogger = defaultLogger
+) {
+  try {
+    await bigquery
+      .dataset(datasetId)
+      .table(tableId)
+      .insert([{timestamp: new Date(), ...metadata}]);
+  } catch (e) {
+    // dumping the error like this is required because error objects from BigQuery
+    // contain nested data, including insert errors in arrays.
+    logger.error(util.inspect(e, false, null));
+    throw e;
+  }
+}

--- a/packages/repo-metadata-lint/src/store-metadata.ts
+++ b/packages/repo-metadata-lint/src/store-metadata.ts
@@ -38,9 +38,8 @@ export async function storeMetadata(
   logger: GCFLogger = defaultLogger
 ) {
   try {
-    const metadataRecord = {timestamp: new Date(), ...metadata};
-    logger.info('storing repo metadata', metadataRecord);
-    await bigquery.dataset(datasetId).table(tableId).insert([metadataRecord]);
+    logger.info('storing repo metadata', metadata);
+    await bigquery.dataset(datasetId).table(tableId).insert([metadata]);
   } catch (e) {
     // dumping the error like this is required because error objects from BigQuery
     // contain nested data, including insert errors in arrays.

--- a/packages/repo-metadata-lint/src/store-metadata.ts
+++ b/packages/repo-metadata-lint/src/store-metadata.ts
@@ -38,10 +38,9 @@ export async function storeMetadata(
   logger: GCFLogger = defaultLogger
 ) {
   try {
-    await bigquery
-      .dataset(datasetId)
-      .table(tableId)
-      .insert([{timestamp: new Date(), ...metadata}]);
+    const metadataRecord = {timestamp: new Date(), ...metadata};
+    logger.info('storing repo metadata', metadataRecord);
+    await bigquery.dataset(datasetId).table(tableId).insert([metadataRecord]);
   } catch (e) {
     // dumping the error like this is required because error objects from BigQuery
     // contain nested data, including insert errors in arrays.

--- a/packages/repo-metadata-lint/src/validate.ts
+++ b/packages/repo-metadata-lint/src/validate.ts
@@ -17,6 +17,7 @@ import Ajv from 'ajv';
 import schema from './repo-metadata-schema.json';
 import {Octokit} from '@octokit/rest';
 import {RepositoryFileCache} from '@google-automations/git-file-utils';
+import * as StoreMetadata from './store-metadata';
 
 export interface ValidationResult {
   status: 'success' | 'error';
@@ -97,6 +98,17 @@ export class Validate {
           );
         }
       }
+    }
+
+    // On success, store an entry in a metadata table. This data is
+    // used to answer questions such as API coverage:
+    if (result.status === 'success') {
+      await StoreMetadata.storeMetadata({
+        release_level: repoMetadata.release_level,
+        language: repoMetadata.language,
+        repository: repoMetadata.repository,
+        api_service: `${repoMetadata.api_shortname}.googleapis.com`,
+      });
     }
 
     return result;

--- a/packages/repo-metadata-lint/test/validate.ts
+++ b/packages/repo-metadata-lint/test/validate.ts
@@ -15,6 +15,7 @@
 import {describe, it, afterEach} from 'mocha';
 import assert from 'assert';
 import {Validate} from '../src/validate';
+import * as StoreMetadata from '../src/store-metadata';
 import {Octokit} from '@octokit/rest';
 import {readFileSync} from 'fs';
 import * as sinon from 'sinon';
@@ -72,6 +73,7 @@ describe('validate', () => {
   });
 
   it('succeeds if api_shortname missing, but library type does not correspond to API', async () => {
+    const storeMetadataStub = sandbox.stub(StoreMetadata, 'storeMetadata');
     const file = JSON.stringify({
       name: 'bigquery',
       release_level: 'stable',
@@ -85,6 +87,7 @@ describe('validate', () => {
     );
     assert.strictEqual(result.status, 'success');
     assert.strictEqual(result.errors.length, 0);
+    sandbox.assert.calledOnce(storeMetadataStub);
   });
 
   it('returns validation error if library_type missing', async () => {
@@ -205,6 +208,7 @@ describe('validate', () => {
   });
 
   it('succeeds when all fields are valid for GAPIC libraries', async () => {
+    const storeMetadataStub = sandbox.stub(StoreMetadata, 'storeMetadata');
     const file = JSON.stringify({
       release_level: 'stable',
       library_type: 'GAPIC_AUTO',
@@ -217,9 +221,11 @@ describe('validate', () => {
       file
     );
     assert.strictEqual(result.status, 'success');
+    sandbox.assert.calledOnce(storeMetadataStub);
   });
 
   it('succeeds for release_level of unreleased', async () => {
+    const storeMetadataStub = sandbox.stub(StoreMetadata, 'storeMetadata');
     const file = JSON.stringify({
       release_level: 'unreleased',
       library_type: 'GAPIC_AUTO',
@@ -232,5 +238,6 @@ describe('validate', () => {
       file
     );
     assert.strictEqual(result.status, 'success');
+    sandbox.assert.calledOnce(storeMetadataStub);
   });
 });


### PR DESCRIPTION
Store validated fields from .repo-metadata.json in a BigQuery table, so that it can feed into team analytics, e.g., library coverage.