### PR TITLE
fix: update existing bulk copy-code PRs

### DIFF
--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -505,6 +505,19 @@ export async function copyCodeAndAppendOrCreatePullRequest(
       i + params.maxYamlCountPerPullRequest
     );
 
+    const wparams: WorkingCopyParams = {...params, destDir, workDir};
+    const updated = await findAndAppendPullRequest(
+      wparams,
+      leftOverBatch,
+      logger,
+      withNestedCommitDelimiters
+    );
+
+    if (updated) {
+      logger.info('Updated existing batch PR.');
+      continue;
+    }
+
     const destBranch = branchNameForCopies(leftOverBatch);
     cmd(`git checkout ${defaultBranch}`, {cwd: destDir});
     cmd(`git checkout -b ${destBranch}`, {cwd: destDir});

--- a/packages/owl-bot/test/fake-octokit.ts
+++ b/packages/owl-bot/test/fake-octokit.ts
@@ -55,7 +55,7 @@ export class FakePulls {
   updates: any[] = [];
   reviewComments: any[] = [];
 
-  list() {
+  list(search: any) {
     return Promise.resolve({data: this.pulls});
   }
 


### PR DESCRIPTION
If there were no found individual PRs, make sure we look for an
existing bulk PR and append to that PR before attempting to create a
new bulk PR.

Fixes #5075 
