### PR TITLE
Revert "fix: flip flag to turn on *draft* copy code PRs (#5157)"

### DIFF
--- a/packages/owl-bot/src/bin/commands/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/bin/commands/scan-googleapis-gen-and-create-pull-requests.ts
@@ -98,7 +98,7 @@ export const scanGoogleapisGenAndCreatePullRequestsCommand: yargs.CommandModule<
       .option('draft-pull-requests', {
         describe: 'When creating pull requests, make them drafts.',
         type: 'boolean',
-        default: true,
+        default: false,
         demand: false,
       });
   },


### PR DESCRIPTION
This reverts commit 7b5ef7eb6e652cc05335ce801477c74f68d6aa74.

Creating draft pull requests works, but owl bot never follows up and removes the draft label.

Fixes https://github.com/googleapis/repo-automation-bots/issues/5160
