### PR TITLE
fix: don't revalidate bot schema when trying to execute

### DIFF
--- a/packages/cherry-pick-bot/src/bot.ts
+++ b/packages/cherry-pick-bot/src/bot.ts
@@ -59,8 +59,7 @@ export = (app: Probot) => {
       octokit,
       owner,
       repo,
-      CONFIGURATION_FILE_PATH,
-      {schema: schema}
+      CONFIGURATION_FILE_PATH
     );
     if (!remoteConfig) {
       logger.debug(`cherry-pick-bot not configured for ${owner}/${repo}`);
@@ -176,8 +175,7 @@ export = (app: Probot) => {
       octokit,
       owner,
       repo,
-      CONFIGURATION_FILE_PATH,
-      {schema: schema}
+      CONFIGURATION_FILE_PATH
     );
     if (!remoteConfig) {
       logger.debug(`cherry-pick-bot not configured for ${owner}/${repo}`);


### PR DESCRIPTION
We have a presubmit check that does the validation. If the schema is invalid at runtime, let it fail.

Fixes #4928