### PR TITLE
fix: log the labels when owl-bot skips draft PR

### DIFF
--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -194,7 +194,9 @@ function OwlBot(privateKey: string | undefined, app: Probot, db?: Db): void {
         )
       ) {
         logger.info(
-          `skipping draft PR ${context.payload.pull_request.issue_url}`
+          `skipping draft PR ${context.payload.pull_request.issue_url}` +
+            ' with labels ',
+          ...context.payload.pull_request.labels
         );
         return;
       }


### PR DESCRIPTION
Debugging why owl-bot is still skipping draft PRs that it shouldn't.

Debugging https://github.com/googleapis/repo-automation-bots/issues/5179