### PR TITLE
fix: allow list supported organizations

### DIFF
--- a/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/src/scan-googleapis-gen-and-create-pull-requests.ts
@@ -20,6 +20,7 @@ import {
   copyCodeAndAppendOrCreatePullRequest,
   CopyParams,
   copyTagFrom,
+  InvalidOrgError,
   toLocalRepo,
 } from './copy-code';
 import {getFilesModifiedBySha} from '.';
@@ -192,13 +193,18 @@ export async function scanGoogleapisGenAndCreatePullRequests(
       octokitFactory,
       maxYamlCountPerPullRequest,
     };
-    await copyCodeAndAppendOrCreatePullRequest(
-      params,
-      todo.yamlPaths,
-      logger,
-      withNestedCommitDelimiters,
-      draftPullRequests
-    );
+    try {
+      await copyCodeAndAppendOrCreatePullRequest(
+        params,
+        todo.yamlPaths,
+        logger,
+        withNestedCommitDelimiters,
+        draftPullRequests
+      );
+    } catch (err) {
+      if (err instanceof InvalidOrgError) continue;
+      else throw err;
+    }
   }
   return todoStack.length;
 }

--- a/packages/owl-bot/test/make-repos.ts
+++ b/packages/owl-bot/test/make-repos.ts
@@ -30,7 +30,7 @@ export function makeAbcRepo(logger = console): string {
   const cmd = newCmd(logger);
 
   // Create a git repo.
-  const dir = tmp.dirSync().name;
+  const dir = tmp.dirSync({template: 'googleapis-XXXXXX'}).name;
   cmd('git init -b main', {cwd: dir});
   cmd('git config user.email "test@example.com"', {cwd: dir});
   cmd('git config user.name "test"', {cwd: dir});
@@ -61,7 +61,7 @@ export function makeRepoWithOwlBotYaml(
 ): string {
   const cmd = newCmd(console);
 
-  const dir = tmp.dirSync().name;
+  const dir = tmp.dirSync({template: 'googleapis-XXXXXX'}).name;
   cmd('git init -b main', {cwd: dir});
   cmd('git config user.email "test@example.com"', {cwd: dir});
   cmd('git config user.name "test"', {cwd: dir});


### PR DESCRIPTION
Currently an org outside of those explicitly supported by OwlBot can cause the system to fail. 

This introduces an allow list as a patch for this.
