### PR TITLE
fix: getAuthenticatedOctokit is a standalone method

### DIFF
--- a/packages/gcf-utils/package-lock.json
+++ b/packages/gcf-utils/package-lock.json
@@ -3935,6 +3935,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/google-auth-library/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/google-gax": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.6.1.tgz",
@@ -4139,6 +4150,18 @@
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -4990,17 +5013,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
       "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -6161,9 +6173,9 @@
       }
     },
     "node_modules/probot": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/probot/-/probot-12.3.0.tgz",
-      "integrity": "sha512-I7qpD6myIt5eEqAOv14mrbdh4HdLG1MQgCHGQJpIj6rdDeQaacQDL2THlMSqIU2VBcdIRpLqNv7D0z2NG0la3w==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-12.3.1.tgz",
+      "integrity": "sha512-ECSgycmAC0ILEK6cOa+x3QPufP5JybsuohOFCYr3glQU5SkbmypZJE/Sfio9mxAFHK5LCXveIDsfZCxf6ck4JA==",
       "dependencies": {
         "@octokit/core": "^3.2.4",
         "@octokit/plugin-enterprise-compatibility": "^1.2.8",
@@ -6495,6 +6507,17 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/probot/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/probot/node_modules/pino": {
@@ -7242,6 +7265,17 @@
       },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -11333,6 +11367,16 @@
         "gtoken": "^6.1.0",
         "jws": "^4.0.0",
         "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "google-gax": {
@@ -11481,6 +11525,17 @@
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "html-escaper": {
@@ -12128,14 +12183,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
       "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "make-dir": {
       "version": "3.1.0",
@@ -13014,9 +13061,9 @@
       }
     },
     "probot": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/probot/-/probot-12.3.0.tgz",
-      "integrity": "sha512-I7qpD6myIt5eEqAOv14mrbdh4HdLG1MQgCHGQJpIj6rdDeQaacQDL2THlMSqIU2VBcdIRpLqNv7D0z2NG0la3w==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-12.3.1.tgz",
+      "integrity": "sha512-ECSgycmAC0ILEK6cOa+x3QPufP5JybsuohOFCYr3glQU5SkbmypZJE/Sfio9mxAFHK5LCXveIDsfZCxf6ck4JA==",
       "requires": {
         "@octokit/core": "^3.2.4",
         "@octokit/plugin-enterprise-compatibility": "^1.2.8",
@@ -13347,6 +13394,14 @@
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
           }
         },
         "pino": {
@@ -13893,6 +13948,16 @@
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "send": {

--- a/packages/gcf-utils/src/installations.ts
+++ b/packages/gcf-utils/src/installations.ts
@@ -52,7 +52,7 @@ export async function* eachInstallation(
 ): AsyncGenerator<AppInstallation, void, void> {
   const octokit = await getAuthenticatedOctokit(undefined);
   const installationsPaginated = octokit.paginate.iterator(
-    octokit.apps.listInstallations
+    octokit.apps.listInstallations as any
   );
   for await (const response of installationsPaginated) {
     for (const installation of response.data) {
@@ -78,7 +78,7 @@ export async function* eachInstalledRepository(
 ): AsyncGenerator<InstalledRepository, void, void> {
   const octokit = await getAuthenticatedOctokit(installationId);
   const installationRepositoriesPaginated = octokit.paginate.iterator(
-    octokit.apps.listReposAccessibleToInstallation,
+    octokit.apps.listReposAccessibleToInstallation as any,
     {
       mediaType: {
         previews: ['machine-man'],

--- a/packages/gcf-utils/src/installations.ts
+++ b/packages/gcf-utils/src/installations.ts
@@ -14,6 +14,7 @@
 //
 
 import {WrapConfig} from './configuration';
+import {getAuthenticatedOctokit} from './gcf-utils';
 
 // Helper interface to abstract the response of the list installations GitHub response
 export interface AppInstallation {
@@ -49,7 +50,7 @@ export interface InstalledRepository {
 export async function* eachInstallation(
   wrapConfig: WrapConfig
 ): AsyncGenerator<AppInstallation, void, void> {
-  const octokit = await this.getAuthenticatedOctokit(undefined, wrapConfig);
+  const octokit = await getAuthenticatedOctokit(undefined);
   const installationsPaginated = octokit.paginate.iterator(
     octokit.apps.listInstallations
   );
@@ -75,10 +76,7 @@ export async function* eachInstalledRepository(
   installationId: number,
   wrapConfig: WrapConfig
 ): AsyncGenerator<InstalledRepository, void, void> {
-  const octokit = await this.getAuthenticatedOctokit(
-    installationId,
-    wrapConfig
-  );
+  const octokit = await getAuthenticatedOctokit(installationId);
   const installationRepositoriesPaginated = octokit.paginate.iterator(
     octokit.apps.listReposAccessibleToInstallation,
     {


### PR DESCRIPTION
fix
```
TypeError: Cannot read properties of undefined (reading 'getAuthenticatedOctokit')
    at eachInstallation (/usr/src/app/node_modules/gcf-utils/build/src/installations.js:26:32)
    at eachInstallation.next (<anonymous>)
    at GCFBootstrapper.handleScheduledInstallation (/usr/src/app/node_modules/gcf-utils/build/src/gcf-utils.js:492:30)
    at GCFBootstrapper.handleScheduled (/usr/src/app/node_modules/gcf-utils/build/src/gcf-utils.js:447:24)
    at /usr/src/app/node_modules/gcf-utils/build/src/gcf-utils.js:290:32
```