### PR TITLE
fix: don't open bug when .OwlBot.yaml is missing

### DIFF
--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -191,7 +191,7 @@ export async function copyCodeIntoCommit(
     let yaml: OwlBotYaml | undefined;
     try {
       if (!fs.existsSync(localYamlPath)) {
-        logger.warn(`${localYamlPath} doesn't exist.`)
+        logger.warn(`${localYamlPath} doesn't exist.`);
         continue;
       }
       yaml = await loadOwlBotYaml(localYamlPath);

--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -190,6 +190,10 @@ export async function copyCodeIntoCommit(
     const localYamlPath = path.join(params.destDir, yamlPath);
     let yaml: OwlBotYaml | undefined;
     try {
+      if (!fs.existsSync(localYamlPath)) {
+        logger.warn(`${localYamlPath} doesn't exist.`)
+        continue;
+      }
       yaml = await loadOwlBotYaml(localYamlPath);
     } catch (e) {
       await reportError(e, yamlPath);
@@ -547,7 +551,7 @@ export async function copyCodeAndAppendOrCreatePullRequest(
       const issue = await octokit.issues.create({
         owner: params.destRepo.owner,
         repo: params.destRepo.repo,
-        title: `${yamlPath} is missing or defective`,
+        title: `${yamlPath} is defective`,
         body: `While attempting to copy files from
 ${sourceLink}
 


### PR DESCRIPTION
The contents of the repo are the source of truth.  scan-googleapis-gen-and-create-pull requests queries firestore to find .OwlBot.yaml files.  Firestore may have stale data.  So if Owl Bot queries firestore, finds an .OwlBot.yaml, and then can't find the .OwlBot.yaml in the repo, then that's not actually a problem.

Fixes https://github.com/googleapis/repo-automation-bots/issues/5242
