### PR TITLE
fix(repo-metadata-lint): add runtimeconfig to the list of non-gRPC APIs

### DIFF
--- a/packages/repo-metadata-lint/src/validate.ts
+++ b/packages/repo-metadata-lint/src/validate.ts
@@ -35,6 +35,7 @@ const API_LIBRARY_TYPES = [
 // Manually curated list of allowed api_shortname entries
 const EXTRA_ALLOWED_API_SHORTNAMES = [
   'bigquery', // handwritten client that has no protos
+  'runtimeconfig', // handwritten client that has no protos
 ];
 
 interface ApiIndex {


### PR DESCRIPTION
Fixes https://github.com/googleapis/python-runtimeconfig/issues/175