### PR TITLE
chore: Update config-schema.json to allow "always-bump-minor" and "always-bump-major" versioning strategies.

### DIFF
--- a/packages/release-please/src/config-schema.json
+++ b/packages/release-please/src/config-schema.json
@@ -48,6 +48,8 @@
                     "enum": [
                         "default",
                         "always-bump-patch",
+                        "always-bump-major",
+                        "always-bump-minor",
                         "service-pack"
                     ]
                 },


### PR DESCRIPTION
Adding "always-bump-minor" and "always-bump-major" to the allowed values for versioning.
Reference PR: https://github.com/googleapis/release-please/pull/1744

