### PR TITLE
fix: add more use cases to gapic-generator updates

### DIFF
--- a/packages/auto-approve/__snapshots__/auto-approve.test.js
+++ b/packages/auto-approve/__snapshots__/auto-approve.test.js
@@ -1,185 +1,185 @@
 exports['auto-approve main auto-approve function config exists on main branch approves and tags a PR if a config exists & is valid & PR is valid 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "success",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "Successful auto-approve.yml config check",
-    "text": ""
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'success',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'Successful auto-approve.yml config check',
+    'text': ''
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch approves and tags a PR if a config exists & is valid & PR is valid 2'] = {
-  "event": "APPROVE"
+  'event': 'APPROVE'
 }
 
 exports['auto-approve main auto-approve function config exists on main branch still attempts to add an automerge: exact label if there is an approval 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "success",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "Successful auto-approve.yml config check",
-    "text": ""
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'success',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'Successful auto-approve.yml config check',
+    'text': ''
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch approves and tags a PR if everything is valid, and it is coming from a fork 1'] = {
-  "head_sha": "65f14b92a8135948008c6e26344167a2dac9f066",
-  "name": "Auto-approve.yml check",
-  "conclusion": "success",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "Successful auto-approve.yml config check",
-    "text": ""
+  'head_sha': '65f14b92a8135948008c6e26344167a2dac9f066',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'success',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'Successful auto-approve.yml config check',
+    'text': ''
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch approves and tags a PR if everything is valid, and it is coming from a fork 2'] = {
-  "event": "APPROVE"
+  'event': 'APPROVE'
 }
 
 exports['auto-approve main auto-approve function config exists on main branch retries if etag is not current 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "success",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "Successful auto-approve.yml config check",
-    "text": ""
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'success',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'Successful auto-approve.yml config check',
+    'text': ''
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch retries if etag is not current 2'] = {
-  "event": "APPROVE"
+  'event': 'APPROVE'
 }
 
 exports['auto-approve main auto-approve function config exists on main branch stops retrying to add the label after 3 attempts, even if it is never successful 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "success",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "Successful auto-approve.yml config check",
-    "text": ""
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'success',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'Successful auto-approve.yml config check',
+    'text': ''
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch stops retrying to add the label after 3 attempts, even if it is never successful 2'] = {
-  "event": "APPROVE"
+  'event': 'APPROVE'
 }
 
 exports['auto-approve main auto-approve function config exists on main branch submits a failing check if config exists but is not valid 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "failure",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "auto-approve.yml config check failed",
-    "text": "See the following errors in your auto-approve.yml config:\n[{\"wrongProperty\":\"wrongProperty\",\"message\":\"message\"}]\n"
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'failure',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'auto-approve.yml config check failed',
+    'text': 'See the following errors in your auto-approve.yml config:\n[{"wrongProperty":"wrongProperty","message":"message"}]\n'
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch logs to the console if config is valid but PR is not 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "success",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "Successful auto-approve.yml config check",
-    "text": ""
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'success',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'Successful auto-approve.yml config check',
+    'text': ''
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch will not check config on master if the config is modified on PR 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "failure",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "auto-approve.yml config check failed",
-    "text": "See the following errors in your auto-approve.yml config:\n\n"
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'failure',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'auto-approve.yml config check failed',
+    'text': 'See the following errors in your auto-approve.yml config:\n\n'
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch uses the correct function to check the PR if the config is V2 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "success",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "Successful auto-approve.yml config check",
-    "text": ""
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'success',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'Successful auto-approve.yml config check',
+    'text': ''
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch uses the correct function to check the PR if the config is V2 2'] = {
-  "event": "APPROVE"
+  'event': 'APPROVE'
 }
 
 exports['auto-approve main auto-approve function config exists on main branch uses the correct function to check the PR if the config is V1 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "success",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "Successful auto-approve.yml config check",
-    "text": ""
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'success',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'Successful auto-approve.yml config check',
+    'text': ''
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch uses the correct function to check the PR if the config is V1 2'] = {
-  "event": "APPROVE"
+  'event': 'APPROVE'
 }
 
 exports['auto-approve main auto-approve function config does not exist on main branch attempts to create a passing status check if PR contains correct config 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "success",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "Successful auto-approve.yml config check",
-    "text": ""
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'success',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'Successful auto-approve.yml config check',
+    'text': ''
   }
 }
 
 exports['auto-approve main auto-approve function config does not exist on main branch attempts to create a failing status check if PR contains wrong config, and error messages check out 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "failure",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "auto-approve.yml config check failed",
-    "text": "See the following errors in your auto-approve.yml config:\n[{\"wrongProperty\":\"wrongProperty\",\"message\":\"message\"}]\n"
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'failure',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'auto-approve.yml config check failed',
+    'text': 'See the following errors in your auto-approve.yml config:\n[{"wrongProperty":"wrongProperty","message":"message"}]\n'
   }
 }
 
 exports['auto-approve main auto-approve function config does not exist on main branch passes PR if auto-approve is on main, not PR 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "success",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "Successful auto-approve.yml config check",
-    "text": ""
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'success',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'Successful auto-approve.yml config check',
+    'text': ''
   }
 }
 
 exports['auto-approve main auto-approve function config does not exist on main branch passes PR if auto-approve is on main, not PR 2'] = {
-  "event": "APPROVE"
+  'event': 'APPROVE'
 }
 
 exports['auto-approve gets secrets and authenticates separately for approval creates a separate octokit instance and authenticates with secret in secret manager 1'] = {
-  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
-  "name": "Auto-approve.yml check",
-  "conclusion": "success",
-  "output": {
-    "title": "Auto-approve.yml check",
-    "summary": "Successful auto-approve.yml config check",
-    "text": ""
+  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
+  'name': 'Auto-approve.yml check',
+  'conclusion': 'success',
+  'output': {
+    'title': 'Auto-approve.yml check',
+    'summary': 'Successful auto-approve.yml config check',
+    'text': ''
   }
 }
 
 exports['auto-approve gets secrets and authenticates separately for approval creates a separate octokit instance and authenticates with secret in secret manager 2'] = {
-  "event": "APPROVE"
+  'event': 'APPROVE'
 }

--- a/packages/auto-approve/src/interfaces.ts
+++ b/packages/auto-approve/src/interfaces.ts
@@ -51,10 +51,10 @@ export interface FileRule {
 export interface Versions {
   oldDependencyName: string;
   newDependencyName: string;
-  oldMajorVersion: string;
-  oldMinorVersion: string;
-  newMajorVersion: string;
-  newMinorVersion: string;
+  oldMajorVersion?: string;
+  oldMinorVersion?: string;
+  newMajorVersion?: string;
+  newMinorVersion?: string;
 }
 
 /**

--- a/packages/auto-approve/src/process-checks/node/generator-dependency.ts
+++ b/packages/auto-approve/src/process-checks/node/generator-dependency.ts
@@ -107,7 +107,7 @@ export class NodeGeneratorDependency extends BaseLanguageRule {
         -      urls = ["https://github.com/protocolbuffers/protobuf/archive/v24.2.tar.gz"],
       */
       oldVersion:
-        /[\s]*name = "(@?\S*)",\n-[\s]*sha256 = "\S*",\n-[\s]*strip_prefix = "\w*-(\d*)\.(\d*|\d*\.\d*)",\n-[\s]*urls? = \S*/,
+        /[\s]*name = "(@?\S*)",\n-[\s]*sha256 = "\S*",\n-[\s]*strip_prefix = "\w*-(\d*)\.(\d*|\d*\.\d*)"/,
       /* This would match:
             name = "aspect_rules_js",
         -    anything,
@@ -117,7 +117,7 @@ export class NodeGeneratorDependency extends BaseLanguageRule {
         +    strip_prefix = "rules_js-1.30.0",
         +    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.30.0.tar.gz",
       */ newVersion:
-        /[\s]*name = "(@?\S*)",\n-.*\n-.*\n-.*\n\+[\s]*sha256 = "\S*",\n\+[\s]*strip_prefix = "\w*-(\d*)\.(\d*|\d*\.\d*)",\n\+[\s]*urls? = \S*/,
+        /[\s]*name = "(@?\S*)",\n-.*\n-.*\n-.*\n\+[\s]*sha256 = "\S*",\n\+[\s]*strip_prefix = "\w*-(\d*)\.(\d*|\d*\.\d*)"/,
     },
   ];
   constructor(octokit: Octokit) {

--- a/packages/auto-approve/src/utils-for-pr-checking.ts
+++ b/packages/auto-approve/src/utils-for-pr-checking.ts
@@ -194,7 +194,6 @@ export function getVersionsV2(
         : oldVersions[2];
   }
 
-
   if (newVersions) {
     newDependencyName = newVersions[1];
     newMajorVersion = newVersions[2];

--- a/packages/auto-approve/test/node-generator.test.ts
+++ b/packages/auto-approve/test/node-generator.test.ts
@@ -291,4 +291,199 @@ describe('behavior of Node Generator Dependency process', () => {
 
     assert.ok(await nodeDependency.checkPR(incomingPR));
   });
+
+  it('should allow for package-lock.json and yarn.locks to  be approved', async () => {
+    const incomingPR = {
+      author: 'renovate-bot',
+      title: 'chore(deps): update dependency @types/module-alias to ^2.0.4',
+      fileCount: 4,
+      changedFiles: [
+        {
+          sha: '47b7a23cfa41986bc1fbeb5f204a688c407bd662',
+          filename: 'package-lock.json',
+          status: 'modified',
+          additions: 4,
+          deletions: 4,
+          changes: 8,
+          blob_url:
+            'https://github.com/googleapis/gapic-generator-typescript/blob/fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4/package-lock.json',
+          raw_url:
+            'https://github.com/googleapis/gapic-generator-typescript/raw/fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4/package-lock.json',
+          contents_url:
+            'https://api.github.com/repos/googleapis/gapic-generator-typescript/contents/package-lock.json?ref=fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4',
+          patch:
+            '@@ -26,7 +26,7 @@\n' +
+            '       "devDependencies": {\n' +
+            '         "@bazel/bazelisk": "^1.18.0",\n' +
+            '         "@types/mocha": "^10.0.2",\n' +
+            '-        "@types/module-alias": "^2.0.2",\n' +
+            '+        "@types/module-alias": "^2.0.4",\n' +
+            '         "@types/node": "^18.11.18",\n' +
+            '         "@types/nunjucks": "^3.2.4",\n' +
+            '         "@types/object-hash": "^3.0.4",\n' +
+            '@@ -948,9 +948,9 @@\n' +
+            '       "dev": true\n' +
+            '     },\n' +
+            '     "node_modules/@types/module-alias": {\n' +
+            '-      "version": "2.0.2",\n' +
+            '-      "resolved": "https://registry.npmjs.org/@types/module-alias/-/module-alias-2.0.2.tgz",\n' +
+            '-      "integrity": "sha512-Oeo5NEjAceFgN8OzGiLXPswgv2GBmrDGuTnLS0sQ8g4Mq5sB5c97Hu5B+n9Gu/j+5Y+oUb4TSawHXkZ8MENGyw==",\n' +
+            '+      "version": "2.0.4",\n' +
+            '+      "resolved": "https://registry.npmjs.org/@types/module-alias/-/module-alias-2.0.4.tgz",\n' +
+            '+      "integrity": "sha512-5+G/QXO/DvHZw60FjvbDzO4JmlD/nG5m2/vVGt25VN1eeP3w2bCoks1Wa7VuptMPM1TxJdx6RjO70N9Fw0nZPA==",\n' +
+            '       "dev": true\n' +
+            '     },\n' +
+            '     "node_modules/@types/node": {',
+        },
+        {
+          sha: '9e843cbdfa997155d1fbd69e1e288862460191dd',
+          filename: 'package.json',
+          status: 'modified',
+          additions: 1,
+          deletions: 1,
+          changes: 2,
+          blob_url:
+            'https://github.com/googleapis/gapic-generator-typescript/blob/fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4/package.json',
+          raw_url:
+            'https://github.com/googleapis/gapic-generator-typescript/raw/fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4/package.json',
+          contents_url:
+            'https://api.github.com/repos/googleapis/gapic-generator-typescript/contents/package.json?ref=fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4',
+          patch:
+            '@@ -54,7 +54,7 @@\n' +
+            '   "devDependencies": {\n' +
+            '     "@bazel/bazelisk": "^1.18.0",\n' +
+            '     "@types/mocha": "^10.0.2",\n' +
+            '-    "@types/module-alias": "^2.0.2",\n' +
+            '+    "@types/module-alias": "^2.0.4",\n' +
+            '     "@types/node": "^18.11.18",\n' +
+            '     "@types/nunjucks": "^3.2.4",\n' +
+            '     "@types/object-hash": "^3.0.4",',
+        },
+        {
+          sha: '4a9621187881844d2e22fd6b91bbea7c1bfecd4a',
+          filename: 'pnpm-lock.yaml',
+          status: 'modified',
+          additions: 4,
+          deletions: 4,
+          changes: 8,
+          blob_url:
+            'https://github.com/googleapis/gapic-generator-typescript/blob/fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4/pnpm-lock.yaml',
+          raw_url:
+            'https://github.com/googleapis/gapic-generator-typescript/raw/fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4/pnpm-lock.yaml',
+          contents_url:
+            'https://api.github.com/repos/googleapis/gapic-generator-typescript/contents/pnpm-lock.yaml?ref=fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4',
+          patch:
+            '@@ -41,8 +41,8 @@ devDependencies:\n' +
+            '     specifier: ^10.0.2\n' +
+            '     version: 10.0.2\n' +
+            "   '@types/module-alias':\n" +
+            '-    specifier: ^2.0.2\n' +
+            '-    version: 2.0.2\n' +
+            '+    specifier: ^2.0.4\n' +
+            '+    version: 2.0.4\n' +
+            "   '@types/node':\n" +
+            '     specifier: ^18.11.18\n' +
+            '     version: 18.13.0\n' +
+            '@@ -550,8 +550,8 @@ packages:\n' +
+            '     resolution: {integrity: sha512-NaHL0+0lLNhX6d9rs+NSt97WH/gIlRHmszXbQ/8/MV/eVcFNdeJ/GYhrFuUc8K7WuPhRhTSdMkCp8VMzhUq85w==}\n' +
+            '     dev: true\n' +
+            ' \n' +
+            '-  /@types/module-alias@2.0.2:\n' +
+            '-    resolution: {integrity: sha512-Oeo5NEjAceFgN8OzGiLXPswgv2GBmrDGuTnLS0sQ8g4Mq5sB5c97Hu5B+n9Gu/j+5Y+oUb4TSawHXkZ8MENGyw==}\n' +
+            '+  /@types/module-alias@2.0.4:\n' +
+            '+    resolution: {integrity: sha512-5+G/QXO/DvHZw60FjvbDzO4JmlD/nG5m2/vVGt25VN1eeP3w2bCoks1Wa7VuptMPM1TxJdx6RjO70N9Fw0nZPA==}\n' +
+            '     dev: true\n' +
+            ' \n' +
+            '   /@types/node@18.13.0:',
+        },
+        {
+          sha: '7d38d61b7d2ed761db882221e05129582a6a952b',
+          filename: 'yarn.lock',
+          status: 'modified',
+          additions: 4,
+          deletions: 4,
+          changes: 8,
+          blob_url:
+            'https://github.com/googleapis/gapic-generator-typescript/blob/fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4/yarn.lock',
+          raw_url:
+            'https://github.com/googleapis/gapic-generator-typescript/raw/fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4/yarn.lock',
+          contents_url:
+            'https://api.github.com/repos/googleapis/gapic-generator-typescript/contents/yarn.lock?ref=fa9de0ca47f16632a766dfe2a3693e6ebbbcf3e4',
+          patch:
+            '@@ -498,10 +498,10 @@\n' +
+            '   resolved "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.2.tgz"\n' +
+            '   integrity sha512-NaHL0+0lLNhX6d9rs+NSt97WH/gIlRHmszXbQ/8/MV/eVcFNdeJ/GYhrFuUc8K7WuPhRhTSdMkCp8VMzhUq85w==\n' +
+            ' \n' +
+            '-"@types/module-alias@^2.0.2":\n' +
+            '-  version "2.0.2"\n' +
+            '-  resolved "https://registry.npmjs.org/@types/module-alias/-/module-alias-2.0.2.tgz"\n' +
+            '-  integrity sha512-Oeo5NEjAceFgN8OzGiLXPswgv2GBmrDGuTnLS0sQ8g4Mq5sB5c97Hu5B+n9Gu/j+5Y+oUb4TSawHXkZ8MENGyw==\n' +
+            '+"@types/module-alias@^2.0.4":\n' +
+            '+  version "2.0.4"\n' +
+            '+  resolved "https://registry.npmjs.org/@types/module-alias/-/module-alias-2.0.4.tgz"\n' +
+            '+  integrity sha512-5+G/QXO/DvHZw60FjvbDzO4JmlD/nG5m2/vVGt25VN1eeP3w2bCoks1Wa7VuptMPM1TxJdx6RjO70N9Fw0nZPA==\n' +
+            ' \n' +
+            ' "@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^18.11.18":\n' +
+            '   version "18.17.14"',
+        },
+      ],
+      repoName: 'testRepoName',
+      repoOwner: 'testRepoOwner',
+      prNumber: 1,
+      body: 'body',
+    };
+    const nodeDependency = new NodeGeneratorDependency(octokit);
+
+    assert.ok(await nodeDependency.checkPR(incomingPR));
+  });
+
+  it('should update ci.yaml files', async () => {
+    const incomingPR = {
+      author: 'renovate-bot',
+      title: 'chore(deps): update actions/checkout digest to b4ffde6',
+      fileCount: 1,
+      changedFiles: [
+        {
+          sha: '988992a0b7d84efc67acb03c0b14314d1d4f6918',
+          filename: '.github/workflows/ci.yaml',
+          status: 'modified',
+          additions: 2,
+          deletions: 2,
+          changes: 4,
+          blob_url:
+            'https://github.com/googleapis/gapic-generator-typescript/blob/83bc0cb7d92a992d4c9a5e493ca55c70ce31a6c0/.github%2Fworkflows%2Fci.yaml',
+          raw_url:
+            'https://github.com/googleapis/gapic-generator-typescript/raw/83bc0cb7d92a992d4c9a5e493ca55c70ce31a6c0/.github%2Fworkflows%2Fci.yaml',
+          contents_url:
+            'https://api.github.com/repos/googleapis/gapic-generator-typescript/contents/.github%2Fworkflows%2Fci.yaml?ref=83bc0cb7d92a992d4c9a5e493ca55c70ce31a6c0',
+          patch:
+            '@@ -16,7 +16,7 @@ jobs:\n' +
+            '     # time.\n' +
+            ' \n' +
+            '     steps:\n' +
+            '-    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4\n' +
+            '+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4\n' +
+            ' \n' +
+            '     - name: Cache Bazel files\n' +
+            '       id: cache-bazel\n' +
+            '@@ -142,7 +142,7 @@ jobs:\n' +
+            '   lint:\n' +
+            '     runs-on: ubuntu-latest\n' +
+            '     steps:\n' +
+            '-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4\n' +
+            '+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4\n' +
+            '       - uses: actions/setup-node@v3\n' +
+            '         with:\n' +
+            '           node-version: 14',
+        },
+      ],
+      repoName: 'testRepoName',
+      repoOwner: 'testRepoOwner',
+      prNumber: 1,
+      body: 'body',
+    };
+    const nodeDependency = new NodeGeneratorDependency(octokit);
+
+    assert.ok(await nodeDependency.checkPR(incomingPR));
+  });
 });


### PR DESCRIPTION
I went through all of the PRs open in the generator today to see why auto-approve wasn't merging a large portion of them: https://github.com/googleapis/gapic-generator-typescript/pulls

Two main use cases stood out to me: 

1. We update lock-files when we update deps
2. We sometimes update sha's that don't have a corresponding major or minor version ([example](https://github.com/googleapis/gapic-generator-typescript/pull/1491))


This PR updates those use cases.