### PR TITLE
fix(deps): update releasetool to 1.17.0

### DIFF
--- a/packages/release-trigger/requirements.in
+++ b/packages/release-trigger/requirements.in
@@ -1,2 +1,2 @@
-gcp-releasetool>=1.16.0
+gcp-releasetool>=1.17.0
 keyrings.alt

--- a/packages/release-trigger/requirements.txt
+++ b/packages/release-trigger/requirements.txt
@@ -117,9 +117,9 @@ cryptography==41.0.6 \
     # via
     #   gcp-releasetool
     #   secretstorage
-gcp-releasetool==1.16.0 \
-    --hash=sha256:27bf19d2e87aaa884096ff941aa3c592c482be3d6a2bfe6f06afafa6af2353e3 \
-    --hash=sha256:a316b197a543fd036209d0caba7a8eb4d236d8e65381c80cbc6d7efaa7606d63
+gcp-releasetool==1.17.0 \
+    --hash=sha256:1a759f4b0906f4ea9dc7db3649aa11a632c72f6dc6a54f10cf57c1925d034a1c \
+    --hash=sha256:f23db51d85484998af5549181be726f177bf90b481de238fe7a99ec970266b6b
     # via -r requirements.in
 google-auth==2.15.0 \
     --hash=sha256:6897b93556d8d807ad70701bb89f000183aea366ca7ed94680828b37437a4994 \


### PR DESCRIPTION
## [1.17.0](https://github.com/googleapis/releasetool/compare/v1.16.0...v1.17.0) (2024-01-17)


### Features

* Add appengine-plugins to repo list ([#530](https://github.com/googleapis/releasetool/issues/530)) ([ae19e0e](https://github.com/googleapis/releasetool/commit/ae19e0e11d4d060599992b326af4a7ef21b7baf5))
* Update PHP tags ([#518](https://github.com/googleapis/releasetool/issues/518)) ([cdc159b](https://github.com/googleapis/releasetool/commit/cdc159ba86c22be9d6eba64a1b69f14200bcd4eb))
