### PR TITLE
fix(owl-bot): ignore non-cloud php repos

### DIFF
--- a/packages/owl-bot/src/should-ignore-repo.ts
+++ b/packages/owl-bot/src/should-ignore-repo.ts
@@ -32,6 +32,6 @@ export function shouldIgnoreRepo(ownerSlashRepo: string): boolean {
   // subdirectories of google-cloud-php and never accept pull requests.
   const regexp = process.env.IGNORE_REPO_REGEXP
     ? new RegExp(process.env.IGNORE_REPO_REGEXP)
-    : /googleapis\/(googleapis(-gen)?|google-cloud-php-.+)/;
+    : /googleapis\/(googleapis(-gen)?|google-cloud-php-.+|php-.+)/;
   return regexp.test(ownerSlashRepo);
 }

--- a/packages/owl-bot/test/should-ignore-repo.ts
+++ b/packages/owl-bot/test/should-ignore-repo.ts
@@ -26,6 +26,9 @@ describe('shouldIgnoreRepo', () => {
   it('ignores PHP sharded repo', () => {
     assert.ok(shouldIgnoreRepo('googleapis/google-cloud-php-asset'));
   });
+  it('ignores non-cloud PHP sharded repo', () => {
+    assert.ok(shouldIgnoreRepo('googleapis/php-shopping-merchant-reports'));
+  });
   it("doesn't ignore PHP root repo", () => {
     assert.ok(!shouldIgnoreRepo('googleapis/google-cloud-php'));
   });


### PR DESCRIPTION
owl-bot is opening some PRs against sharded, non-php repos. We should not be opening copy-code PRs against these repos.

example: https://github.com/googleapis/php-shopping-merchant-reports/pull/5

These repos `googleapis/php-<something>`, are non-cloud and split of the primary PHP monorepo `googleapis/google-cloud-php`.
