### PR TITLE
feat: require node 18 for owl-bot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
-          node-version: ${{ (endsWith(matrix.package, '-utils') || matrix.package == 'canary-bot' || matrix.package == 'datastore-lock' || matrix.package == 'object-selector' || matrix.package == 'release-please' ) && 18 || 14 }}
+          node-version: ${{ (endsWith(matrix.package, '-utils') || matrix.package == 'canary-bot' || matrix.package == 'datastore-lock' || matrix.package == 'object-selector' || matrix.package == 'release-please' || matrix.package == 'owl-bot' ) && 18 || 14 }}
       - run: echo ./packages/${{ matrix.package }}
       - run: cd ./packages/${{ matrix.package }}
       - run: npm ci

--- a/packages/owl-bot/package-lock.json
+++ b/packages/owl-bot/package-lock.json
@@ -60,7 +60,7 @@
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       },
       "optionalDependencies": {
         "fsevents": "*"
@@ -1047,11 +1047,11 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
-      "integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
       "dependencies": {
-        "@octokit/types": "^7.0.0",
+        "@octokit/types": "^9.0.0",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -1059,12 +1059,17 @@
         "node": ">= 14"
       }
     },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
+      "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw=="
+    },
     "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.1.tgz",
-      "integrity": "sha512-Zk4OUMLCSpXNI8KZZn47lVLJSsgMyCimsWWQI5hyjZg7hdYm0kjotaIkbG0Pp8SfU2CofMBzonboTqvzn3FrJA==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
       "dependencies": {
-        "@octokit/openapi-types": "^13.11.0"
+        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/graphql": {
@@ -9838,21 +9843,26 @@
       }
     },
     "@octokit/endpoint": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
-      "integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
       "requires": {
-        "@octokit/types": "^7.0.0",
+        "@octokit/types": "^9.0.0",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "18.1.1",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
+          "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw=="
+        },
         "@octokit/types": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.1.tgz",
-          "integrity": "sha512-Zk4OUMLCSpXNI8KZZn47lVLJSsgMyCimsWWQI5hyjZg7hdYm0kjotaIkbG0Pp8SfU2CofMBzonboTqvzn3FrJA==",
+          "version": "9.3.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
           "requires": {
-            "@octokit/openapi-types": "^13.11.0"
+            "@octokit/openapi-types": "^18.0.0"
           }
         }
       }

--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -8,7 +8,7 @@
     "build/src"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "start-backend": "node ./build/src/server-backend.js",
@@ -19,7 +19,7 @@
     "fix": "gts fix",
     "lint": "gts check",
     "mocha": "npm run compile && c8 mocha build/test",
-    "test": "c8 mocha build/test && node ./build/src/bin/owl-bot.js --help",
+    "test": "c8 mocha --node-option no-experimental-fetch build/test && node ./build/src/bin/owl-bot.js --help",
     "system-test": "c8 mocha build/system-test",
     "pretest": "npm run compile",
     "presystem-test": "npm run compile",


### PR DESCRIPTION
Fixes #5295 

deps: update `@octokit/endpoint` to v7
build: test owl-bot against node 18
ci: use `no-experimental-fetch` for nock/node18 compatibility