### PR TITLE
fix: add correct file extension to gs log url

### DIFF
--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -185,7 +185,7 @@ function summarizeBuild(
     text = `successfully ran ${build.steps.length} steps 🎉!`;
   }
   if (build.logsBucket) {
-    text += `\nView the full log at ${build.logsBucket}/log-${build.id}`;
+    text += `\nView the full log at ${build.logsBucket}/log-${build.id}.txt`;
   }
   return {
     conclusion,

--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -185,7 +185,7 @@ function summarizeBuild(
     text = `successfully ran ${build.steps.length} steps 🎉!`;
   }
   if (build.logsBucket) {
-    text += `\nView the full log at ${build.logsBucket}/log-${build.id}.txt`;
+    text += `\nView the full log at ${build.logsBucket}/log-${build.id}.txt\n`;
   }
   return {
     conclusion,


### PR DESCRIPTION
The logs url is a `.txt` file. Also add a newline for formatting