### PR TITLE
feat: add ability to comment on pull request

### DIFF
--- a/packages/trusted-contribution/.eslintrc.json
+++ b/packages/trusted-contribution/.eslintrc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "./node_modules/gts",
+  "root": true
 }

--- a/packages/trusted-contribution/README.md
+++ b/packages/trusted-contribution/README.md
@@ -18,26 +18,31 @@ To configure the bot, you can create a configuration file:
 `.github/trusted-contribution.yml`. The contents of this file allow for the following
 options:
 
-| Name | Description | Type | Default |
-|----- | ----------- | ---- | ------- |
-| `trustedContributors` | List of user login names that are considered trusted  | `string[]` | `['renovate-bot', 'release-please[bot]', 'gcf-merge-on-green[bot]']` |
-| `annotations` | The list of annotation objects to leave the on the PR | `object` | `{ type: 'label'; text: 'kokoro:force-run' }` |
-| `annotation.type` | Configure the bot to either comment on the PR or add a label | `comment`|`label` | `label` |
-| `annotation.text` | The label text or comment text to be left on the PR | `string` | `kokoro:force-run`
+| Name                  | Description                                                        | Type       | Default                                                              |
+| --------------------- | ------------------------------------------------------------------ | ---------- | -------------------------------------------------------------------- |
+| `trustedContributors` | List of user login names that are considered trusted               | `string[]` | `['renovate-bot', 'release-please[bot]', 'gcf-merge-on-green[bot]']` |
+| `commentInstructions` | Whether to comment on the PR with instructions for the maintainers | `boolean`  | `false`                                                              |
+| `annotations`         | The list of annotation objects to leave the on the PR              | `object`   | `{ type: 'label'; text: 'kokoro:force-run' }`                        |
+| `annotation.type`     | Configure the bot to either comment on the PR or add a label       | `comment`  | `label`                                                              |
+| `annotation.text`     | The label text or comment text to be left on the PR                | `string`   | `kokoro:force-run`                                                   |
 
 ## Deployment and Permissions
 
 ### Repository permissions
+
 - metadata - read
 - pull requests - read & write
 
 ### Organization permissions
+
 - None
 
 ### User permissions
+
 - None
 
 ## Subscribe to events
+
 - pull request
 
 ## Testing

--- a/packages/trusted-contribution/__snapshots__/comments.js
+++ b/packages/trusted-contribution/__snapshots__/comments.js
@@ -1,0 +1,19 @@
+exports['buildComment should build instructions for a label 1'] = `
+Reviewers, you may need to add the \`kokoro: run\` label to this pull request.
+`
+
+exports['buildComment should build instructions for a comment 1'] = `
+Reviewers, you may need to comment on this pull request with \`/gcbrun\`.
+`
+
+exports['buildComment should build instructions for 2 things 1'] = `
+Reviewers, you may need to add the \`kokoro: run\` label to this pull request and comment on this pull request with \`/gcbrun\`.
+`
+
+exports['buildComment should build instructions for 3 things 1'] = `
+Reviewers, you may need to add the \`kokoro: run\` label to this pull request, add the \`kokoro: force-run\` label to this pull request, and comment on this pull request with \`/gcbrun\`.
+`
+
+exports['buildComment should build instructions for multiple things as array 1'] = `
+Reviewers, you may need to add the \`kokoro: run\` label to this pull request, add the \`kokoro: force-run\` label to this pull request, and comment on this pull request with \`/gcbrun\`.
+`

--- a/packages/trusted-contribution/package-lock.json
+++ b/packages/trusted-contribution/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@google-automations/bot-config-utils": "^6.1.0",
+        "@google-automations/issue-utils": "^3.0.0",
         "@google-cloud/secret-manager": "^4.1.2",
         "gcf-utils": "^14.2.0",
         "jsonwebtoken": "^9.0.0"
@@ -292,6 +293,100 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/@google-automations/issue-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-automations/issue-utils/-/issue-utils-3.0.0.tgz",
+      "integrity": "sha512-6fEd63rw4HOAS6YG5w/rVR2ExWocre0+HysVTv0DsFKdIYiRLENWe6F96lNCXi6kq37dO7FUE9rw8JLdlojm5Q==",
+      "dependencies": {
+        "gcf-utils": "^15.0.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@google-automations/issue-utils/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@google-automations/issue-utils/node_modules/gcf-utils": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-15.0.1.tgz",
+      "integrity": "sha512-UHxvXGoX/4k4JIAH9PHV7CB+J5wmT6KAJR/X4PxibQZ3Lp8M4AeKsg/6p2KLLdsftxFg8N+ss+iUnQ0PYWt0EQ==",
+      "dependencies": {
+        "@google-cloud/kms": "^3.0.1",
+        "@google-cloud/run": "^0.3.0",
+        "@google-cloud/secret-manager": "^4.1.2",
+        "@google-cloud/storage": "^6.4.1",
+        "@google-cloud/tasks": "^3.0.2",
+        "@octokit/auth-app": "^4.0.5",
+        "@octokit/plugin-enterprise-compatibility": "^2.0.3",
+        "@octokit/rest": "^19.0.4",
+        "@octokit/types": "^9.0.0",
+        "@probot/octokit-plugin-config": "^1.1.6",
+        "@types/bunyan": "^1.8.8",
+        "@types/dotenv": "^6.1.1",
+        "@types/end-of-stream": "^1.4.1",
+        "@types/express": "^4.17.13",
+        "@types/into-stream": "^3.1.1",
+        "@types/ioredis": "^4.28.10",
+        "@types/sonic-boom": "^2.1.0",
+        "@types/uuid": "^9.0.0",
+        "body-parser": "^1.20.0",
+        "express": "^4.18.1",
+        "gaxios": "^5.0.1",
+        "get-stream": "^6.0.1",
+        "google-gax": "^3.5.2",
+        "into-stream": "^6.0.0",
+        "jsonwebtoken": "^9.0.0",
+        "octokit-auth-probot": "^1.2.8",
+        "pino": "^8.4.2",
+        "probot": "^12.2.7",
+        "tmp": "^0.2.1",
+        "uuid": "^9.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "genkey": "build/src/bin/genkey.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@google-automations/issue-utils/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@google-automations/issue-utils/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@google-cloud/kms": {
@@ -8464,6 +8559,84 @@
         "gcf-utils": "^14.0.1",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.0"
+      }
+    },
+    "@google-automations/issue-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-automations/issue-utils/-/issue-utils-3.0.0.tgz",
+      "integrity": "sha512-6fEd63rw4HOAS6YG5w/rVR2ExWocre0+HysVTv0DsFKdIYiRLENWe6F96lNCXi6kq37dO7FUE9rw8JLdlojm5Q==",
+      "requires": {
+        "gcf-utils": "^15.0.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "gcf-utils": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-15.0.1.tgz",
+          "integrity": "sha512-UHxvXGoX/4k4JIAH9PHV7CB+J5wmT6KAJR/X4PxibQZ3Lp8M4AeKsg/6p2KLLdsftxFg8N+ss+iUnQ0PYWt0EQ==",
+          "requires": {
+            "@google-cloud/kms": "^3.0.1",
+            "@google-cloud/run": "^0.3.0",
+            "@google-cloud/secret-manager": "^4.1.2",
+            "@google-cloud/storage": "^6.4.1",
+            "@google-cloud/tasks": "^3.0.2",
+            "@octokit/auth-app": "^4.0.5",
+            "@octokit/plugin-enterprise-compatibility": "^2.0.3",
+            "@octokit/rest": "^19.0.4",
+            "@octokit/types": "^9.0.0",
+            "@probot/octokit-plugin-config": "^1.1.6",
+            "@types/bunyan": "^1.8.8",
+            "@types/dotenv": "^6.1.1",
+            "@types/end-of-stream": "^1.4.1",
+            "@types/express": "^4.17.13",
+            "@types/into-stream": "^3.1.1",
+            "@types/ioredis": "^4.28.10",
+            "@types/sonic-boom": "^2.1.0",
+            "@types/uuid": "^9.0.0",
+            "body-parser": "^1.20.0",
+            "express": "^4.18.1",
+            "gaxios": "^5.0.1",
+            "get-stream": "^6.0.1",
+            "google-gax": "^3.5.2",
+            "into-stream": "^6.0.0",
+            "jsonwebtoken": "^9.0.0",
+            "octokit-auth-probot": "^1.2.8",
+            "pino": "^8.4.2",
+            "probot": "^12.2.7",
+            "tmp": "^0.2.1",
+            "uuid": "^9.0.0",
+            "yargs": "^17.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+        }
       }
     },
     "@google-cloud/kms": {

--- a/packages/trusted-contribution/package.json
+++ b/packages/trusted-contribution/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@google-automations/bot-config-utils": "^6.1.0",
+    "@google-automations/issue-utils": "^3.0.0",
     "@google-cloud/secret-manager": "^4.1.2",
     "gcf-utils": "^14.2.0",
     "jsonwebtoken": "^9.0.0"

--- a/packages/trusted-contribution/src/comments.ts
+++ b/packages/trusted-contribution/src/comments.ts
@@ -1,0 +1,69 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ConfigurationOptions} from './config';
+
+const CONTRIBUTOR_AUTHOR_ASSOCIATIONS = new Set(['OWNER', 'COLLABORATOR']);
+/**
+ * Determine whether or not the PR author is considered a repository contributor.
+ *
+ * @param {string} authorAssociation The type of user that the PR author is
+ * @return {boolean} Whether or not the author is considered a repository contributor
+ */
+export function isContributor(authorAssociation: string): boolean {
+  return CONTRIBUTOR_AUTHOR_ASSOCIATIONS.has(authorAssociation);
+}
+
+/**
+ * For a given configuration, build instructions for what labels/comments a
+ * maintainer should make to do the equivalent of what this bot would do if
+ * the contributor was trusted.
+ *
+ * @param {ConfigurationOptions} configuration The bot configuration
+ * @return {string|undefined} Returns undefined if no comment should be made.
+ *   Otherwise returns a string message to comment.
+ */
+export function buildComment(
+  configuration: ConfigurationOptions
+): string | undefined {
+  const annotations = configuration.annotations ?? [];
+  const activities: string[] = [];
+  for (const annotation of annotations) {
+    // The annotation text could be a string or array of strings. Normalize to
+    // an array of strings and enumerate.
+    const textEntries =
+      typeof annotation.text === 'string' ? [annotation.text] : annotation.text;
+    for (const textEntry of textEntries) {
+      if (annotation.type === 'comment') {
+        activities.push(`comment on this pull request with \`${textEntry}\``);
+      } else if (annotation.type === 'label') {
+        activities.push(`add the \`${textEntry}\` label to this pull request`);
+      }
+    }
+  }
+  if (activities.length === 0) {
+    return undefined;
+  }
+  // oxford comma
+  const activityList =
+    activities.length === 2
+      ? activities.join(' and ')
+      : activities.length > 2
+      ? activities
+          .slice(0, activities.length - 1)
+          .concat(`and ${activities.slice(-1)}`)
+          .join(', ')
+      : activities.join(', ');
+  return `Reviewers, you may need to ${activityList}.`;
+}

--- a/packages/trusted-contribution/src/config-schema.json
+++ b/packages/trusted-contribution/src/config-schema.json
@@ -1,47 +1,58 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "trusted-contribution config",
-    "description": "Schema for defining the trusted-contribution config",
-    "additionalProperties": false,
-    "type": "object",
-    "definitions": {
-	"Annotation": {
-	    "additionalProperties": false,
-	    "required": ["type", "text"],
-	    "type": "object",
-	    "properties": {
-		"type": {
-		    "enum": ["comment", "label"]
-		},
-		"text":{
-			"oneOf": [
-				{"type": "string"},
-				{
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			]
-		}
-	    }
-	}
-    },
-    "properties": {
-	"trustedContributors": {
-	    "type": "array",
-	    "items": {
-		"type": "string"
-	    }
-	},
-	"annotations": {
-	    "type": "array",
-	    "items": {
-		"$ref": "#/definitions/Annotation"
-	    }
-	},
-	"disabled": {
-	    "type": "boolean"
-	}
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "trusted-contribution config",
+  "description": "Schema for defining the trusted-contribution config",
+  "additionalProperties": false,
+  "type": "object",
+  "definitions": {
+    "Annotation": {
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "text"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "comment",
+            "label"
+          ]
+        },
+        "text": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      }
     }
+  },
+  "properties": {
+    "trustedContributors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "annotations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Annotation"
+      }
+    },
+    "disabled": {
+      "type": "boolean"
+    },
+    "commentInstructions": {
+      "type": "boolean"
+    }
+  }
 }

--- a/packages/trusted-contribution/src/config.ts
+++ b/packages/trusted-contribution/src/config.ts
@@ -21,6 +21,7 @@ export interface ConfigurationOptions {
   trustedContributors?: string[];
   annotations?: Annotation[];
   disabled?: boolean;
+  commentInstructions?: boolean;
 }
 
 export const WELL_KNOWN_CONFIGURATION_FILE = 'trusted-contribution.yml';

--- a/packages/trusted-contribution/test/comments.ts
+++ b/packages/trusted-contribution/test/comments.ts
@@ -1,0 +1,79 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it} from 'mocha';
+import snapshot from 'snap-shot-it';
+import assert from 'assert';
+import {buildComment} from '../src/comments';
+import {ConfigurationOptions} from '../src/config';
+
+describe('buildComment', () => {
+  it('skips if there are no annotations', () => {
+    const configuration: ConfigurationOptions = {
+      annotations: [],
+    };
+    const comment = buildComment(configuration);
+    assert.strictEqual(comment, undefined);
+  });
+  it('should build instructions for a label', () => {
+    const configuration: ConfigurationOptions = {
+      annotations: [{type: 'label', text: 'kokoro: run'}],
+    };
+    const comment = buildComment(configuration);
+    assert.ok(comment);
+    snapshot(comment);
+  });
+  it('should build instructions for a comment', () => {
+    const configuration: ConfigurationOptions = {
+      annotations: [{type: 'comment', text: '/gcbrun'}],
+    };
+    const comment = buildComment(configuration);
+    assert.ok(comment);
+    snapshot(comment);
+  });
+  it('should build instructions for 2 things', () => {
+    const configuration: ConfigurationOptions = {
+      annotations: [
+        {type: 'label', text: 'kokoro: run'},
+        {type: 'comment', text: '/gcbrun'},
+      ],
+    };
+    const comment = buildComment(configuration);
+    assert.ok(comment);
+    snapshot(comment);
+  });
+  it('should build instructions for 3 things', () => {
+    const configuration: ConfigurationOptions = {
+      annotations: [
+        {type: 'label', text: 'kokoro: run'},
+        {type: 'label', text: 'kokoro: force-run'},
+        {type: 'comment', text: '/gcbrun'},
+      ],
+    };
+    const comment = buildComment(configuration);
+    assert.ok(comment);
+    snapshot(comment);
+  });
+  it('should build instructions for multiple things as array', () => {
+    const configuration: ConfigurationOptions = {
+      annotations: [
+        {type: 'label', text: ['kokoro: run', 'kokoro: force-run']},
+        {type: 'comment', text: '/gcbrun'},
+      ],
+    };
+    const comment = buildComment(configuration);
+    assert.ok(comment);
+    snapshot(comment);
+  });
+});

--- a/packages/trusted-contribution/test/fixtures/comments.yml
+++ b/packages/trusted-contribution/test/fixtures/comments.yml
@@ -1,0 +1,5 @@
+annotations:
+  - type: 'label'
+    text:
+      'kokoro:force-run'
+commentInstructions: true


### PR DESCRIPTION
Fixes #5307

Adds a new `commentInstructions` boolean configuration for the bot (opt-in feature). If set and the PR author is not "trusted", comment on the PR with reminder instructions for the maintainers on how to apply labels/comment in order to trigger CI (whatever the bot would do for a trusted contributor).
