### PR TITLE
fix: make sure regex checking is at the start of the title, and that test catches it appropriately

### DIFF
--- a/packages/auto-approve/src/process-checks/node/owlbot-template-changes.ts
+++ b/packages/auto-approve/src/process-checks/node/owlbot-template-changes.ts
@@ -38,7 +38,7 @@ export class OwlBotTemplateChangesNode extends OwlBotTemplateChanges {
     // For this particular rule, we want to check a pattern and an antipattern;
     // we want it to start with regular commit convention,
     // and it should not be breaking or fix or feat
-    titleRegex: /$(chore|build|tests|refactor)/,
+    titleRegex: /^(chore|build|tests|refactor)/,
     titleRegexExclude: /(fix|feat|breaking|!)/,
     bodyRegex: /PiperOrigin-RevId/,
   };
@@ -106,8 +106,8 @@ export class OwlBotTemplateChangesNode extends OwlBotTemplateChanges {
         authorshipMatches,
         titleMatches,
         !bodyMatches,
-        otherOwlBotPRs,
-        otherCommitAuthors,
+        !otherOwlBotPRs,
+        !otherCommitAuthors,
       ],
       incomingPR.repoOwner,
       incomingPR.repoName,

--- a/packages/auto-approve/test/node-owlbot-template-changes.test.ts
+++ b/packages/auto-approve/test/node-owlbot-template-changes.test.ts
@@ -223,7 +223,7 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
 
     assert.deepStrictEqual(
       await owlBotTemplateChanges.checkPR(incomingPR),
-      false
+      true
     );
     scopes.forEach(scope => scope.done());
   });


### PR DESCRIPTION
Also, make logging a little less confusing. Instead of saying:

```
{"severity":"INFO","level":30,"message":"Check otherOwlBotPRs for testRepoOwner/testRepoName/1 for no particular file is false"} // which means there are no otherowlbotPRs, so the check passes
{"severity":"INFO","level":30,"message":"Check otherCommitAuthors for testRepoOwner/testRepoName/1 for no particular file is false"} // which means there are no otherowlbotPRs, so the check passes
```

say:

```{"severity":"INFO","level":30,"message":"Check otherOwlBotPRs for testRepoOwner/testRepoName/1 for no particular file is true"} 
{"severity":"INFO","level":30,"message":"Check otherCommitAuthors for testRepoOwner/testRepoName/1 for no particular file is true"}```
