### PR TITLE
feat: add owlbot PRs process check for Node

### DIFF
--- a/packages/auto-approve/README.md
+++ b/packages/auto-approve/README.md
@@ -34,6 +34,7 @@ processes:
   - "JavaSampleAppDependency"
   - "NodeGeneratorDependency"
   - "OwlBotTemplateChangesNode"
+  - "OwlBotPRsNode"
 ```
 
 These processes represent different workflows for what auto-approve will approve and merge in a given repository. To see their logic in full, see the corresponding file in /src/process-checks.
@@ -193,6 +194,13 @@ Below is what each process checks for:
   - Checks that the title of the PR does NOT include BREAKING, feat, fix, !
   - Checks that the title of the PR starts with chore, build, test, refactor
   - Checks that the body of the PR does not contain 'PiperOrigin-RevId'
+  - Checks that the PR is the first of owlbot PRs in the repo (so that they are not merged out of order)
+  - Checks that there are no other commit authors other than owlbot on the repo
+* OwlBotPRsNode:
+  - Checks that the author is 'gcf-owl-bot[bot]'
+  - Checks that the title of the PR does NOT include BREAKING, feat, fix, !
+  - Checks that the title of the PR starts with chore, build, test, refactor
+  - Checks that the body of the PR DOES contain 'PiperOrigin-RevId'
   - Checks that the PR is the first of owlbot PRs in the repo (so that they are not merged out of order)
   - Checks that there are no other commit authors other than owlbot on the repo
   

--- a/packages/auto-approve/README.md
+++ b/packages/auto-approve/README.md
@@ -198,8 +198,8 @@ Below is what each process checks for:
   - Checks that there are no other commit authors other than owlbot on the repo
 * OwlBotPRsNode:
   - Checks that the author is 'gcf-owl-bot[bot]'
-  - Checks that the title of the PR does NOT include BREAKING, feat, fix, !
-  - Checks that the title of the PR starts with chore, build, test, refactor
+  - Checks that the title of the PR does NOT include BREAKING, !
+  - Checks that the title of the PR starts with chore, build, test, refactor, feat, fix,
   - Checks that the body of the PR DOES contain 'PiperOrigin-RevId'
   - Checks that the PR is the first of owlbot PRs in the repo (so that they are not merged out of order)
   - Checks that there are no other commit authors other than owlbot on the repo

--- a/packages/auto-approve/__snapshots__/auto-approve.test.js
+++ b/packages/auto-approve/__snapshots__/auto-approve.test.js
@@ -1,185 +1,185 @@
 exports['auto-approve main auto-approve function config exists on main branch approves and tags a PR if a config exists & is valid & PR is valid 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'success',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'Successful auto-approve.yml config check',
-    'text': ''
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "success",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "Successful auto-approve.yml config check",
+    "text": ""
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch approves and tags a PR if a config exists & is valid & PR is valid 2'] = {
-  'event': 'APPROVE'
+  "event": "APPROVE"
 }
 
 exports['auto-approve main auto-approve function config exists on main branch still attempts to add an automerge: exact label if there is an approval 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'success',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'Successful auto-approve.yml config check',
-    'text': ''
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "success",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "Successful auto-approve.yml config check",
+    "text": ""
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch approves and tags a PR if everything is valid, and it is coming from a fork 1'] = {
-  'head_sha': '65f14b92a8135948008c6e26344167a2dac9f066',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'success',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'Successful auto-approve.yml config check',
-    'text': ''
+  "head_sha": "65f14b92a8135948008c6e26344167a2dac9f066",
+  "name": "Auto-approve.yml check",
+  "conclusion": "success",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "Successful auto-approve.yml config check",
+    "text": ""
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch approves and tags a PR if everything is valid, and it is coming from a fork 2'] = {
-  'event': 'APPROVE'
+  "event": "APPROVE"
 }
 
 exports['auto-approve main auto-approve function config exists on main branch retries if etag is not current 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'success',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'Successful auto-approve.yml config check',
-    'text': ''
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "success",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "Successful auto-approve.yml config check",
+    "text": ""
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch retries if etag is not current 2'] = {
-  'event': 'APPROVE'
+  "event": "APPROVE"
 }
 
 exports['auto-approve main auto-approve function config exists on main branch stops retrying to add the label after 3 attempts, even if it is never successful 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'success',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'Successful auto-approve.yml config check',
-    'text': ''
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "success",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "Successful auto-approve.yml config check",
+    "text": ""
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch stops retrying to add the label after 3 attempts, even if it is never successful 2'] = {
-  'event': 'APPROVE'
+  "event": "APPROVE"
 }
 
 exports['auto-approve main auto-approve function config exists on main branch submits a failing check if config exists but is not valid 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'failure',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'auto-approve.yml config check failed',
-    'text': 'See the following errors in your auto-approve.yml config:\n[{"wrongProperty":"wrongProperty","message":"message"}]\n'
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "failure",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "auto-approve.yml config check failed",
+    "text": "See the following errors in your auto-approve.yml config:\n[{\"wrongProperty\":\"wrongProperty\",\"message\":\"message\"}]\n"
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch logs to the console if config is valid but PR is not 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'success',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'Successful auto-approve.yml config check',
-    'text': ''
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "success",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "Successful auto-approve.yml config check",
+    "text": ""
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch will not check config on master if the config is modified on PR 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'failure',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'auto-approve.yml config check failed',
-    'text': 'See the following errors in your auto-approve.yml config:\n\n'
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "failure",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "auto-approve.yml config check failed",
+    "text": "See the following errors in your auto-approve.yml config:\n\n"
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch uses the correct function to check the PR if the config is V2 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'success',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'Successful auto-approve.yml config check',
-    'text': ''
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "success",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "Successful auto-approve.yml config check",
+    "text": ""
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch uses the correct function to check the PR if the config is V2 2'] = {
-  'event': 'APPROVE'
+  "event": "APPROVE"
 }
 
 exports['auto-approve main auto-approve function config exists on main branch uses the correct function to check the PR if the config is V1 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'success',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'Successful auto-approve.yml config check',
-    'text': ''
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "success",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "Successful auto-approve.yml config check",
+    "text": ""
   }
 }
 
 exports['auto-approve main auto-approve function config exists on main branch uses the correct function to check the PR if the config is V1 2'] = {
-  'event': 'APPROVE'
+  "event": "APPROVE"
 }
 
 exports['auto-approve main auto-approve function config does not exist on main branch attempts to create a passing status check if PR contains correct config 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'success',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'Successful auto-approve.yml config check',
-    'text': ''
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "success",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "Successful auto-approve.yml config check",
+    "text": ""
   }
 }
 
 exports['auto-approve main auto-approve function config does not exist on main branch attempts to create a failing status check if PR contains wrong config, and error messages check out 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'failure',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'auto-approve.yml config check failed',
-    'text': 'See the following errors in your auto-approve.yml config:\n[{"wrongProperty":"wrongProperty","message":"message"}]\n'
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "failure",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "auto-approve.yml config check failed",
+    "text": "See the following errors in your auto-approve.yml config:\n[{\"wrongProperty\":\"wrongProperty\",\"message\":\"message\"}]\n"
   }
 }
 
 exports['auto-approve main auto-approve function config does not exist on main branch passes PR if auto-approve is on main, not PR 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'success',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'Successful auto-approve.yml config check',
-    'text': ''
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "success",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "Successful auto-approve.yml config check",
+    "text": ""
   }
 }
 
 exports['auto-approve main auto-approve function config does not exist on main branch passes PR if auto-approve is on main, not PR 2'] = {
-  'event': 'APPROVE'
+  "event": "APPROVE"
 }
 
 exports['auto-approve gets secrets and authenticates separately for approval creates a separate octokit instance and authenticates with secret in secret manager 1'] = {
-  'head_sha': 'c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a',
-  'name': 'Auto-approve.yml check',
-  'conclusion': 'success',
-  'output': {
-    'title': 'Auto-approve.yml check',
-    'summary': 'Successful auto-approve.yml config check',
-    'text': ''
+  "head_sha": "c5b0c82f5d58dd4a87e4e3e5f73cd752e552931a",
+  "name": "Auto-approve.yml check",
+  "conclusion": "success",
+  "output": {
+    "title": "Auto-approve.yml check",
+    "summary": "Successful auto-approve.yml config check",
+    "text": ""
   }
 }
 
 exports['auto-approve gets secrets and authenticates separately for approval creates a separate octokit instance and authenticates with secret in secret manager 2'] = {
-  'event': 'APPROVE'
+  "event": "APPROVE"
 }

--- a/packages/auto-approve/__snapshots__/check-config.test.js
+++ b/packages/auto-approve/__snapshots__/check-config.test.js
@@ -35,7 +35,7 @@ exports['check for config whether YAML file has valid schema should fail if ther
 `
 
 exports['check for config whether YAML file has valid schema V2 should fail if YAML has any other properties than the ones specified 1'] = `
-[{"wrongProperty":{"allowedValues":["UpdateDiscoveryArtifacts","RegenerateReadme","DiscoveryDocUpdate","PythonDependency","PythonSampleDependency","NodeDependency","NodeRelease","JavaApiaryCodegen","JavaDependency","OwlBotTemplateChanges","OwlBotTemplateChangesNode","OwlBotAPIChanges","PHPApiaryCodegen","PythonSampleAppDependency","JavaSampleAppDependency","DockerDependency","GoDependency","GoApiaryCodegen","NodeGeneratorDependency"]},"message":"must be equal to one of the allowed values"}]
+[{"wrongProperty":{"allowedValues":["UpdateDiscoveryArtifacts","RegenerateReadme","DiscoveryDocUpdate","PythonDependency","PythonSampleDependency","NodeDependency","NodeRelease","JavaApiaryCodegen","JavaDependency","OwlBotTemplateChanges","OwlBotTemplateChangesNode","OwlBotPRsNode","OwlBotAPIChanges","PHPApiaryCodegen","PythonSampleAppDependency","JavaSampleAppDependency","DockerDependency","GoDependency","GoApiaryCodegen","NodeGeneratorDependency"]},"message":"must be equal to one of the allowed values"}]
 `
 
 exports['check for config whether YAML file has valid schema V2 should fail if the property is wrong 1'] = `

--- a/packages/auto-approve/src/check-pr-v2.ts
+++ b/packages/auto-approve/src/check-pr-v2.ts
@@ -29,6 +29,7 @@ import {NodeDependency} from './process-checks/node/dependency';
 import {NodeGeneratorDependency} from './process-checks/node/generator-dependency';
 import {NodeRelease} from './process-checks/node/release';
 import {OwlBotTemplateChangesNode} from './process-checks/node/owlbot-template-changes';
+import {OwlBotNode} from './process-checks/node/owlbot';
 import {JavaDependency} from './process-checks/java/dependency';
 import {OwlBotTemplateChanges} from './process-checks/owl-bot-template-changes';
 import {OwlBotAPIChanges} from './process-checks/owl-bot-api-changes';
@@ -72,6 +73,10 @@ const typeMap = [
   {
     configValue: 'OwlBotTemplateChangesNode',
     configType: OwlBotTemplateChangesNode,
+  },
+  {
+    configValue: 'OwlBotPRsNode',
+    configType: OwlBotNode,
   },
   {
     configValue: 'JavaApiaryCodegen',

--- a/packages/auto-approve/src/process-checks/node/owlbot-template-changes.ts
+++ b/packages/auto-approve/src/process-checks/node/owlbot-template-changes.ts
@@ -38,7 +38,7 @@ export class OwlBotTemplateChangesNode extends OwlBotTemplateChanges {
     // For this particular rule, we want to check a pattern and an antipattern;
     // we want it to start with regular commit convention,
     // and it should not be breaking or fix or feat
-    titleRegex: /$(chore|build|tests|refactor)/,
+    titleRegex: /^(chore|build|tests|refactor)/,
     titleRegexExclude: /(fix|feat|breaking|!)/,
     bodyRegex: /PiperOrigin-RevId/,
   };
@@ -106,8 +106,8 @@ export class OwlBotTemplateChangesNode extends OwlBotTemplateChanges {
         authorshipMatches,
         titleMatches,
         !bodyMatches,
-        otherOwlBotPRs,
-        otherCommitAuthors,
+        !otherOwlBotPRs,
+        !otherCommitAuthors,
       ],
       incomingPR.repoOwner,
       incomingPR.repoName,

--- a/packages/auto-approve/src/process-checks/node/owlbot.ts
+++ b/packages/auto-approve/src/process-checks/node/owlbot.ts
@@ -37,7 +37,7 @@ export class OwlBotNode extends OwlBotTemplateChangesNode {
     author: 'gcf-owl-bot[bot]',
     // For this particular rule, we want to check a pattern and an antipattern;
     // we want it to start with regular commit convention,
-    // and it should not be breaking or fix or feat
+    // and it should not be breaking
     titleRegex: /^(chore|build|tests|refactor|fix|feat)/,
     titleRegexExclude: /(breaking|!)/,
     bodyRegex: /^((?!PiperOrigin-RevId).)*$/,

--- a/packages/auto-approve/src/process-checks/node/owlbot.ts
+++ b/packages/auto-approve/src/process-checks/node/owlbot.ts
@@ -38,8 +38,8 @@ export class OwlBotNode extends OwlBotTemplateChangesNode {
     // For this particular rule, we want to check a pattern and an antipattern;
     // we want it to start with regular commit convention,
     // and it should not be breaking or fix or feat
-    titleRegex: /^(chore|build|tests|refactor)/,
-    titleRegexExclude: /(fix|feat|breaking|!)/,
+    titleRegex: /^(chore|build|tests|refactor|fix|feat)/,
+    titleRegexExclude: /(breaking|!)/,
     bodyRegex: /^((?!PiperOrigin-RevId).)*$/,
   };
 

--- a/packages/auto-approve/src/process-checks/node/owlbot.ts
+++ b/packages/auto-approve/src/process-checks/node/owlbot.ts
@@ -28,7 +28,7 @@ import {OwlBotTemplateChangesNode} from './owlbot-template-changes';
  * true if the PR:
   - has an author that is 'gcf-owl-bot[bot]'
   - has a title that does NOT include BREAKING, or !
-  - has a PR body that does not contain 'PiperOrigin-RevId'
+  - has a PR body that DOES contain 'PiperOrigin-RevId'
   - is the first owlbot template PR in a repo (so they are merged in order)
   - has no other commit authors on the PR
  */

--- a/packages/auto-approve/src/process-checks/node/owlbot.ts
+++ b/packages/auto-approve/src/process-checks/node/owlbot.ts
@@ -1,0 +1,53 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PullRequest} from '../../interfaces';
+import {
+  checkAuthor,
+  checkTitleOrBody,
+  reportIndividualChecks,
+  getOpenPRsInRepoFromSameAuthor,
+} from '../../utils-for-pr-checking';
+import {listCommitsOnAPR} from '../../get-pr-info';
+import {Octokit} from '@octokit/rest';
+import {OwlBotTemplateChangesNode} from './owlbot-template-changes';
+
+/**
+ * The OwlBotTemplateChanges class's checkPR function returns
+ * true if the PR:
+  - has an author that is 'gcf-owl-bot[bot]'
+  - has a title that does NOT include BREAKING, or !
+  - has a PR body that does not contain 'PiperOrigin-RevId'
+  - is the first owlbot template PR in a repo (so they are merged in order)
+  - has no other commit authors on the PR
+ */
+export class OwlBotNode extends OwlBotTemplateChangesNode {
+  classRule = {
+    author: 'gcf-owl-bot[bot]',
+    // For this particular rule, we want to check a pattern and an antipattern;
+    // we want it to start with regular commit convention,
+    // and it should not be breaking or fix or feat
+    titleRegex: /^(chore|build|tests|refactor)/,
+    titleRegexExclude: /(fix|feat|breaking|!)/,
+    bodyRegex: /^((?!PiperOrigin-RevId).)*$/,
+  };
+
+  constructor(octokit: Octokit) {
+    super(octokit);
+  }
+
+  public async checkPR(incomingPR: PullRequest): Promise<boolean> {
+    return super.checkPR(incomingPR);
+  }
+}

--- a/packages/auto-approve/src/valid-pr-schema-v2.json
+++ b/packages/auto-approve/src/valid-pr-schema-v2.json
@@ -23,6 +23,7 @@
           "JavaDependency",
           "OwlBotTemplateChanges",
           "OwlBotTemplateChangesNode",
+          "OwlBotPRsNode",
           "OwlBotAPIChanges",
           "PHPApiaryCodegen",
           "PythonSampleAppDependency",

--- a/packages/auto-approve/test/node-owlbot.test.ts
+++ b/packages/auto-approve/test/node-owlbot.test.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {OwlBotTemplateChangesNode} from '../src/process-checks/node/owlbot-template-changes';
+import {OwlBotNode} from '../src/process-checks/node/owlbot';
 import {describe, it} from 'mocha';
 import assert from 'assert';
 import nock from 'nock';
@@ -44,7 +44,7 @@ function listCommitsOnAPR(
     .reply(200, response);
 }
 
-describe('behavior of OwlBotTemplateChangesNode process', () => {
+describe('behavior of OwlBotNode process', () => {
   it('should return false in checkPR if incoming PR does not match classRules', async () => {
     const incomingPR = {
       author: 'testAuthor',
@@ -54,10 +54,10 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
       repoName: 'testRepoName',
       repoOwner: 'testRepoOwner',
       prNumber: 1,
-      body: 'body',
+      body: 'PiperOrigin-RevId: 413686247',
     };
 
-    const owlBotTemplateChanges = new OwlBotTemplateChangesNode(octokit);
+    const owlBotTemplateChanges = new OwlBotNode(octokit);
 
     const scopes = [
       getPRsOnRepo('testRepoOwner', 'testRepoName', [
@@ -84,9 +84,9 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
       repoName: 'testRepoName',
       repoOwner: 'testRepoOwner',
       prNumber: 1,
-      body: 'body',
+      body: 'PiperOrigin-RevId: 413686247',
     };
-    const owlBotTemplateChanges = new OwlBotTemplateChangesNode(octokit);
+    const owlBotChanges = new OwlBotNode(octokit);
 
     const scopes = [
       getPRsOnRepo('testRepoOwner', 'testRepoName', [
@@ -97,14 +97,11 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
       ]),
     ];
 
-    assert.deepStrictEqual(
-      await owlBotTemplateChanges.checkPR(incomingPR),
-      false
-    );
+    assert.deepStrictEqual(await owlBotChanges.checkPR(incomingPR), false);
     scopes.forEach(scope => scope.done());
   });
 
-  it('should return false in checkPR if incoming PR includes PiperOrigin-RevId', async () => {
+  it('should return false in checkPR if incoming PR does NOT include PiperOrigin-RevId', async () => {
     const incomingPR = {
       author: 'gcf-owl-bot[bot]',
       title: 'chore: a new PR',
@@ -116,12 +113,11 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
       body:
         '... signature to CreateFeatureStore, CreateEntityType, CreateFeature feat: add network and enable_private_service_connect to IndexEndpoint feat: add service_attachment to IndexPrivateEndpoints feat: add stratified_split field to training_pipeline InputDataConfig fix: remove invalid resource annotations in LineageSubgraph' +
         'Regenerate this pull request now.' +
-        'PiperOrigin-RevId: 413686247' +
         'Source-Link: googleapis/googleapis@244a89d' +
         'Source-Link: googleapis/googleapis-gen@c485e44' +
         'Copy-Tag: eyJwIjoiLmdpdGh1Yi8uT3dsQm90LnlhbWwiLCJoIjoiYzQ4NWU0NGExYjJmZWY1MTZlOWJjYTM2NTE0ZDUwY2ViZDVlYTUxZiJ9',
     };
-    const owlBotTemplateChanges = new OwlBotTemplateChangesNode(octokit);
+    const owlBotChanges = new OwlBotNode(octokit);
 
     const scopes = [
       getPRsOnRepo('testRepoOwner', 'testRepoName', [
@@ -132,10 +128,7 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
       ]),
     ];
 
-    assert.deepStrictEqual(
-      await owlBotTemplateChanges.checkPR(incomingPR),
-      false
-    );
+    assert.deepStrictEqual(await owlBotChanges.checkPR(incomingPR), false);
     scopes.forEach(scope => scope.done());
   });
 
@@ -148,8 +141,9 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
       repoName: 'testRepoName',
       repoOwner: 'testRepoOwner',
       prNumber: 1,
+      body: 'PiperOrigin-RevId: 413686247',
     };
-    const owlBotTemplateChanges = new OwlBotTemplateChangesNode(octokit);
+    const owlBotChanges = new OwlBotNode(octokit);
 
     const scopes = [
       getPRsOnRepo('testRepoOwner', 'testRepoName', [
@@ -161,10 +155,7 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
       ]),
     ];
 
-    assert.deepStrictEqual(
-      await owlBotTemplateChanges.checkPR(incomingPR),
-      false
-    );
+    assert.deepStrictEqual(await owlBotChanges.checkPR(incomingPR), false);
     scopes.forEach(scope => scope.done());
   });
 
@@ -177,8 +168,9 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
       repoName: 'testRepoName',
       repoOwner: 'testRepoOwner',
       prNumber: 1,
+      body: 'PiperOrigin-RevId: 413686247',
     };
-    const owlBotTemplateChanges = new OwlBotTemplateChangesNode(octokit);
+    const owlBotChanges = new OwlBotNode(octokit);
 
     const scopes = [
       getPRsOnRepo('testRepoOwner', 'testRepoName', [
@@ -190,14 +182,11 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
       ]),
     ];
 
-    assert.deepStrictEqual(
-      await owlBotTemplateChanges.checkPR(incomingPR),
-      false
-    );
+    assert.deepStrictEqual(await owlBotChanges.checkPR(incomingPR), false);
     scopes.forEach(scope => scope.done());
   });
 
-  it('should return true in checkPR if incoming PR does match classRules, is the first in the PRs', async () => {
+  it('should return true in checkPR if incoming PR does match classRules, is the first in the PRs, and has no other commits', async () => {
     const incomingPR = {
       author: 'gcf-owl-bot[bot]',
       title: 'chore: a fine title',
@@ -206,9 +195,9 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
       repoName: 'testRepoName',
       repoOwner: 'testRepoOwner',
       prNumber: 1,
-      body: 'body',
+      body: 'PiperOrigin-RevId: 413686247',
     };
-    const owlBotTemplateChanges = new OwlBotTemplateChangesNode(octokit);
+    const owlBotChanges = new OwlBotNode(octokit);
 
     const scopes = [
       getPRsOnRepo('testRepoOwner', 'testRepoName', [
@@ -221,10 +210,7 @@ describe('behavior of OwlBotTemplateChangesNode process', () => {
       ]),
     ];
 
-    assert.deepStrictEqual(
-      await owlBotTemplateChanges.checkPR(incomingPR),
-      true
-    );
+    assert.deepStrictEqual(await owlBotChanges.checkPR(incomingPR), true);
     scopes.forEach(scope => scope.done());
   });
 });


### PR DESCRIPTION
See: https://docs.google.com/document/d/1PxkDU5nZihyxDJ9XvjwX7GvDDdJu8qm4TpoxMUsryz0/edit?tab=t.0#heading=h.689e00isjkgi

Adding owlbot process checks for Node:

```
Auto-approve would approve and tag owl-bot PRs if and only if:
The PR author is ‘gcf-owl-bot[bot]’
The title of the PR, and the commits in the PR, do not include breaking, BREAKING or !
The body of the PR contains a ‘PiperOrigin-RevId’
There are no other PRs in the repository opened by gcf-owl-bot[bot]
Checks that the PR does not have any commits from any other authors other than gcf-owl-bot[bot]
```