### PR TITLE
chore: update release-please to 16.11.0

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -17,7 +17,7 @@
         "@octokit/webhooks": "^10.1.5",
         "gcf-utils": "^15.0.0",
         "jsonwebtoken": "^9.0.0",
-        "release-please": "^16.10.0"
+        "release-please": "^16.11.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",


### PR DESCRIPTION
Update `release-please` to latest version (`16.11.0`) in order to use the feature in https://github.com/googleapis/release-please/pull/2300