### PR TITLE
build: enable renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,7 @@
+{
+  "extends": [
+    // update base images in Dockerfiles
+    ":docker",
+    ":disableDependencyDashboard",
+  ]
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,5 @@
   "extends": [
     // update base images in Dockerfiles
     ":docker",
-    ":disableDependencyDashboard",
   ]
 }


### PR DESCRIPTION
Use renovate to update versioned Dockerfile base images.

Note: using `.json5` for a more readable config format