### PR TITLE
feat(auto-approve): added a RubyApiaryCodegen process for the auto-approve bot

### DIFF
--- a/packages/auto-approve/README.md
+++ b/packages/auto-approve/README.md
@@ -35,6 +35,7 @@ processes:
   - "NodeGeneratorDependency"
   - "OwlBotTemplateChangesNode"
   - "OwlBotPRsNode"
+  - "RubyApiaryCodegen"
 ```
 
 These processes represent different workflows for what auto-approve will approve and merge in a given repository. To see their logic in full, see the corresponding file in /src/process-checks.
@@ -203,7 +204,9 @@ Below is what each process checks for:
   - Checks that the body of the PR DOES contain 'PiperOrigin-RevId'
   - Checks that the PR is the first of owlbot PRs in the repo (so that they are not merged out of order)
   - Checks that there are no other commit authors other than owlbot on the repo
-  
+* RubyApiaryCodegen
+  - Checks that the author is 'yoshi-code-bot'
+  - Checks that the title of the PR matches the regexp: /^feat: Automated regeneration of .* client$/
 
 This change in configuration permits the following:
 * Allows for more complete testing as described by c8, by codifying the logic in TS as opposed to the JSON validation schema

--- a/packages/auto-approve/__snapshots__/check-config.test.js
+++ b/packages/auto-approve/__snapshots__/check-config.test.js
@@ -35,7 +35,7 @@ exports['check for config whether YAML file has valid schema should fail if ther
 `
 
 exports['check for config whether YAML file has valid schema V2 should fail if YAML has any other properties than the ones specified 1'] = `
-[{"wrongProperty":{"allowedValues":["UpdateDiscoveryArtifacts","RegenerateReadme","DiscoveryDocUpdate","PythonDependency","PythonSampleDependency","NodeDependency","NodeRelease","JavaApiaryCodegen","JavaDependency","OwlBotTemplateChanges","OwlBotTemplateChangesNode","OwlBotPRsNode","OwlBotAPIChanges","PHPApiaryCodegen","PythonSampleAppDependency","JavaSampleAppDependency","DockerDependency","GoDependency","GoApiaryCodegen","NodeGeneratorDependency"]},"message":"must be equal to one of the allowed values"}]
+[{"wrongProperty":{"allowedValues":["UpdateDiscoveryArtifacts","RegenerateReadme","DiscoveryDocUpdate","PythonDependency","PythonSampleDependency","NodeDependency","NodeRelease","JavaApiaryCodegen","JavaDependency","OwlBotTemplateChanges","OwlBotTemplateChangesNode","OwlBotPRsNode","OwlBotAPIChanges","PHPApiaryCodegen","PythonSampleAppDependency","JavaSampleAppDependency","DockerDependency","GoDependency","GoApiaryCodegen","RubyApiaryCodegen","NodeGeneratorDependency"]},"message":"must be equal to one of the allowed values"}]
 `
 
 exports['check for config whether YAML file has valid schema V2 should fail if the property is wrong 1'] = `

--- a/packages/auto-approve/src/check-pr-v2.ts
+++ b/packages/auto-approve/src/check-pr-v2.ts
@@ -38,6 +38,7 @@ import {PHPApiaryCodegen} from './process-checks/php/apiary-codegen';
 import {PythonSampleDependency} from './process-checks/python/sample-dependency';
 import {logger as defaultLogger, GCFLogger} from 'gcf-utils';
 import {GoApiaryCodegen} from './process-checks/go/apiary-codegen';
+import {RubyApiaryCodegen} from './process-checks/ruby/apiary-codegen';
 // This file manages the logic to check whether a given PR matches the config in the repository
 
 // We need this typeMap to convert the JSON input (string) into a corresponding type.
@@ -121,6 +122,10 @@ const typeMap = [
   {
     configValue: 'NodeGeneratorDependency',
     configType: NodeGeneratorDependency,
+  },
+  {
+    configValue: 'RubyApiaryCodegen',
+    configType: RubyApiaryCodegen,
   },
 ];
 

--- a/packages/auto-approve/src/process-checks/ruby/apiary-codegen.ts
+++ b/packages/auto-approve/src/process-checks/ruby/apiary-codegen.ts
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PullRequest} from '../../interfaces';
+import {
+  checkAuthor,
+  checkTitleOrBody,
+  reportIndividualChecks,
+} from '../../utils-for-pr-checking';
+import {Octokit} from '@octokit/rest';
+import {BaseLanguageRule} from '../base';
+
+/**
+ * The RubyApiaryCodegen class's checkPR function returns
+ * true if the PR:
+  - has an author that is 'yoshi-code-bot'
+  - has a title that matches the regexp: /^feat: Automated regeneration of .* client$/
+ */
+export class RubyApiaryCodegen extends BaseLanguageRule {
+  classRule = {
+    author: 'yoshi-code-bot',
+    titleRegex: /^feat: Automated regeneration of .* client$/,
+  };
+  constructor(octokit: Octokit) {
+    super(octokit);
+  }
+
+  public async checkPR(incomingPR: PullRequest): Promise<boolean> {
+    const authorshipMatches = checkAuthor(
+      this.classRule.author,
+      incomingPR.author
+    );
+
+    const titleMatches = checkTitleOrBody(
+      incomingPR.title,
+      this.classRule.titleRegex
+    );
+    reportIndividualChecks(
+      ['authorshipMatches', 'titleMatches'],
+      [authorshipMatches, titleMatches],
+      incomingPR.repoOwner,
+      incomingPR.repoName,
+      incomingPR.prNumber
+    );
+
+    return authorshipMatches && titleMatches;
+  }
+}

--- a/packages/auto-approve/src/valid-pr-schema-v2.json
+++ b/packages/auto-approve/src/valid-pr-schema-v2.json
@@ -31,6 +31,7 @@
           "DockerDependency",
           "GoDependency",
           "GoApiaryCodegen",
+          "RubyApiaryCodegen",
           "NodeGeneratorDependency"
         ]
       }

--- a/packages/auto-approve/test/ruby-apiary-codegen.test.ts
+++ b/packages/auto-approve/test/ruby-apiary-codegen.test.ts
@@ -1,0 +1,62 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {RubyApiaryCodegen} from '../src/process-checks/ruby/apiary-codegen';
+import {describe, it} from 'mocha';
+import assert from 'assert';
+const {Octokit} = require('@octokit/rest');
+
+const octokit = new Octokit({
+  auth: 'mypersonalaccesstoken123',
+});
+describe('RubyApiaryCodegen', () => {
+  it('should return false in checkPR if incoming PR does not match classRules', async () => {
+    const incomingPR = {
+      author: 'testAuthor',
+      title: 'testTitle',
+      fileCount: 3,
+      changedFiles: [{filename: 'hello', sha: '2345'}],
+      repoName: 'testRepoName',
+      repoOwner: 'testRepoOwner',
+      prNumber: 1,
+      body: 'body',
+    };
+
+    const rule = new RubyApiaryCodegen(octokit);
+
+    assert.deepStrictEqual(await rule.checkPR(incomingPR), false);
+  });
+
+  it('should return true in checkPR if incoming PR does match classRules', async () => {
+    const incomingPR = {
+      author: 'yoshi-code-bot',
+      title: 'feat: Automated regeneration of admin v1 client',
+      fileCount: 3,
+      changedFiles: [
+        {
+          filename: 'README.md',
+          sha: '2345',
+        },
+      ],
+      repoName: 'testRepoName',
+      repoOwner: 'testRepoOwner',
+      prNumber: 1,
+      body: 'body',
+    };
+
+    const rule = new RubyApiaryCodegen(octokit);
+
+    assert.ok(await rule.checkPR(incomingPR));
+  });
+});


### PR DESCRIPTION
This will be used for the Ruby and Elixir apiary client repos. Codegen in those repos is currently blocked due to the removal of `YOSHI_APPROVER_TOKEN`; we're migrating to auto-approve in response.

Implementation is closely based on the existing PHPApiaryCodegen.