### PR TITLE
fix(deps): lock octokit/graphql to commonjs version

### DIFF
--- a/packages/gcf-utils/package-lock.json
+++ b/packages/gcf-utils/package-lock.json
@@ -14,6 +14,7 @@
         "@google-cloud/storage": "^7.12.1",
         "@google-cloud/tasks": "^5.5.0",
         "@octokit/auth-app": "^4.0.5",
+        "@octokit/graphql": "^5.0.0",
         "@octokit/plugin-enterprise-compatibility": "^2.0.3",
         "@octokit/rest": "^19.0.4",
         "@octokit/types": "^9.0.0",

--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -24,6 +24,7 @@
     "@google-cloud/storage": "^7.12.1",
     "@google-cloud/tasks": "^5.5.0",
     "@octokit/auth-app": "^4.0.5",
+    "@octokit/graphql": "^5.0.0",
     "@octokit/plugin-enterprise-compatibility": "^2.0.3",
     "@octokit/rest": "^19.0.4",
     "@octokit/types": "^9.0.0",


### PR DESCRIPTION
Without locking the version, downstream apps that use octokit/graphql that do not declare a version, will get an ESM version (8.0.0+). This is incompatible with what our libraries and probot can handle.