### PR TITLE
build: re-enable npm package updates for renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,9 +3,12 @@
     "config:recommended",
     // update base images in Dockerfiles
     ":docker",
+    // prevent upgrading to packages that can be unpublished 
+    "npm:unpublishSafe",
   ],
   "enabledManagers": [
     "dockerfile", 
     "github-actions",
-  ]
+    "npm",
+  ],
 }


### PR DESCRIPTION
Use `npm:unpublishSafe` to prevent updating to packages that can be unpublished/yanked.