### PR TITLE
feat(label-sinc): add label for PRs containing GenAI code

### DIFF
--- a/packages/label-sync/src/labels.json
+++ b/packages/label-sync/src/labels.json
@@ -279,6 +279,11 @@
       "name": "asset: pattern",
       "description": "DEE Asset tagging - Pattern.",
       "color": "EFDE28"      
+    },
+    {
+      "name": "generated: genai",
+      "description": "Contains Generative AI based code, requesting an additional reviewer.",
+      "color": "FFCC00"
     }
   ]
 }


### PR DESCRIPTION
Adding a label to mark GenAI PRs for an additional reviewer, per go/code-ai-policy