### PR TITLE
feat: add ability to configure app to skip throttling on rate limits

### DIFF
--- a/packages/gcf-utils/src/configuration.ts
+++ b/packages/gcf-utils/src/configuration.ts
@@ -32,6 +32,8 @@ export interface WrapConfig {
   // When batch scheduling cron requests, delay groups of requests by X seconds
   // to avoid flooding
   flowControlDelayInSeconds: number;
+  // Whether or not to throttle on rate limiting
+  throttleOnRateLimits: boolean;
 }
 
 // Default configuration options
@@ -42,4 +44,5 @@ export const DEFAULT_WRAP_CONFIG: WrapConfig = {
   maxRetries: 10,
   maxPubSubRetries: 0,
   flowControlDelayInSeconds: DEFAULT_FLOW_CONTROL_DELAY_IN_SECOND,
+  throttleOnRateLimits: true,
 };

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -136,6 +136,9 @@ export interface WrapOptions {
 
   // Delay in task scheduling flow control
   flowControlDelayInSeconds?: number;
+
+  // Whether or not to throttle on rate limiting. Defaults to `true`.
+  throttleOnRateLimits?: boolean;
 }
 
 // Default logger, in general, you will want to configure a local logger that
@@ -529,8 +532,9 @@ export class GCFBootstrapper {
               requestLogger.warn('Rate limit exceeded', rateLimits);
               // On GitHub quota issues, return a 503 to throttle our task queues
               // https://cloud.google.com/tasks/docs/common-pitfalls#backoff_errors_and_enforced_rates
-              response.status(503).send({
-                statusCode: 503,
+              const statusCode = wrapConfig.throttleOnRateLimits ? 503 : 500;
+              response.status(statusCode).send({
+                statusCode: statusCode,
                 body: JSON.stringify({
                   ...rateLimits,
                   message: 'Rate Limited',


### PR DESCRIPTION
Sometimes we don't want to throttle all tasks in case rate limits from one installation block other installations.