### PR TITLE
build: deploy all cloud functions on node 18

### DIFF
--- a/packages/auto-label/cloudbuild.yaml
+++ b/packages/auto-label/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/blunderbuss/cloudbuild.yaml
+++ b/packages/blunderbuss/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/do-not-merge/cloudbuild.yaml
+++ b/packages/do-not-merge/cloudbuild.yaml
@@ -40,7 +40,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/failurechecker/cloudbuild.yaml
+++ b/packages/failurechecker/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/flakybot/cloudbuild.yaml
+++ b/packages/flakybot/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/generated-files-bot/cloudbuild.yaml
+++ b/packages/generated-files-bot/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/header-checker-lint/cloudbuild.yaml
+++ b/packages/header-checker-lint/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/label-sync/cloudbuild.yaml
+++ b/packages/label-sync/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/npm
     id: "cron-deploy"

--- a/packages/owl-bot/cloudbuild.yaml
+++ b/packages/owl-bot/cloudbuild.yaml
@@ -41,7 +41,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
       - "540s"
       - "68a5145e-8907-4301-a4b6-b7e37892a510"
 

--- a/packages/policy/cloudbuild.yaml
+++ b/packages/policy/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/npm
     id: "cron-deploy"

--- a/packages/repo-metadata-lint/cloudbuild.yaml
+++ b/packages/repo-metadata-lint/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/npm
     id: "cron-deploy"

--- a/packages/sync-repo-settings/cloudbuild.yaml
+++ b/packages/sync-repo-settings/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/npm
     id: "cron-deploy"

--- a/packages/trusted-contribution/cloudbuild.yaml
+++ b/packages/trusted-contribution/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs14"
+      - "nodejs18"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"


### PR DESCRIPTION
All the bots are currently tested against node 18. Node 14 runtime is deprecated and scheduled for removal.

Currently a few deployments are failing because the bots cannot resolve dependencies on node 14.