### PR TITLE
deps: upgrading owlbot dependencies

### DIFF
--- a/packages/owl-bot/package-lock.json
+++ b/packages/owl-bot/package-lock.json
@@ -4555,9 +4555,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.1.tgz",
+      "integrity": "sha512-1KyfJV+cQO/OCt5iqtSQJJrXH908vQXJXVfuo47Iaa4k8Kxl+Vt7YJdilIc+gl631QJ60tFgYHeXoSpvR5+fZw==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -12827,9 +12827,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.1.tgz",
+      "integrity": "sha512-1KyfJV+cQO/OCt5iqtSQJJrXH908vQXJXVfuo47Iaa4k8Kxl+Vt7YJdilIc+gl631QJ60tFgYHeXoSpvR5+fZw==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",


### PR DESCRIPTION
Upgrading the dependencies to use the latest gcf-utils. I ran `npm update gcf-utils` in the owl-bot directory.