### PR TITLE
fix: bazelbot insufficient memory error

### DIFF
--- a/packages/bazel-bot/cloudbuild.yaml
+++ b/packages/bazel-bot/cloudbuild.yaml
@@ -37,5 +37,5 @@ steps:
 timeout: '10800s'
 
 options:
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'
 logsBucket: 'gs://repo-automation-bots-bazel-gcb-logs'


### PR DESCRIPTION
https://cloud.google.com/build/docs/optimize-builds/increase-vcpu-for-builds#increase_vcpu_for_default_pools
https://cloud.google.com/build/pricing
The E-series is the current supported machine type.

The reason why you see all line changed is that I converted the Windows-style new line characters to UNIX-style.