### PR TITLE
build: simplify deploy scripts

### DIFF
--- a/scripts/publish-cloud-run.sh
+++ b/scripts/publish-cloud-run.sh
@@ -16,7 +16,7 @@
 set -eo pipefail
 
 if [ $# -lt 6 ]; then
-  echo "Usage: $0 <botDirectory> <projectId> <bucket> <keyLocation> <keyRing> <region> [botName] [timeout] [min-instance] [concurrency]"
+  echo "Usage: $0 <botDirectory> <projectId> <bucket> <keyLocation> <keyRing> <region> [botName]"
   exit 1
 fi
 
@@ -32,35 +32,6 @@ if [ $# -ge 7 ]; then
   botName=$7
 fi
 
-if [ $# -ge 8 ]; then
-  timeout=$8
-else
-  timeout="3600"
-fi
-
-if [ $# -ge 9 ]; then
-  minInstances=$9
-else
-  minInstances="0"
-fi
-
-if [ -z "${CONCURRENCY}" ]; then
-  if [ $# -ge 10 ]; then
-    CONCURRENCY=${10}
-  else
-    CONCURRENCY="80"
-  fi
-fi
-
-if [ "${project}" == "repo-automation-bots" ]; then
-    webhookTmpBucket=tmp-webhook-payloads
-elif [ "${project}" == "repo-automation-bots-staging" ]; then
-    webhookTmpBucket=tmp-webhook-payloads-staging
-else
-    echo "deploying to '${project}' is not supported"
-    exit 1
-fi
-
 if [ -z "${SERVICE_NAME}" ]; then
   SERVICE_NAME=${botName//_/-}
 fi
@@ -70,82 +41,13 @@ if [ -z "${IMAGE_NAME}" ]; then
 fi
 
 pushd "${directoryName}"
-functionName=${botName//-/_}
-queueName=${botName//_/-}
 
 deployArgs=(
   "--image"
   "${IMAGE_NAME}"
-  "--set-env-vars"
-  "DRIFT_PRO_BUCKET=${bucket}"
-  "--set-env-vars"
-  "KEY_LOCATION=${keyLocation}"
-  "--set-env-vars"
-  "KEY_RING=${keyRing}"
-  "--set-env-vars"
-  "GCF_SHORT_FUNCTION_NAME=${functionName}"
-  "--set-env-vars"
-  "PROJECT_ID=${project}"
-  "--set-env-vars"
-  "GCF_LOCATION=${region}"
-  "--set-env-vars"
-  "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD='1'"
-  "--set-env-vars"
-  "WEBHOOK_TMP=${webhookTmpBucket}"
-  "--set-env-vars"
-  "BOT_RUNTIME=run"
   "--platform"
   "managed"
-  "--region"
-  "${region}"
-  "--timeout"
-  "${timeout}"
-  "--min-instances"
-  "${minInstances}"
-  "--concurrency"
-  "${CONCURRENCY}"
   "--quiet"
 )
-if [ -n "${SERVICE_ACCOUNT}" ]; then
-  deployArgs+=( "--service-account" "${SERVICE_ACCOUNT}" )
-fi
-if [ -n "${MEMORY}" ]; then
-  deployArgs+=( "--memory" "${MEMORY}" )
-fi
-if [ -n "${NUMBER_OF_CPU}" ]; then
-  deployArgs+=( "--cpu" "${NUMBER_OF_CPU}" )
-fi
 echo "About to cloud run app ${SERVICE_NAME}"
 gcloud run deploy "${SERVICE_NAME}" "${deployArgs[@]}"
-
-if [ -z "${SECURE_ACCESS}" ]; then
-  echo "Adding ability for allUsers to execute the service"
-  gcloud run services add-iam-policy-binding "${SERVICE_NAME}" \
-    --member="allUsers" \
-    --region "${region}" \
-    --role="roles/run.invoker"
-fi
-
-echo "Deploying Queue ${queueName}"
-
-maxConcurrentDispatches="2048"
-if [ -n "${TASK_MAX_CONCURRENT_DISPATCHES}" ]; then
-  maxConcurrentDispatches="${TASK_MAX_CONCURRENT_DISPATCHES}"
-fi
-
-maxDispatchesPerSecond="500"
-if [ -n "${TASK_MAX_DISPATCHES_PER_SECOND}" ]; then
-  maxDispatchesPerSecond="${TASK_MAX_DISPATCHES_PER_SECOND}"
-fi
-
-verb="create"
-if gcloud tasks queues describe "${queueName}"  &>/dev/null; then
-  verb="update"
-fi
-
-gcloud --quiet tasks queues ${verb} "${queueName}" \
-  --max-concurrent-dispatches="${maxConcurrentDispatches}" \
-  --max-attempts="100" \
-  --max-retry-duration="43200s" \
-  --max-dispatches-per-second="${maxDispatchesPerSecond}" \
-  --min-backoff="5s"

--- a/scripts/publish-function.sh
+++ b/scripts/publish-function.sh
@@ -16,7 +16,7 @@
 set -eo pipefail
 
 if [ $# -lt 6 ]; then
-  echo "Usage: $0 <botDirectory> <projectId> <bucket> <keyLocation> <keyRing> <functionRegion> [functionRuntime] [timeout]"
+  echo "Usage: $0 <botDirectory> <projectId> <bucket> <keyLocation> <keyRing> <functionRegion> [functionRuntime]"
   exit 1
 fi
 
@@ -35,84 +35,17 @@ else
     functionRuntime=nodejs10
 fi
 
-if [ $# -ge 8 ]; then
-    timeout=$8
-else
-    # default to the max timeout (9 minutes)
-    timeout=540s
-fi
-
-# TODO(bcoe): figure out better approach for setting environment variables for
-# cloud functions (this list is getting too long).
-if [ $# -ge 9 ]; then
-    regenerate_trigger=$9
-else
-    regenerate_trigger=none
-fi
-
-if [ "${project}" == "repo-automation-bots" ]; then
-    webhookTmpBucket=tmp-webhook-payloads
-elif [ "${project}" == "repo-automation-bots-staging" ]; then
-    webhookTmpBucket=tmp-webhook-payloads-staging
-else
-    echo "deploying to '${project}' is not supported"
-    exit 1
-fi
-
 botName=$(echo "${directoryName}" | rev | cut -d/ -f1 | rev)
-workdir=$(pwd)
-targetDir="${workdir}/targets/${botName}"
 
 pushd "${targetDir}"
 functionName=${botName//-/_}
-queueName=${botName//_/-}
 
 deployArgs=(
   "--trigger-http"
   "--runtime"
   "${functionRuntime}"
-  "--region"
-  "${functionRegion}"
-  "--update-env-vars"
-  "BOT_RUNTIME=functions,DRIFT_PRO_BUCKET=${bucket},KEY_LOCATION=${keyLocation},KEY_RING=${keyRing},GCF_SHORT_FUNCTION_NAME=${functionName},PROJECT_ID=${project},GCF_LOCATION=${functionRegion},PUPPETEER_SKIP_CHROMIUM_DOWNLOAD='1',WEBHOOK_TMP=${webhookTmpBucket},CLOUD_BUILD_TRIGGER_REGENERATE_PULL_REQUEST=${regenerate_trigger}"
-  "--timeout"
-  "${timeout}"
 )
-if [ -n "${SERVICE_ACCOUNT}" ]; then
-  deployArgs+=( "--service-account" "${SERVICE_ACCOUNT}" )
-fi
+
 echo "About to publish function ${functionName}"
 echo gcloud functions deploy "${functionName}" "${deployArgs[@]}"
 gcloud functions deploy "${functionName}" "${deployArgs[@]}"
-
-if [ -z "${SECURE_ACCESS}" ]; then
-  echo "Adding ability for allUsers to execute the Function"
-  gcloud functions add-iam-policy-binding "${functionName}" \
-    --region="${functionRegion}" \
-    --member=allUsers \
-    --role=roles/cloudfunctions.invoker
-fi
-
-echo "Deploying Queue ${queueName}"
-
-maxConcurrentDispatches="2048"
-if [ -n "${TASK_MAX_CONCURRENT_DISPATCHES}" ]; then
-  maxConcurrentDispatches="${TASK_MAX_CONCURRENT_DISPATCHES}"
-fi
-
-maxDispatchesPerSecond="500"
-if [ -n "${TASK_MAX_DISPATCHES_PER_SECOND}" ]; then
-  maxDispatchesPerSecond="${TASK_MAX_DISPATCHES_PER_SECOND}"
-fi
-
-verb="create"
-if gcloud tasks queues describe "${queueName}"  &>/dev/null; then
-  verb="update"
-fi
-
-gcloud --quiet tasks queues ${verb} "${queueName}" \
-  --max-concurrent-dispatches="${maxConcurrentDispatches}" \
-  --max-attempts="100" \
-  --max-retry-duration="43200s" \
-  --max-dispatches-per-second="${maxDispatchesPerSecond}" \
-  --min-backoff="5s"


### PR DESCRIPTION
service configuration including task queues are being managed by terraform instead

In a follow-up, we should be able to directly run the gcloud deploy commands to simplify the release process
