### PR TITLE
build: rename second docker push step

### DIFF
--- a/packages/canary-bot/cloudbuild.yaml
+++ b/packages/canary-bot/cloudbuild.yaml
@@ -72,7 +72,7 @@ steps:
     args: ["push", "gcr.io/$PROJECT_ID/canary-bot-cloud-run"]
 
   - name: gcr.io/cloud-builders/docker
-    id: "push-docker"
+    id: "push-docker-gcf-frontend"
     waitFor: ["build-docker"]
     args: ["push", "gcr.io/$PROJECT_ID/canary-bot"]
 


### PR DESCRIPTION
Fixes `invalid build: invalid .steps field: build step #5 - "push-docker": the ID is not unique`
