### PR TITLE
build: fix deployment for canary-bot and cherry-pick-bot

### DIFF
--- a/packages/canary-bot/cloudbuild.yaml
+++ b/packages/canary-bot/cloudbuild.yaml
@@ -54,11 +54,6 @@ steps:
     waitFor: ["build-docker"]
     args: ["push", "gcr.io/$PROJECT_ID/canary-bot-cloud-run"]
 
-  - name: gcr.io/cloud-builders/docker
-    id: "push-docker-gcf-frontend"
-    waitFor: ["build-docker"]
-    args: ["push", "gcr.io/$PROJECT_ID/canary-bot"]
-
   - name: gcr.io/cloud-builders/gcloud
     id: "deploy-cloud-run-frontend"
     waitFor: ["push-docker"]

--- a/packages/cherry-pick-bot/cloudbuild.yaml
+++ b/packages/cherry-pick-bot/cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
       - "--quiet"
 
   - name: gcr.io/cloud-builders/gcloud
-    id: "deploy-cloud-run"
+    id: "deploy-cloud-run-backend"
     waitFor: ["push-docker"]
     entrypoint: gcloud
     dir: $_DIRECTORY


### PR DESCRIPTION
Both cloudbuild.yaml files had duplicated step ids.

canary-bot had the same step twice (from a merge conflict)
cherry-pick-bot needed to differentiate between the frontend and backend deployment
