### PR TITLE
chore(canary-bot): remove unnecessary cross-spawn from npm

### DIFF
--- a/packages/canary-bot/Dockerfile
+++ b/packages/canary-bot/Dockerfile
@@ -36,6 +36,9 @@ RUN npm run compile
 
 FROM node:18.20.5-slim
 
+# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
+RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/
+
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Resolves CVE-2024-21538 for canary-bot.

For other bots: #5575.