### PR TITLE
feat: use datastore-lock in issue handler

### DIFF
--- a/packages/canary-bot/package-lock.json
+++ b/packages/canary-bot/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@google-automations/datastore-lock": "^6.0.0",
         "@google-automations/issue-utils": "^4.0.0",
         "dayjs": "^1.11.5",
         "gcf-utils": "^16.0.1",
@@ -199,6 +200,20 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/@google-automations/datastore-lock": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-automations/datastore-lock/-/datastore-lock-6.0.0.tgz",
+      "integrity": "sha512-VvueJTVaYeHF8CHrjFdwkOsm/ECcphzs9X+Esz4yJKvph+6M+qUQpbJFDjI0wTVCemNWxqW/cfFli3REkcishw==",
+      "dependencies": {
+        "@google-cloud/datastore": "^9.0.0",
+        "gcf-utils": "^16.0.0",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@google-automations/issue-utils": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@google-automations/issue-utils/-/issue-utils-4.0.0.tgz",
@@ -209,6 +224,25 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@google-cloud/datastore": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/datastore/-/datastore-9.2.1.tgz",
+      "integrity": "sha512-55sQB8AmVN+zzvKjexwma3azSoD+V0B46p4/iIZ6UpR7Me7IZd5pU25T3z7mW7lG1SYVX/kgImPnZJjj8Tc45Q==",
+      "dependencies": {
+        "@google-cloud/promisify": "^4.0.0",
+        "arrify": "^2.0.1",
+        "async-mutex": "^0.5.0",
+        "concat-stream": "^2.0.0",
+        "extend": "^3.0.2",
+        "google-gax": "^4.0.5",
+        "is": "^3.3.0",
+        "split-array-stream": "^2.0.0",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@google-cloud/paginator": {
@@ -2108,6 +2142,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/async-mutex/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -2282,6 +2329,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2530,6 +2582,20 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -4706,6 +4772,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4808,6 +4882,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-stream-ended": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -7532,6 +7611,14 @@
       "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
     },
+    "node_modules/split-array-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-2.0.0.tgz",
+      "integrity": "sha512-hmMswlVY91WvGMxs0k8MRgq8zb2mSen4FmDNc5AFiTWtrBpdZN6nwD6kROVe4vNL+ywrvbCKsWVCnEd4riELIg==",
+      "dependencies": {
+        "is-stream-ended": "^0.1.4"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -7889,6 +7976,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
       "version": "4.9.4",
@@ -8334,6 +8426,17 @@
         }
       }
     },
+    "@google-automations/datastore-lock": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-automations/datastore-lock/-/datastore-lock-6.0.0.tgz",
+      "integrity": "sha512-VvueJTVaYeHF8CHrjFdwkOsm/ECcphzs9X+Esz4yJKvph+6M+qUQpbJFDjI0wTVCemNWxqW/cfFli3REkcishw==",
+      "requires": {
+        "@google-cloud/datastore": "^9.0.0",
+        "gcf-utils": "^16.0.0",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^9.0.0"
+      }
+    },
     "@google-automations/issue-utils": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@google-automations/issue-utils/-/issue-utils-4.0.0.tgz",
@@ -8341,6 +8444,22 @@
       "requires": {
         "gcf-utils": "^16.0.0",
         "jsonwebtoken": "^9.0.0"
+      }
+    },
+    "@google-cloud/datastore": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/datastore/-/datastore-9.2.1.tgz",
+      "integrity": "sha512-55sQB8AmVN+zzvKjexwma3azSoD+V0B46p4/iIZ6UpR7Me7IZd5pU25T3z7mW7lG1SYVX/kgImPnZJjj8Tc45Q==",
+      "requires": {
+        "@google-cloud/promisify": "^4.0.0",
+        "arrify": "^2.0.1",
+        "async-mutex": "^0.5.0",
+        "concat-stream": "^2.0.0",
+        "extend": "^3.0.2",
+        "google-gax": "^4.0.5",
+        "is": "^3.3.0",
+        "split-array-stream": "^2.0.0",
+        "stream-events": "^1.0.5"
       }
     },
     "@google-cloud/paginator": {
@@ -9856,6 +9975,21 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
     "async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -9985,6 +10119,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "bytes": {
       "version": "3.1.2",
@@ -10167,6 +10306,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -11778,6 +11928,11 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
+    "is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -11847,6 +12002,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+    },
+    "is-stream-ended": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
     },
     "is-unicode-supported": {
       "version": "0.1.0",
@@ -14021,6 +14181,14 @@
       "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
     },
+    "split-array-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-2.0.0.tgz",
+      "integrity": "sha512-hmMswlVY91WvGMxs0k8MRgq8zb2mSen4FmDNc5AFiTWtrBpdZN6nwD6kROVe4vNL+ywrvbCKsWVCnEd4riELIg==",
+      "requires": {
+        "is-stream-ended": "^0.1.4"
+      }
+    },
     "split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -14288,6 +14456,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typescript": {
       "version": "4.9.4",

--- a/packages/canary-bot/package.json
+++ b/packages/canary-bot/package.json
@@ -27,6 +27,7 @@
     "lint": "gts check"
   },
   "dependencies": {
+    "@google-automations/datastore-lock": "^6.0.0",
     "@google-automations/issue-utils": "^4.0.0",
     "dayjs": "^1.11.5",
     "gcf-utils": "^16.0.1",

--- a/packages/canary-bot/src/canary-bot.ts
+++ b/packages/canary-bot/src/canary-bot.ts
@@ -132,19 +132,22 @@ export = (app: Probot) => {
       const installations = await appOctokit.apps.listInstallations();
       const addition = `This app has ${installations.data.length} installation(s).`;
 
-      await withDatastoreLock({
-        lockId: 'canary-bot',
-        target: 'issue-handler',
-      }, async () => {
-        await addOrUpdateIssueComment(
-          await getAuthenticatedOctokit(context.payload.installation?.id),
-          owner,
-          repo,
-          context.payload.issue.number,
-          context.payload.installation!.id,
-          getIssueBody(addition)
-        );
-      })
+      await withDatastoreLock(
+        {
+          lockId: 'canary-bot',
+          target: 'issue-handler',
+        },
+        async () => {
+          await addOrUpdateIssueComment(
+            await getAuthenticatedOctokit(context.payload.installation?.id),
+            owner,
+            repo,
+            context.payload.issue.number,
+            context.payload.installation!.id,
+            getIssueBody(addition)
+          );
+        }
+      );
     } else if (context.payload.issue.title.includes('canary-bot error')) {
       // For testing gcf-utils' error handling.
       throw new Error(

--- a/packages/canary-bot/test/test.ts
+++ b/packages/canary-bot/test/test.ts
@@ -26,6 +26,7 @@ import nock from 'nock';
 import {describe, it, afterEach, beforeEach} from 'mocha';
 import assert from 'assert';
 import * as sinon from 'sinon';
+import * as datastoreLockModule from '@google-automations/datastore-lock';
 
 nock.disableNetConnect();
 
@@ -176,6 +177,13 @@ describe('canary-bot', () => {
   describe('responds to events', () => {
     it('responds to issues', async () => {
       getAuthenticatedOctokitStub.resolves(new Octokit());
+      sandbox.replace(
+        datastoreLockModule,
+        'withDatastoreLock',
+        async (details: any, f: () => Promise<any>) => {
+          return f();
+        }
+      );
       const scope = nock('https://api.github.com')
         .get('/app/installations')
         .reply(200, []);


### PR DESCRIPTION
This will allow us to test permissions for datastore on the canary-bot backend.
