### PR TITLE
build: force --no-gen2 when deploying GCF

### DIFF
--- a/packages/canary-bot/cloudbuild.yaml
+++ b/packages/canary-bot/cloudbuild.yaml
@@ -32,6 +32,8 @@ steps:
       - "deploy"
       - "canary_bot"
       - "--no-gen2"
+      - "--service-account"
+      - "canary-bot-frontend@repo-automation-bots.iam.gserviceaccount.com"
       - "--trigger-http"
       - "--region"
       - "$_REGION"

--- a/packages/canary-bot/cloudbuild.yaml
+++ b/packages/canary-bot/cloudbuild.yaml
@@ -31,6 +31,7 @@ steps:
       - "functions"
       - "deploy"
       - "canary_bot"
+      - "--no-gen2"
       - "--trigger-http"
       - "--region"
       - "$_REGION"


### PR DESCRIPTION
```
Could not create Cloud Run service canary-bot. A Cloud Run service with this name already exists. Please redeploy the function with a different name.
```

This is probably because Cloud Run took over Cloud Functions.