### PR TITLE
feat: handle BOT_NAME and BOT_LOCATION configuration via env

### DIFF
--- a/packages/gcf-utils/Dockerfile
+++ b/packages/gcf-utils/Dockerfile
@@ -16,13 +16,11 @@ FROM node:16-stretch
 
 USER root
 
-ENV PROJECT_ID=repo-automation-bots
-ENV GCF_SHORT_FUNCTION_NAME=snippet_bot
-ENV INSTALLATION_ID=9602930
-ENV GCF_LOCATION=us-central1
-
-COPY . /workspace
-RUN cd /workspace/packages/gcf-utils && \
+COPY . /code
+RUN cd /code && \
     npm --version && \
-    npm i && \
-    npm run system-test
+    npm i
+WORKDIR /code
+
+ENTRYPOINT [ "npm" ]
+CMD ["run", "system-test"]

--- a/packages/gcf-utils/cloudbuild-test.yaml
+++ b/packages/gcf-utils/cloudbuild-test.yaml
@@ -1,6 +1,32 @@
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'build', '--network=cloudbuild', '-t', 'test-result', '-f', 'packages/gcf-utils/Dockerfile', '.']
+    id: build
+    dir: packages/gcf-utils
+    args:
+    - 'build'
+    - '--network=cloudbuild'
+    - '-t'
+    - 'test-image'
+    - '-f'
+    - 'Dockerfile'
+    - '.'
+  - name: test-image
+    waitFor: ['build']
+    dir: /code
+    env:
+    - 'PROJECT_ID=$PROJECT_ID'
+    - 'GCF_SHORT_FUNCTION_NAME=snippet_bot'
+    - 'INSTALLATION_ID=9602930'
+    - 'GCF_LOCATION=us-central1'
+
+  - name: test-image
+    waitFor: ['build']
+    dir: /code
+    env:
+    - 'PROJECT_ID=$PROJECT_ID'
+    - 'BOT_NAME=snippet_bot'
+    - 'INSTALLATION_ID=9602930'
+    - 'BOT_LOCATION=us-central1'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -178,7 +178,10 @@ export async function getBotSecrets(
   options: BotSecretsOptions = {}
 ): Promise<BotSecrets> {
   const projectId = options.projectId ?? process.env.PROJECT_ID;
-  const botName = options.botName ?? process.env.GCF_SHORT_FUNCTION_NAME;
+  const botName =
+    options.botName ??
+    process.env.GCF_SHORT_FUNCTION_NAME ??
+    process.env.BOT_NAME;
   const secretsClient =
     options.secretsClient ??
     new SecretManagerV1.SecretManagerServiceClient({
@@ -276,8 +279,9 @@ export class GCFBootstrapper {
     options = {
       ...{
         projectId: process.env.PROJECT_ID,
-        functionName: process.env.GCF_SHORT_FUNCTION_NAME,
-        location: process.env.GCF_LOCATION,
+        functionName:
+          process.env.GCF_SHORT_FUNCTION_NAME ?? process.env.BOT_NAME,
+        location: process.env.GCF_LOCATION ?? process.env.BOT_LOCATION,
         payloadBucket: process.env.WEBHOOK_TMP,
         taskCaller: process.env.TASK_CALLER_SERVICE_ACCOUNT,
       },
@@ -304,13 +308,13 @@ export class GCFBootstrapper {
     this.projectId = options.projectId;
     if (!options.functionName) {
       throw new Error(
-        'Missing required `functionName`. Please provide as a constructor argument or set the GCF_SHORT_FUNCTION_NAME env variable.'
+        'Missing required `functionName`. Please provide as a constructor argument or set the GCF_SHORT_FUNCTION_NAME or BOT_NAME env variable.'
       );
     }
     this.functionName = options.functionName;
     if (!options.location) {
       throw new Error(
-        'Missing required `location`. Please provide as a constructor argument or set the GCF_LOCATION env variable.'
+        'Missing required `location`. Please provide as a constructor argument or set the GCF_LOCATION or BOT_LOCATION env variable.'
       );
     }
     this.location = options.location;
@@ -994,7 +998,8 @@ export class GCFBootstrapper {
   ): Promise<string> {
     if (this.taskTargetEnvironment === 'functions') {
       // https://us-central1-repo-automation-bots.cloudfunctions.net/merge_on_green
-      return `https://${location}-${projectId}.cloudfunctions.net/${botName}`;
+      const functionName = botName.replace(/-/g, '_');
+      return `https://${location}-${projectId}.cloudfunctions.net/${functionName}`;
     } else if (this.taskTargetEnvironment === 'run') {
       if (this.cloudRunURL) {
         return this.cloudRunURL;

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -1875,7 +1875,7 @@ describe('GCFBootstrapper', () => {
               'X-GitHub-Delivery': 'some-request-id',
               'Content-Type': 'application/json',
             }),
-            url: 'https://my-location-my-project.cloudfunctions.net/my-function-name',
+            url: 'https://my-location-my-project.cloudfunctions.net/my_function_name',
           },
         },
       });
@@ -1911,7 +1911,7 @@ describe('GCFBootstrapper', () => {
               'X-GitHub-Delivery': 'some-request-id',
               'Content-Type': 'application/json',
             }),
-            url: 'https://my-location-my-project.cloudfunctions.net/my-function-name',
+            url: 'https://my-location-my-project.cloudfunctions.net/my_function_name',
           },
         },
       });
@@ -2116,7 +2116,7 @@ describe('GCFBootstrapper', () => {
               'X-GitHub-Delivery': 'some-request-id',
               'Content-Type': 'application/json',
             }),
-            url: 'https://my-location-my-project.cloudfunctions.net/my-function-name-backend',
+            url: 'https://my-location-my-project.cloudfunctions.net/my_function_name_backend',
           },
         },
       });


### PR DESCRIPTION
Handle better env var names (GCF_SHORT_FUNCTION_NAME -> BOT_NAME and GCF_LOCATION -> BOT_LOCATION)

fix: ensure that Cloud Function URL uses underscored name of bot
test: fix test at runtime, not docker build time
test: set test env variables at runtime not build time