### PR TITLE
fix: set default taskTargetName based on runtime environment

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -258,6 +258,19 @@ function defaultTaskEnvironment(): BotEnvironment {
   return process.env.BOT_RUNTIME === 'run' ? 'run' : 'functions';
 }
 
+function defaultTaskTarget(
+  botEnvironment: BotEnvironment,
+  botName: string
+): string {
+  if (botEnvironment === 'run') {
+    // Cloud Run defaults to dasherized bot name + '-backend'
+    return `${botName.replace(/_/g, '-')}-backend`;
+  } else {
+    // Cloud Functions defaults to underscored bot name
+    return botName.replace(/-/g, '_');
+  }
+}
+
 export class GCFBootstrapper {
   probot?: Probot;
 
@@ -319,7 +332,9 @@ export class GCFBootstrapper {
     }
     this.location = options.location;
     this.payloadBucket = options.payloadBucket;
-    this.taskTargetName = options.taskTargetName || this.functionName;
+    this.taskTargetName =
+      options.taskTargetName ||
+      defaultTaskTarget(this.taskTargetEnvironment, this.functionName);
     this.taskCaller = options.taskCaller || DEFAULT_TASK_CALLER;
     this.flowControlDelayInSeconds = DEFAULT_FLOW_CONTROL_DELAY_IN_SECOND;
     this.cloudRunURL = undefined;

--- a/packages/gcf-utils/test/gcf-bootstrapper.ts
+++ b/packages/gcf-utils/test/gcf-bootstrapper.ts
@@ -1988,7 +1988,7 @@ describe('GCFBootstrapper', () => {
       // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/36436
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sinon.assert.calledOnceWithExactly(getServiceStub as any, {
-        name: 'projects/my-project/locations/my-location/services/my-function-name',
+        name: 'projects/my-project/locations/my-location/services/my-function-name-backend',
       });
       // Make sure the Cloud Run service URL is cached.
       await bootstrapper.enqueueTask({
@@ -2040,7 +2040,7 @@ describe('GCFBootstrapper', () => {
       // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/36436
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sinon.assert.calledOnceWithExactly(getServiceStub as any, {
-        name: 'projects/my-project/locations/my-location/services/my-function-name',
+        name: 'projects/my-project/locations/my-location/services/my-function-name-backend',
       });
     });
 
@@ -2084,7 +2084,7 @@ describe('GCFBootstrapper', () => {
       // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/36436
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sinon.assert.calledOnceWithExactly(getServiceStub as any, {
-        name: 'projects/my-project/locations/my-location/services/my-function-name',
+        name: 'projects/my-project/locations/my-location/services/my-function-name-backend',
       });
     });
 


### PR DESCRIPTION
For Cloud Run based bots, we no longer need to specify the taskTargetName. This also allows re-using the same frontend image for both a GCF backend and Cloud Run backend by configuring via environment variables (setting BOT_RUNTIME env var).