### PR TITLE
feat(owlbot): skip running owlbot on PRs from forks

### DIFF
--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -616,7 +616,9 @@ const runPostProcessor = async (
 ) => {
   // If the pull request is from a fork, skip.
   if (opts.head !== opts.base) {
-    logger.info(`head ${opts.head} does not match base ${opts.base} skipping PR from fork`);
+    logger.info(
+      `head ${opts.head} does not match base ${opts.base}, skipping PR from fork`
+    );
     return;
   }
   // Fetch the .Owlbot.lock.yaml from head of PR:

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -614,6 +614,11 @@ const runPostProcessor = async (
   logger: GCFLogger,
   breakLoop = true
 ) => {
+  // If the pull request is from a fork, skip.
+  if (opts.head !== opts.base) {
+    logger.info(`head ${opts.head} does not match base ${opts.base} skipping PR from fork`);
+    return;
+  }
   // Fetch the .Owlbot.lock.yaml from head of PR:
   let lock: OwlBotLock | undefined = undefined;
   async function createCheck(

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -59,6 +59,7 @@ import {shouldIgnoreRepo} from './should-ignore-repo';
 // We use lower case organization names here, so we need to always
 // check against lower cased owner.
 const ALLOWED_ORGANIZATIONS = ['googleapis', 'googlecloudplatform'];
+const ALLOWED_FORK_OWNERS = ['yoshi-code-bot'];
 const GOOGLEAPIS_INSTALLATION_ID = 14695777;
 
 interface PubSubContext {
@@ -615,7 +616,7 @@ const runPostProcessor = async (
   breakLoop = true
 ) => {
   // If the pull request is from a fork, skip.
-  if (opts.head !== opts.base) {
+  if (opts.head !== opts.base || ALLOWED_FORK_OWNERS.includes(opts.owner)) {
     logger.info(
       `head ${opts.head} does not match base ${opts.base}, skipping PR from fork`
     );

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -615,8 +615,9 @@ const runPostProcessor = async (
   logger: GCFLogger,
   breakLoop = true
 ) => {
-  // If the pull request is from a fork, skip.
-  if (opts.head !== opts.base || ALLOWED_FORK_OWNERS.includes(opts.owner)) {
+  // If the pull request is from a fork and not from allowlist, skip.
+  const forkOwner = opts.head.split('/')[0];
+  if (opts.head !== opts.base && !ALLOWED_FORK_OWNERS.includes(forkOwner)) {
     logger.info(
       `head ${opts.head} does not match base ${opts.base}, skipping PR from fork`
     );

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -922,7 +922,7 @@ describe('OwlBot', () => {
     });
   });
 
-  it('triggers build when "owlbot:run" label is added to fork', async () => {
+  it('does not trigger build when "owlbot:run" label is added to fork', async () => {
     const payload = {
       action: 'labeled',
       installation: {
@@ -959,15 +959,6 @@ describe('OwlBot', () => {
     image: node
     digest: sha256:9205bb385656cd196f5303b03983282c95c2dfab041d275465c525b501574e5c`;
     const githubMock = nock('https://api.github.com')
-      .get('/repos/googleapis/owl-bot-testing/pulls/33')
-      .reply(200, payload.pull_request)
-      .get(
-        '/repos/rennie/owl-bot-testing/contents/.github%2F.OwlBot.lock.yaml?ref=abc123'
-      )
-      .reply(200, {
-        content: Buffer.from(config).toString('base64'),
-        encoding: 'base64',
-      })
       .delete('/repos/googleapis/owl-bot-testing/issues/33/labels/owlbot%3Arun')
       .reply(200);
     const triggerBuildStub = sandbox
@@ -992,10 +983,10 @@ describe('OwlBot', () => {
       payload: payload as any,
       id: 'abc123',
     });
-    sandbox.assert.calledOnce(triggerBuildStub);
-    sandbox.assert.calledOnce(createCheckStub);
+    sandbox.assert.notCalled(triggerBuildStub);
+    sandbox.assert.notCalled(createCheckStub);
     sandbox.assert.notCalled(hasOwlBotLoopStub);
-    sandbox.assert.calledOnce(updatePullRequestStub);
+    sandbox.assert.notCalled(updatePullRequestStub);
     githubMock.done();
   });
   it('triggers build when "owlbot:run" label is added to PR from same repo', async () => {

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -977,7 +977,7 @@ describe('OwlBot', () => {
       .resolves(false);
     const createCheckStub = sandbox.stub(core, 'createCheck');
     const loggerStub = sandbox.stub(logger, 'info');
-        await probot.receive({
+    await probot.receive({
       name: 'pull_request',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       payload: payload as any,

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -921,7 +921,6 @@ describe('OwlBot', () => {
       assert.strictEqual(refreshConfigsStub.called, false);
     });
   });
-
   it('does not trigger build when "owlbot:run" label is added to fork', async () => {
     const payload = {
       action: 'labeled',
@@ -940,7 +939,7 @@ describe('OwlBot', () => {
         ],
         head: {
           repo: {
-            full_name: 'rennie/owl-bot-testing',
+            full_name: 'yoshi-code-bot/owl-bot-testing',
           },
           ref: 'abc123',
         },

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -939,7 +939,7 @@ describe('OwlBot', () => {
         ],
         head: {
           repo: {
-            full_name: 'yoshi-code-bot/owl-bot-testing',
+            full_name: 'rennie/owl-bot-testing',
           },
           ref: 'abc123',
         },
@@ -976,16 +976,97 @@ describe('OwlBot', () => {
       .stub(core, 'hasOwlBotLoop')
       .resolves(false);
     const createCheckStub = sandbox.stub(core, 'createCheck');
+    const loggerStub = sandbox.stub(logger, 'info');
+        await probot.receive({
+      name: 'pull_request',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      payload: payload as any,
+      id: 'abc123',
+    });
+    sandbox.assert.calledWith(
+      loggerStub,
+      sandbox.match(/.*skipping PR from fork*/)
+    );
+    sandbox.assert.notCalled(triggerBuildStub);
+    sandbox.assert.notCalled(createCheckStub);
+    sandbox.assert.notCalled(hasOwlBotLoopStub);
+    sandbox.assert.notCalled(updatePullRequestStub);
+    githubMock.done();
+  });
+  it('triggers build when "owlbot:run" label is added to yoshi-code-bot fork PR', async () => {
+    const payload = {
+      action: 'labeled',
+      installation: {
+        id: 12345,
+      },
+      sender: {
+        login: 'yoshi-code-bot',
+      },
+      pull_request: {
+        number: 33,
+        labels: [
+          {
+            name: OWLBOT_RUN_LABEL,
+          },
+        ],
+        head: {
+          repo: {
+            full_name: 'yoshi-code-bot/owl-bot-testing',
+          },
+          ref: 'abc123',
+        },
+        base: {
+          ref: 'blerg',
+          repo: {
+            full_name: 'googleapis/owl-bot-testing',
+          },
+        },
+      },
+      label: {
+        name: OWLBOT_RUN_LABEL,
+      },
+    };
+    const config = `docker:
+    image: node
+    digest: sha256:9205bb385656cd196f5303b03983282c95c2dfab041d275465c525b501574e5c`;
+    const githubMock = nock('https://api.github.com')
+      .get('/repos/googleapis/owl-bot-testing/pulls/33')
+      .reply(200, payload.pull_request)
+      .get(
+        '/repos/yoshi-code-bot/owl-bot-testing/contents/.github%2F.OwlBot.lock.yaml?ref=abc123'
+      )
+      .reply(200, {
+        content: Buffer.from(config).toString('base64'),
+        encoding: 'base64',
+      })
+      .delete('/repos/googleapis/owl-bot-testing/issues/33/labels/owlbot%3Arun')
+      .reply(200);
+    const triggerBuildStub = sandbox
+      .stub(core, 'triggerPostProcessBuild')
+      .resolves({
+        text: 'the text for check',
+        summary: 'summary for check',
+        conclusion: 'success',
+        detailsURL: 'http://www.example.com',
+      });
+    const updatePullRequestStub = sandbox.stub(
+      core,
+      'updatePullRequestAfterPostProcessor'
+    );
+    const hasOwlBotLoopStub = sandbox
+      .stub(core, 'hasOwlBotLoop')
+      .resolves(false);
+    const createCheckStub = sandbox.stub(core, 'createCheck');
     await probot.receive({
       name: 'pull_request',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       payload: payload as any,
       id: 'abc123',
     });
-    sandbox.assert.notCalled(triggerBuildStub);
-    sandbox.assert.notCalled(createCheckStub);
+    sandbox.assert.calledOnce(triggerBuildStub);
+    sandbox.assert.calledOnce(createCheckStub);
     sandbox.assert.notCalled(hasOwlBotLoopStub);
-    sandbox.assert.notCalled(updatePullRequestStub);
+    sandbox.assert.calledOnce(updatePullRequestStub);
     githubMock.done();
   });
   it('triggers build when "owlbot:run" label is added to PR from same repo', async () => {


### PR DESCRIPTION
Disable running OwlBot on fork PRs even if the `owlbot:run` label is added.
`yoshi-code-bot` is the only exception.

b/379713607

**Potential future enhancements**:
- Add a comment to the PR that OwlBot did not execute
- Do not remove the `owlbot:run` label
- Consider removing `yoshi-code-bot` from allowlist