### PR TITLE
build: update gcf-utils to 16.2.1 and use environment defaults

### DIFF
--- a/packages/cherry-pick-bot/package-lock.json
+++ b/packages/cherry-pick-bot/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-automations/bot-config-utils": "^8.0.0",
         "@octokit/rest": "^19.0.4",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0",
         "yargs": "^17.5.1"
       },
@@ -3959,9 +3959,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -11728,9 +11728,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/cherry-pick-bot/package.json
+++ b/packages/cherry-pick-bot/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@google-automations/bot-config-utils": "^8.0.0",
     "@octokit/rest": "^19.0.4",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0",
     "yargs": "^17.5.1"
   },

--- a/packages/cherry-pick-bot/src/server.ts
+++ b/packages/cherry-pick-bot/src/server.ts
@@ -15,9 +15,7 @@
 import {GCFBootstrapper} from 'gcf-utils';
 import appFn from './bot';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'run',
-});
+const bootstrap = new GCFBootstrapper();
 const server = bootstrap.server(appFn);
 const port = process.env.PORT ?? 8080;
 


### PR DESCRIPTION
Currently, the `cherry-pick-bot` is queuing backend requests to target the frontend Cloud Run service (`cherry-pick-bot`) rather than the backend (`cherry-pick-bot-backend`). This updates `gcf-utils` to correctly default to target the Cloud Run backend service which has the appropriate permissions.

Prior to gcf-utils 16.2.0, the default Cloud Run backend was the name of the bot (which is actually the frontend)