### PR TITLE
deps: upgrade gcf-based bots to gcf-utils 16.2.1

### DIFF
--- a/packages/auto-label/package-lock.json
+++ b/packages/auto-label/package-lock.json
@@ -12,7 +12,7 @@
         "@google-automations/bot-config-utils": "^8.0.0",
         "@google-automations/label-utils": "^5.0.0",
         "@google-cloud/storage": "^7.12.1",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
@@ -4194,9 +4194,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -12248,9 +12248,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/auto-label/package.json
+++ b/packages/auto-label/package.json
@@ -31,7 +31,7 @@
     "@google-automations/bot-config-utils": "^8.0.0",
     "@google-automations/label-utils": "^5.0.0",
     "@google-cloud/storage": "^7.12.1",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/auto-label/src/server.ts
+++ b/packages/auto-label/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please

--- a/packages/blunderbuss/package-lock.json
+++ b/packages/blunderbuss/package-lock.json
@@ -12,7 +12,7 @@
         "@google-automations/bot-config-utils": "^8.0.0",
         "@google-automations/datastore-lock": "^6.0.0",
         "@google-automations/label-utils": "^5.0.0",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
@@ -4189,9 +4189,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -12224,9 +12224,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/blunderbuss/package.json
+++ b/packages/blunderbuss/package.json
@@ -31,7 +31,7 @@
     "@google-automations/bot-config-utils": "^8.0.0",
     "@google-automations/datastore-lock": "^6.0.0",
     "@google-automations/label-utils": "^5.0.0",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/blunderbuss/src/server.ts
+++ b/packages/blunderbuss/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please

--- a/packages/conventional-commit-lint/package-lock.json
+++ b/packages/conventional-commit-lint/package-lock.json
@@ -16,7 +16,7 @@
         "@octokit/graphql": "^5.0.4",
         "@octokit/openapi-types": "^14.0.0",
         "@octokit/webhooks-types": "^6.3.6",
-        "gcf-utils": "^16.0.0",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
@@ -4100,9 +4100,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/conventional-commit-lint/package.json
+++ b/packages/conventional-commit-lint/package.json
@@ -36,7 +36,7 @@
     "@octokit/graphql": "^5.0.4",
     "@octokit/openapi-types": "^14.0.0",
     "@octokit/webhooks-types": "^6.3.6",
-    "gcf-utils": "^16.0.0",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/conventional-commit-lint/src/server.ts
+++ b/packages/conventional-commit-lint/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please

--- a/packages/do-not-merge/package-lock.json
+++ b/packages/do-not-merge/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@google-automations/bot-config-utils": "^8.0.0",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
@@ -3946,9 +3946,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -11750,9 +11750,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/do-not-merge/package.json
+++ b/packages/do-not-merge/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@google-automations/bot-config-utils": "^8.0.0",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/do-not-merge/src/server.ts
+++ b/packages/do-not-merge/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the bot backend. Thus

--- a/packages/failurechecker/package-lock.json
+++ b/packages/failurechecker/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@google-automations/issue-utils": "^4.0.0",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
@@ -4060,9 +4060,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -11952,9 +11952,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/failurechecker/package.json
+++ b/packages/failurechecker/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@google-automations/issue-utils": "^4.0.0",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/failurechecker/src/server.ts
+++ b/packages/failurechecker/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please

--- a/packages/flakybot/package-lock.json
+++ b/packages/flakybot/package-lock.json
@@ -14,7 +14,7 @@
         "@google-automations/label-utils": "^5.0.0",
         "@octokit/openapi-types": "^14.0.0",
         "@octokit/types": "^8.0.0",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0",
         "probot": "^12.2.8",
         "xml-js": "^1.6.11"
@@ -3894,9 +3894,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -11452,9 +11452,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/flakybot/package.json
+++ b/packages/flakybot/package.json
@@ -32,7 +32,7 @@
     "@google-automations/label-utils": "^5.0.0",
     "@octokit/openapi-types": "^14.0.0",
     "@octokit/types": "^8.0.0",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0",
     "probot": "^12.2.8",
     "xml-js": "^1.6.11"

--- a/packages/flakybot/src/server.ts
+++ b/packages/flakybot/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please

--- a/packages/generated-files-bot/package-lock.json
+++ b/packages/generated-files-bot/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-automations/bot-config-utils": "^8.0.0",
         "@google-automations/issue-utils": "^4.0.0",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "js-yaml": "^4.1.0",
         "jsonpath": "^1.1.1",
         "jsonwebtoken": "^9.0.0",
@@ -4120,9 +4120,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -12130,9 +12130,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/generated-files-bot/package.json
+++ b/packages/generated-files-bot/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@google-automations/bot-config-utils": "^8.0.0",
     "@google-automations/issue-utils": "^4.0.0",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "js-yaml": "^4.1.0",
     "jsonpath": "^1.1.1",
     "jsonwebtoken": "^9.0.0",

--- a/packages/generated-files-bot/src/server.ts
+++ b/packages/generated-files-bot/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please

--- a/packages/header-checker-lint/package-lock.json
+++ b/packages/header-checker-lint/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@google-automations/bot-config-utils": "^8.0.0",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0",
         "minimatch": "^5.1.0"
       },
@@ -3945,9 +3945,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -11634,9 +11634,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/header-checker-lint/package.json
+++ b/packages/header-checker-lint/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@google-automations/bot-config-utils": "^8.0.0",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0",
     "minimatch": "^5.1.0"
   },

--- a/packages/header-checker-lint/src/server.ts
+++ b/packages/header-checker-lint/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please

--- a/packages/label-sync/package-lock.json
+++ b/packages/label-sync/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-cloud/storage": "^7.0.0",
         "gaxios": "^5.0.1",
-        "gcf-utils": "^16.0.0",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
@@ -3746,9 +3746,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/label-sync/package.json
+++ b/packages/label-sync/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@google-cloud/storage": "^7.0.0",
     "gaxios": "^5.0.1",
-    "gcf-utils": "^16.0.0",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/label-sync/src/server.ts
+++ b/packages/label-sync/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please

--- a/packages/merge-on-green/package-lock.json
+++ b/packages/merge-on-green/package-lock.json
@@ -12,7 +12,7 @@
         "@google-automations/label-utils": "^5.0.0",
         "@google-cloud/datastore": "^9.1.0",
         "aggregate-error": "^3.1.0",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
@@ -3812,9 +3812,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/merge-on-green/package.json
+++ b/packages/merge-on-green/package.json
@@ -30,7 +30,7 @@
     "@google-automations/label-utils": "^5.0.0",
     "@google-cloud/datastore": "^9.1.0",
     "aggregate-error": "^3.1.0",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/merge-on-green/src/server.ts
+++ b/packages/merge-on-green/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please

--- a/packages/repo-metadata-lint/package-lock.json
+++ b/packages/repo-metadata-lint/package-lock.json
@@ -14,7 +14,7 @@
         "@octokit/rest": "^19.0.4",
         "ajv": "^8.11.0",
         "gaxios": "^5.0.1",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0",
         "yargs": "^17.5.1"
       },
@@ -3787,9 +3787,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -10869,9 +10869,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/repo-metadata-lint/package.json
+++ b/packages/repo-metadata-lint/package.json
@@ -33,7 +33,7 @@
     "@octokit/rest": "^19.0.4",
     "ajv": "^8.11.0",
     "gaxios": "^5.0.1",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0",
     "yargs": "^17.5.1"
   },

--- a/packages/repo-metadata-lint/src/server.ts
+++ b/packages/repo-metadata-lint/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please

--- a/packages/sync-repo-settings/package-lock.json
+++ b/packages/sync-repo-settings/package-lock.json
@@ -12,7 +12,7 @@
         "@google-automations/bot-config-utils": "^8.0.0",
         "@google-automations/issue-utils": "^4.0.0",
         "extend": "^3.0.2",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.0",
         "yargs": "^17.5.1"
@@ -4258,9 +4258,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/sync-repo-settings/package.json
+++ b/packages/sync-repo-settings/package.json
@@ -30,7 +30,7 @@
     "@google-automations/bot-config-utils": "^8.0.0",
     "@google-automations/issue-utils": "^4.0.0",
     "extend": "^3.0.2",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.0",
     "yargs": "^17.5.1"

--- a/packages/sync-repo-settings/src/server.ts
+++ b/packages/sync-repo-settings/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please

--- a/packages/trusted-contribution/package-lock.json
+++ b/packages/trusted-contribution/package-lock.json
@@ -12,7 +12,7 @@
         "@google-automations/bot-config-utils": "^8.0.0",
         "@google-automations/issue-utils": "^4.0.0",
         "@google-cloud/secret-manager": "^5.6.0",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
@@ -3876,9 +3876,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -11452,9 +11452,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/trusted-contribution/package.json
+++ b/packages/trusted-contribution/package.json
@@ -30,7 +30,7 @@
     "@google-automations/bot-config-utils": "^8.0.0",
     "@google-automations/issue-utils": "^4.0.0",
     "@google-cloud/secret-manager": "^5.6.0",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/trusted-contribution/src/server.ts
+++ b/packages/trusted-contribution/src/server.ts
@@ -16,9 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'functions',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because
 // only thing it does is to enqueue a task for the release-please


### PR DESCRIPTION
This allows bots to configure the task-caller service account via environment variables (configured via terraform). It also has the bots rely on env variables for setting the backend type.
