### PR TITLE
deps: update gcf-utils to 16.2.1

### DIFF
--- a/packages/owl-bot/package-lock.json
+++ b/packages/owl-bot/package-lock.json
@@ -24,7 +24,7 @@
         "follow-redirects": "^1.15.2",
         "fs-extra": "^11.0.0",
         "gaxios": "^5.0.1",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "glob": "^8.0.3",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.0",
@@ -4516,9 +4516,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.1.tgz",
-      "integrity": "sha512-1KyfJV+cQO/OCt5iqtSQJJrXH908vQXJXVfuo47Iaa4k8Kxl+Vt7YJdilIc+gl631QJ60tFgYHeXoSpvR5+fZw==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -12758,9 +12758,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.1.tgz",
-      "integrity": "sha512-1KyfJV+cQO/OCt5iqtSQJJrXH908vQXJXVfuo47Iaa4k8Kxl+Vt7YJdilIc+gl631QJ60tFgYHeXoSpvR5+fZw==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -81,7 +81,7 @@
     "follow-redirects": "^1.15.2",
     "fs-extra": "^11.0.0",
     "gaxios": "^5.0.1",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "glob": "^8.0.3",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/owl-bot/src/server-backend.ts
+++ b/packages/owl-bot/src/server-backend.ts
@@ -20,10 +20,7 @@ import {GCFBootstrapper} from 'gcf-utils';
 
 import {owlbot} from './owl-bot';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'run',
-  taskTargetName: 'owl-bot-backend',
-});
+const bootstrap = new GCFBootstrapper();
 
 // Initialize firestore app here to avoid race condition.
 admin.initializeApp({

--- a/packages/owl-bot/src/server-frontend.ts
+++ b/packages/owl-bot/src/server-frontend.ts
@@ -16,10 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'run',
-  taskTargetName: 'owl-bot-backend',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because only thing
 // it does is to enqueue a task for the OwlBot backend. Thus we deploy a dummy

--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -15,7 +15,7 @@
         "@google-automations/label-utils": "^5.0.0",
         "@octokit/rest": "^19.0.4",
         "@octokit/webhooks": "^10.1.5",
-        "gcf-utils": "^16.1.0",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0",
         "release-please": "^16.14.4"
       },
@@ -4098,9 +4098,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -34,7 +34,7 @@
     "@google-automations/label-utils": "^5.0.0",
     "@octokit/rest": "^19.0.4",
     "@octokit/webhooks": "^10.1.5",
-    "gcf-utils": "^16.1.0",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0",
     "release-please": "^16.14.4"
   },

--- a/packages/release-please/src/server.ts
+++ b/packages/release-please/src/server.ts
@@ -15,10 +15,7 @@
 import {GCFBootstrapper} from 'gcf-utils';
 import {api} from './release-please';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'run',
-  taskTargetName: 'release-please-backend',
-});
+const bootstrap = new GCFBootstrapper();
 const server = bootstrap.server(api.handler, {throttleOnRateLimits: false});
 const port = process.env.PORT ?? 8080;
 

--- a/packages/release-trigger/package-lock.json
+++ b/packages/release-trigger/package-lock.json
@@ -12,7 +12,7 @@
         "@google-automations/bot-config-utils": "^8.0.0",
         "@google-automations/datastore-lock": "^6.0.0",
         "@google-automations/issue-utils": "^4.0.0",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
@@ -3932,9 +3932,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -11397,9 +11397,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/release-trigger/package.json
+++ b/packages/release-trigger/package.json
@@ -31,7 +31,7 @@
     "@google-automations/bot-config-utils": "^8.0.0",
     "@google-automations/datastore-lock": "^6.0.0",
     "@google-automations/issue-utils": "^4.0.0",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/release-trigger/src/server-frontend.ts
+++ b/packages/release-trigger/src/server-frontend.ts
@@ -16,10 +16,7 @@
 import {Probot} from 'probot';
 import {GCFBootstrapper} from 'gcf-utils';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'run',
-  taskTargetName: 'release-trigger-backend',
-});
+const bootstrap = new GCFBootstrapper();
 
 // We only need to deploy gcf-utils in the frontend server because only thing
 // it does is to enqueue a task for the backend. Thus we deploy a dummy

--- a/packages/release-trigger/src/server.ts
+++ b/packages/release-trigger/src/server.ts
@@ -15,10 +15,7 @@
 import {GCFBootstrapper} from 'gcf-utils';
 import appFn from './bot';
 
-const bootstrap = new GCFBootstrapper({
-  taskTargetEnvironment: 'run',
-  taskTargetName: 'release-trigger-backend',
-});
+const bootstrap = new GCFBootstrapper();
 const server = bootstrap.server(appFn);
 const port = process.env.PORT ?? 8080;
 

--- a/packages/snippet-bot/package-lock.json
+++ b/packages/snippet-bot/package-lock.json
@@ -15,7 +15,7 @@
         "@google-automations/label-utils": "^5.0.0",
         "@google-cloud/storage": "^7.12.1",
         "follow-redirects": "^1.15.1",
-        "gcf-utils": "^16.0.1",
+        "gcf-utils": "^16.2.1",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.0",
         "lru-cache": "^7.14.0",
@@ -4175,9 +4175,9 @@
       }
     },
     "node_modules/gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "dependencies": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",
@@ -12182,9 +12182,9 @@
       }
     },
     "gcf-utils": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.1.0.tgz",
-      "integrity": "sha512-BwA8U45hE5L9UDhuiCGq8YYzqTp3egslhaekMrQ+dEv3N5NFdRUi0ollWlMKGHIIPOWKWU6cVTUeG3w2wIeEpA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/gcf-utils/-/gcf-utils-16.2.1.tgz",
+      "integrity": "sha512-Kj2OYO68XBfoD9dzsh1cAlx2EXVaMr1xoPvGQsWyVCVVeaGNp6nOS23HiGiYe5v7tYlhlDhF8FPoixCya4FtKA==",
       "requires": {
         "@google-cloud/run": "^1.4.0",
         "@google-cloud/secret-manager": "^5.6.0",

--- a/packages/snippet-bot/package.json
+++ b/packages/snippet-bot/package.json
@@ -35,7 +35,7 @@
     "@google-automations/label-utils": "^5.0.0",
     "@google-cloud/storage": "^7.12.1",
     "follow-redirects": "^1.15.1",
-    "gcf-utils": "^16.0.1",
+    "gcf-utils": "^16.2.1",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.0",
     "lru-cache": "^7.14.0",


### PR DESCRIPTION
For the remaining Cloud Run based bots, update gcf-utils to 16.2.1 which allows for configuring the background task runner via env variables.