### PR TITLE
fix: send pubsub messages to Cloud Run version of owl-bot

### DIFF
--- a/serverless-scheduler-proxy/main.go
+++ b/serverless-scheduler-proxy/main.go
@@ -113,7 +113,7 @@ func rewriteBotContainerURL(c botConfig) func(*http.Request) {
 			log.Printf("handling container pubsub message for subscription: %v\n", pay.Subscription)
 			// TODO: pull bot name and location into configuration, once
 			// we validate this approach:
-			return "owl_bot", "us-central1", "function"
+			return "owl_bot", "us-central1", "run"
 		}
 		rewriteBotURL(c, parser, req)
 	}


### PR DESCRIPTION
This will allow us to run only the Cloud Run versions of the owl-bot backends