### PR TITLE
fix: release-trigger: use trusted docker registry

### DIFF
--- a/packages/release-trigger/Dockerfile
+++ b/packages/release-trigger/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-FROM node:18.20.5-bullseye AS BASE
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/node:18 AS BASE
 
 # Install pyenv dependencies
 RUN apt-get update && \

--- a/packages/release-trigger/cloudbuild-test.yaml
+++ b/packages/release-trigger/cloudbuild-test.yaml
@@ -13,9 +13,19 @@
 # limitations under the License.
 
 steps:
+  - name: gcr.io/cloud-builders/gcloud
+    id: "configure-registry"
+    waitFor: ["-"]
+    entrypoint: gcloud
+    dir: $_DIRECTORY
+    args:
+      - "auth"
+      - "configure-docker"
+      - "us-docker.pkg.dev"
+
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"
-    waitFor: ["-"]
+    waitFor: ["configure-registry"]
     dir: packages/release-trigger
     args:
       - "build"

--- a/packages/release-trigger/cloudbuild.yaml
+++ b/packages/release-trigger/cloudbuild.yaml
@@ -13,9 +13,19 @@
 # limitations under the License.
 
 steps:
+  - name: gcr.io/cloud-builders/gcloud
+    id: "configure-registry"
+    waitFor: ["-"]
+    entrypoint: gcloud
+    dir: $_DIRECTORY
+    args:
+      - "auth"
+      - "configure-docker"
+      - "us-docker.pkg.dev"
+
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"
-    waitFor: ["-"]
+    waitFor: ["configure-registry"]
     dir: packages/release-trigger
     args:
       - "build"


### PR DESCRIPTION
See b/382229925

This PR changes the backend release-trigger base image to use the `us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/` registry.