### PR TITLE
feat(release-trigger): Add GoogleCloudDataproc to allowlist

### DIFF
--- a/packages/release-trigger/src/release-trigger.ts
+++ b/packages/release-trigger/src/release-trigger.ts
@@ -63,7 +63,11 @@ export const execFile = function (
   });
 };
 
-export const ALLOWED_ORGANIZATIONS = ['googleapis', 'GoogleCloudPlatform'];
+export const ALLOWED_ORGANIZATIONS = [
+  'googleapis',
+  'GoogleCloudDataproc',
+  'GoogleCloudPlatform',
+];
 
 export const FAILED_LABEL = 'autorelease: failed';
 export const TAGGED_LABEL = 'autorelease: tagged';


### PR DESCRIPTION
Adding the Dataproc organization to the release-trigger allowlist.