### PR TITLE
fix: allowlist google map repos for snippet bot

### DIFF
--- a/packages/snippet-bot/src/snippet-bot.ts
+++ b/packages/snippet-bot/src/snippet-bot.ts
@@ -85,7 +85,7 @@ const REFRESH_STRING = '- [x] Refresh this comment';
 // Github issue comment API has a limit of 65536 characters.
 const MAX_CHARS_IN_COMMENT = 64000;
 
-const ALLOWED_ORGANIZATIONS = ['googleapis', 'GoogleCloudPlatform'];
+const ALLOWED_ORGANIZATIONS = ['googleapis', 'GoogleCloudPlatform', 'googlemaps', 'googlemaps-samples'];
 
 async function getFiles(dir: string, allFiles: string[]) {
   const files = (await pfs.readdir(dir)).map(f => path.join(dir, f));

--- a/packages/snippet-bot/src/snippet-bot.ts
+++ b/packages/snippet-bot/src/snippet-bot.ts
@@ -85,7 +85,12 @@ const REFRESH_STRING = '- [x] Refresh this comment';
 // Github issue comment API has a limit of 65536 characters.
 const MAX_CHARS_IN_COMMENT = 64000;
 
-const ALLOWED_ORGANIZATIONS = ['googleapis', 'GoogleCloudPlatform', 'googlemaps', 'googlemaps-samples'];
+const ALLOWED_ORGANIZATIONS = [
+  'googleapis',
+  'GoogleCloudPlatform',
+  'googlemaps',
+  'googlemaps-samples',
+];
 
 async function getFiles(dir: string, allFiles: string[]) {
   const files = (await pfs.readdir(dir)).map(f => path.join(dir, f));


### PR DESCRIPTION
We restricted snippet-bot to only run on GCP client library repos, but google maps also uses it internally, so adding to allowlist.

Fixes #5626 🦕
