### PR TITLE
feat(deps): upgrade release-please to 16.15.0 adding new config attribute

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -17,7 +17,7 @@
         "@octokit/webhooks": "^10.1.5",
         "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0",
-        "release-please": "^16.14.4"
+        "release-please": "^16.15.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
@@ -7503,9 +7503,10 @@
       }
     },
     "node_modules/release-please": {
-      "version": "16.14.4",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-16.14.4.tgz",
-      "integrity": "sha512-3i4ze8hkdMhaCvQpJS+m5q6W5UljOcVtBEDkV/k4TU7RvYmfBJz5V97YO00VXvl7F4W8r5orTFNUk66BlnQ0Jw==",
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-16.15.0.tgz",
+      "integrity": "sha512-C55PsUOMzAbPSrdqF/KKAqhaYVRGlarNNWgW/DyAsg15U4g/TkxXVpEZqAV1o38CoEoKhssnKTGnb5/eT4/DUw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^2.0.0",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -36,7 +36,7 @@
     "@octokit/webhooks": "^10.1.5",
     "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0",
-    "release-please": "^16.14.4"
+    "release-please": "^16.15.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",


### PR DESCRIPTION
Hi,

Noticed that the github app is lagging behind on release-please, which makes the newest configuration `always-update` unavailable. This should fix that.

Fixes #5628  🦕

