### PR TITLE
build: configure logs bucket for custom service accounts

### DIFF
--- a/packages/cherry-pick-bot/cloudbuild-test.yaml
+++ b/packages/cherry-pick-bot/cloudbuild-test.yaml
@@ -25,3 +25,7 @@ steps:
 
   # TODO: create container test
   # TODO: create unit & integration tests
+
+logsBucket: 'gs://cherry-pick-bot-deploy-logs'
+options:
+  logging: GCS_ONLY

--- a/packages/cherry-pick-bot/cloudbuild.yaml
+++ b/packages/cherry-pick-bot/cloudbuild.yaml
@@ -61,3 +61,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--quiet"
+
+logsBucket: 'gs://cherry-pick-bot-deploy-logs'
+options:
+  logging: GCS_ONLY

--- a/packages/flakybot/cloudbuild.yaml
+++ b/packages/flakybot/cloudbuild.yaml
@@ -70,3 +70,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--quiet"
+
+logsBucket: 'gs://flakybot-deploy-logs'
+options:
+  logging: GCS_ONLY

--- a/packages/release-please/cloudbuild.yaml
+++ b/packages/release-please/cloudbuild.yaml
@@ -63,3 +63,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--quiet"
+
+logsBucket: 'gs://release-please-deploy-logs'
+options:
+  logging: GCS_ONLY

--- a/packages/release-trigger/cloudbuild-test.yaml
+++ b/packages/release-trigger/cloudbuild-test.yaml
@@ -45,3 +45,7 @@ steps:
       - "-t"
       - "gcr.io/$PROJECT_ID/release-trigger"
       - "."
+
+logsBucket: 'gs://release-trigger-deploy-logs'
+options:
+  logging: GCS_ONLY

--- a/packages/release-trigger/cloudbuild.yaml
+++ b/packages/release-trigger/cloudbuild.yaml
@@ -78,3 +78,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--quiet"
+
+logsBucket: 'gs://release-trigger-deploy-logs'
+options:
+  logging: GCS_ONLY

--- a/packages/snippet-bot/cloudbuild-test.yaml
+++ b/packages/snippet-bot/cloudbuild-test.yaml
@@ -47,3 +47,7 @@ steps:
       - "-t"
       - "gcr.io/$PROJECT_ID/snippet-bot-frontend"
       - "."
+
+logsBucket: 'gs://snippet-bot-deploy-logs'
+options:
+  logging: GCS_ONLY

--- a/packages/snippet-bot/cloudbuild.yaml
+++ b/packages/snippet-bot/cloudbuild.yaml
@@ -80,3 +80,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--quiet"
+
+logsBucket: 'gs://snippet-bot-deploy-logs'
+options:
+  logging: GCS_ONLY


### PR DESCRIPTION
Configure the remaining bots to use logs buckets for dedicated service accounts
