### PR TITLE
fix(owl-bot): OwlBot to report a skip in pull request checks

### DIFF
--- a/packages/owl-bot/cloudbuild-test.yaml
+++ b/packages/owl-bot/cloudbuild-test.yaml
@@ -24,5 +24,8 @@ steps:
       - "-t"
       - "gcr.io/$PROJECT_ID/owl-bot"
       - "."
+logsBucket: 'gs://owl-bot-deploy-logs'
+options:
+  logging: GCS_ONLY
 
   # TODO: run container test and functional/integration test

--- a/packages/owl-bot/src/core.ts
+++ b/packages/owl-bot/src/core.ts
@@ -50,7 +50,7 @@ export interface CheckArgs {
   pr: number;
   repo: string;
   summary: string;
-  conclusion: 'success' | 'failure';
+  conclusion: 'success' | 'failure' | 'skipped';
   detailsURL: string;
   text: string;
   title: string;

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -615,14 +615,6 @@ const runPostProcessor = async (
   logger: GCFLogger,
   breakLoop = true
 ) => {
-  // If the pull request is from a fork and not from allowlist, skip.
-  const forkOwner = opts.head.split('/')[0];
-  if (opts.head !== opts.base && !ALLOWED_FORK_OWNERS.includes(forkOwner)) {
-    logger.info(
-      `head ${opts.head} does not match base ${opts.base}, skipping PR from fork`
-    );
-    return;
-  }
   // Fetch the .Owlbot.lock.yaml from head of PR:
   let lock: OwlBotLock | undefined = undefined;
   async function createCheck(
@@ -656,6 +648,22 @@ const runPostProcessor = async (
       return;
     }
     logger.info(`Created ${logLine}`);
+  }
+
+  // If the pull request is from a fork and not from allowlist, skip.
+  const forkOwner = opts.head.split('/')[0];
+  if (opts.head !== opts.base && !ALLOWED_FORK_OWNERS.includes(forkOwner)) {
+    logger.info(
+      `head ${opts.head} does not match base ${opts.base}, skipping PR from fork`
+    );
+    await createCheck({
+      text: 'Ignored by Owl Bot because the pull request was created from a fork. See go/owlbot-skip-forks.',
+      summary:
+        'Ignored by Owl Bot because the pull request was created from a fork',
+      conclusion: 'success',
+      title: '🦉 OwlBot - skipped this pull request from a fork',
+    });
+    return;
   }
 
   // Attempt to load the OwlBot lock file for a repository, if the lock

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -660,7 +660,7 @@ const runPostProcessor = async (
       text: 'Ignored by Owl Bot because the pull request was created from a fork. See go/owlbot-skip-forks.',
       summary:
         'Ignored by Owl Bot because the pull request was created from a fork',
-      conclusion: 'success',
+      conclusion: 'skipped',
       title: '🦉 OwlBot - skipped this pull request from a fork',
     });
     return;

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -990,7 +990,7 @@ describe('OwlBot', () => {
     sandbox.assert.notCalled(triggerBuildStub);
     sandbox.assert.calledWith(
       createCheckStub,
-      sinon.match.has('conclusion', 'success')
+      sinon.match.has('conclusion', 'skipped')
     );
     sandbox.assert.calledWith(
       createCheckStub,

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -988,7 +988,17 @@ describe('OwlBot', () => {
       sandbox.match(/.*skipping PR from fork*/)
     );
     sandbox.assert.notCalled(triggerBuildStub);
-    sandbox.assert.notCalled(createCheckStub);
+    sandbox.assert.calledWith(
+      createCheckStub,
+      sinon.match.has('conclusion', 'success')
+    );
+    sandbox.assert.calledWith(
+      createCheckStub,
+      sinon.match.has(
+        'text',
+        'Ignored by Owl Bot because the pull request was created from a fork. See go/owlbot-skip-forks.'
+      )
+    );
     sandbox.assert.notCalled(hasOwlBotLoopStub);
     sandbox.assert.notCalled(updatePullRequestStub);
     githubMock.done();


### PR DESCRIPTION
- **fix: OwlBot postprocessor to report a check when skipping a PR**

b/385183332. After https://github.com/googleapis/repo-automation-bots/pull/5587 and before this change, the post processor checks were silently skipped and those repositories that mark it as required cannot merge pull requests from external contributors.

---

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/repo-automation-bots/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
