### PR TITLE
fix(owl-bot): cloud build bucket configuration

### DIFF
--- a/packages/owl-bot/cloudbuild.yaml
+++ b/packages/owl-bot/cloudbuild.yaml
@@ -108,3 +108,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--quiet"
+
+logsBucket: 'gs://owl-bot-deploy-logs'
+options:
+  logging: GCS_ONLY


### PR DESCRIPTION
The deployment failed due to logging configuration (b/385183332#comment10).

This is the same lines that I added in cloudbuild-test.yaml: https://github.com/googleapis/repo-automation-bots/pull/5643/files#diff-ae6d90a3673680601c94bddc10655dd45aecb86e240c4c9d2702b46f6c5eb7d9R27

This file matches what is in the trigger configuration.
