### PR TITLE
fix: Upgrade dependencies in packages/conventional-commit-lint

### DIFF
--- a/packages/conventional-commit-lint/package-lock.json
+++ b/packages/conventional-commit-lint/package-lock.json
@@ -32,7 +32,7 @@
         "nock": "^13.2.9",
         "sinon": "^15.0.0",
         "smee-client": "^1.2.3",
-        "snap-shot-it": "^7.9.6",
+        "snap-shot-it": "^7.4.1",
         "typescript": "~4.9.0"
       },
       "engines": {
@@ -2217,9 +2217,9 @@
       }
     },
     "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
       "dev": true
     },
     "node_modules/argparse": {
@@ -2773,9 +2773,9 @@
       }
     },
     "node_modules/common-tags": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
-      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
       "dev": true,
       "engines": {
         "node": ">=4.0.0"
@@ -3071,25 +3071,31 @@
       }
     },
     "node_modules/disparity": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/disparity/-/disparity-3.0.0.tgz",
-      "integrity": "sha512-n94Rzbv2ambRaFzrnBf34IEiyOdIci7maRpMkoQWB6xFYGA7Nbs0Z5YQzMfTeyQeelv23nayqOcssBoc6rKrgw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
+      "integrity": "sha512-caMA9oIQbDeobWc9MVUF0+o1APVo0UZnfD482x0RaLLAzpAc6Dla2mk5ef7onsG91tziIRr41rj4sVt3BOLLZw==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "diff": "^4.0.1"
+        "ansi-styles": "^2.0.1",
+        "diff": "^1.3.2"
       },
       "bin": {
         "disparity": "bin/disparity"
-      },
+      }
+    },
+    "node_modules/disparity/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/disparity/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha512-VzVc42hMZbYU9Sx/ltb7KYuQ6pqAw+cbFWVy4XKdkuEL2CFaRLGEnISPs7YdzaUGpi+CpIqvRmu7hPQ4T7EQ5w==",
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
@@ -3963,9 +3969,9 @@
       "dev": true
     },
     "node_modules/folktale": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/folktale/-/folktale-2.3.2.tgz",
-      "integrity": "sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/folktale/-/folktale-2.0.1.tgz",
+      "integrity": "sha512-3kDSWVkSlErHIt/dC73vu+5zRqbW1mlnL46s2QfYN7Ps0JcS9MVtuLCrDQOBa7sanA+d9Fd8F+bn0VcyNe68Jw==",
       "deprecated": "This package is no longer actively maintained. Only security patches will be provided, if needed. Consider switching to fp-ts.",
       "dev": true
     },
@@ -5275,15 +5281,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/its-name": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/its-name/-/its-name-1.0.0.tgz",
-      "integrity": "sha512-GYUWFxViqxDvGzsNEItTEuOqqAQVx29Xl9Lh5YUqyJd6gPHTCMiIbjqcjjyUzsBUqEcgwIdRoydwgfFw1oYbhg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
@@ -5903,16 +5900,23 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "dev": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
+    },
+    "node_modules/mkdirp/node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
+      "dev": true
     },
     "node_modules/mocha": {
       "version": "10.4.0",
@@ -6716,9 +6720,9 @@
       }
     },
     "node_modules/pluralize": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -7274,14 +7278,10 @@
       "dev": true
     },
     "node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "dev": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -7953,17 +7953,16 @@
       }
     },
     "node_modules/snap-shot-compare": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/snap-shot-compare/-/snap-shot-compare-3.0.0.tgz",
-      "integrity": "sha512-bdwNOAGuKwPU+qsn0ASxTv+QfkXU+3VmkcDOkt965tes+JQQc8d6SfoLiEiRVhCey4v+ip2IjNUSbZm5nnkI9g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/snap-shot-compare/-/snap-shot-compare-2.8.0.tgz",
+      "integrity": "sha512-7zQ6GWMvgwK7vdvis3cdrxujLUX4Xefz+CFmUFMy+FzhfC0dK5TRrwiCDy5J2nwHz0hKNPt0W3m1l/ZBTTz6mg==",
       "dev": true,
       "dependencies": {
         "check-more-types": "2.24.0",
-        "debug": "4.1.1",
-        "disparity": "3.0.0",
-        "folktale": "2.3.2",
+        "disparity": "2.0.0",
+        "folktale": "2.0.1",
         "lazy-ass": "1.6.0",
-        "strip-ansi": "5.2.0",
+        "strip-ansi": "4.0.0",
         "variable-diff": "1.1.0"
       },
       "engines": {
@@ -7971,15 +7970,54 @@
       }
     },
     "node_modules/snap-shot-compare/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/snap-shot-compare/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/snap-shot-core": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/snap-shot-core/-/snap-shot-core-8.1.0.tgz",
+      "integrity": "sha512-rbWs3pScHAOqYlajtTTauAkzQb/8sl2QOwAugu3KQeCarsGJ6taXXwmeTuuoe6G9mq799AEA7vVNKt2+gJVN3A==",
+      "dev": true,
+      "dependencies": {
+        "arg": "4.1.0",
+        "check-more-types": "2.24.0",
+        "common-tags": "1.8.0",
+        "debug": "4.1.1",
+        "escape-quotes": "1.0.2",
+        "folktale": "2.3.2",
+        "is-ci": "2.0.0",
+        "jsesc": "2.5.2",
+        "lazy-ass": "1.6.0",
+        "mkdirp": "0.5.1",
+        "pluralize": "7.0.0",
+        "quote": "0.4.0",
+        "ramda": "0.26.1"
+      },
+      "bin": {
+        "resave-snapshots": "bin/resave-snapshots.js"
+      },
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/snap-shot-compare/node_modules/debug": {
+    "node_modules/snap-shot-core/node_modules/debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
@@ -7989,132 +8027,52 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/snap-shot-compare/node_modules/ms": {
+    "node_modules/snap-shot-core/node_modules/folktale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/folktale/-/folktale-2.3.2.tgz",
+      "integrity": "sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ==",
+      "deprecated": "This package is no longer actively maintained. Only security patches will be provided, if needed. Consider switching to fp-ts.",
+      "dev": true
+    },
+    "node_modules/snap-shot-core/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "node_modules/snap-shot-compare/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/snap-shot-core": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/snap-shot-core/-/snap-shot-core-10.2.4.tgz",
-      "integrity": "sha512-A7tkcfmvnRKge4VzFLAWA4UYMkvFY4TZKyL+D6hnHjI3HJ4pTepjG5DfR2ACeDKMzCSTQ5EwR2iOotI+Z37zsg==",
-      "dev": true,
-      "dependencies": {
-        "arg": "4.1.3",
-        "check-more-types": "2.24.0",
-        "common-tags": "1.8.0",
-        "debug": "4.3.1",
-        "escape-quotes": "1.0.2",
-        "folktale": "2.3.2",
-        "is-ci": "2.0.0",
-        "jsesc": "2.5.2",
-        "lazy-ass": "1.6.0",
-        "mkdirp": "1.0.4",
-        "pluralize": "8.0.0",
-        "quote": "0.4.0",
-        "ramda": "0.27.1"
-      },
-      "bin": {
-        "resave-snapshots": "bin/resave-snapshots.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/snap-shot-core/node_modules/common-tags": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/snap-shot-core/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/snap-shot-core/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/snap-shot-core/node_modules/ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-      "dev": true
-    },
     "node_modules/snap-shot-it": {
-      "version": "7.9.10",
-      "resolved": "https://registry.npmjs.org/snap-shot-it/-/snap-shot-it-7.9.10.tgz",
-      "integrity": "sha512-9USmsI2jc2kQslRhqkzFX+2K23o6v3VEzlQHwUNpZbbnEdU0ommReg2+Px7260sd+P/6CtaDx+LXadzt4caMVQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/snap-shot-it/-/snap-shot-it-7.4.1.tgz",
+      "integrity": "sha512-HxL/mOlMHGNFp18aExLEylA4r01LaPm0QZ2QII9EKsaUk5de31S4PyclFZEhas6u63WyCm5Cn+DF5fY8y+iiEQ==",
       "dev": true,
       "dependencies": {
         "@bahmutov/data-driven": "1.0.0",
         "check-more-types": "2.24.0",
-        "common-tags": "1.8.2",
-        "debug": "4.3.4",
+        "debug": "4.1.1",
         "has-only": "1.1.1",
-        "its-name": "1.0.0",
-        "lazy-ass": "1.6.0",
-        "pluralize": "8.0.0",
-        "ramda": "0.28.0",
-        "snap-shot-compare": "3.0.0",
-        "snap-shot-core": "10.2.4"
+        "pluralize": "7.0.0",
+        "ramda": "0.26.1",
+        "snap-shot-compare": "2.8.0",
+        "snap-shot-core": "8.1.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/snap-shot-it/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "ms": "^2.1.1"
       }
     },
     "node_modules/snap-shot-it/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "node_modules/sonic-boom": {

--- a/packages/conventional-commit-lint/package.json
+++ b/packages/conventional-commit-lint/package.json
@@ -52,7 +52,7 @@
     "nock": "^13.2.9",
     "sinon": "^15.0.0",
     "smee-client": "^1.2.3",
-    "snap-shot-it": "^7.9.6",
+    "snap-shot-it": "^7.4.1",
     "typescript": "~4.9.0"
   },
   "engines": {


### PR DESCRIPTION
Ran `npm audit fix --force` for packages/conventional-commit-lint

Fixes https://github.com/googleapis/repo-automation-bots/security/dependabot/1822
