### PR TITLE
fix: need to pass in string to webhooks.verify

### DIFF
--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -6,7 +6,7 @@
     "compile": "tsc -p .",
     "pretest": "npm run compile",
     "prepare": "npm run compile",
-    "test": "NODE_OPTIONS='--no-deprecation' cross-env NODE_ENV=test LOG_LEVEL=fatal c8 mocha ./build/test/server.js",
+    "test": "cross-env NODE_ENV=test LOG_LEVEL=fatal c8 mocha ./build/test",
     "system-test": "npm run pretest && cross-env LOG_LEVEL=fatal mocha ./build/test/integration",
     "fix": "gts fix",
     "lint": "gts check"

--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -6,7 +6,7 @@
     "compile": "tsc -p .",
     "pretest": "npm run compile",
     "prepare": "npm run compile",
-    "test": "cross-env NODE_ENV=test LOG_LEVEL=fatal c8 mocha ./build/test",
+    "test": "NODE_OPTIONS='--no-deprecation' cross-env NODE_ENV=test LOG_LEVEL=fatal c8 mocha ./build/test/server.js",
     "system-test": "npm run pretest && cross-env LOG_LEVEL=fatal mocha ./build/test/integration",
     "fix": "gts fix",
     "lint": "gts check"

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -448,9 +448,9 @@ export class GCFBootstrapper {
       if (
         !wrapConfig.skipVerification &&
         !(await this.probot.webhooks.verify(
-          JSON.stringify(
-            request.rawBody ? request.rawBody.toString() : request.body
-          ),
+          request.rawBody
+            ? request.rawBody.toString()
+            : request.body.toString(),
           botRequest.signature
         ))
       ) {

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -445,24 +445,16 @@ export class GCFBootstrapper {
       const botRequest = parseBotRequest(request);
 
       // validate the signature
-      try {
-        if (
-          !wrapConfig.skipVerification &&
-          !(await this.probot.webhooks.verify(
-            request.rawBody ? request.rawBody.toString() : request.body,
-            botRequest.signature
-          ))
-        ) {
-          response.status(400).send({
-            statusCode: 400,
-            body: JSON.stringify({message: 'Invalid signature'}),
-          });
-          return;
-        }
-      } catch (err) {
+      if (
+        !wrapConfig.skipVerification &&
+        !(await this.probot.webhooks.verify(
+          JSON.stringify(request.rawBody ? request.rawBody.toString() : request.body),
+          botRequest.signature
+        ))
+      ) {
         response.status(400).send({
           statusCode: 400,
-          body: JSON.stringify({message: err.message}),
+          body: JSON.stringify({message: 'Invalid signature'}),
         });
         return;
       }

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -460,8 +460,8 @@ export class GCFBootstrapper {
           return;
         }
       } catch (err) {
-        response.status(500).send({
-          statusCode: 500,
+        response.status(400).send({
+          statusCode: 400,
           body: JSON.stringify({message: err.message}),
         });
         return;

--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -448,7 +448,9 @@ export class GCFBootstrapper {
       if (
         !wrapConfig.skipVerification &&
         !(await this.probot.webhooks.verify(
-          JSON.stringify(request.rawBody ? request.rawBody.toString() : request.body),
+          JSON.stringify(
+            request.rawBody ? request.rawBody.toString() : request.body
+          ),
           botRequest.signature
         ))
       ) {

--- a/packages/gcf-utils/test/server.ts
+++ b/packages/gcf-utils/test/server.ts
@@ -290,7 +290,7 @@ describe('GCFBootstrapper', () => {
             return true;
           },
         });
-        assert.deepStrictEqual(response.status, 500);
+        assert.deepStrictEqual(response.status, 400);
         sinon.assert.notCalled(enqueueTask);
         sinon.assert.notCalled(issueSpy);
       });


### PR DESCRIPTION
Based on change to [verify defintion in webhooks](https://github.com/octokit/webhooks-methods.js/releases/tag/v2.0.0) we need to pass in a string for the event payload.  Cleaning this up removes the need to catch the error 