### PR TITLE
deps: update releasetool to 2.6.0

### DIFF
--- a/packages/release-trigger/requirements.in
+++ b/packages/release-trigger/requirements.in
@@ -1,3 +1,3 @@
 cryptography>=43.0.1
-gcp-releasetool>=2.5.0
+gcp-releasetool>=2.6.0
 keyrings.alt

--- a/packages/release-trigger/requirements.txt
+++ b/packages/release-trigger/requirements.txt
@@ -125,10 +125,9 @@ cryptography==44.0.1 \
     # via
     #   -r requirements.in
     #   gcp-releasetool
-    #   secretstorage
-gcp-releasetool==2.5.0 \
-    --hash=sha256:3ff79f53a8357b080ba9c66d7adb1282ff23fe1d46912c3f4d7a31d28553d539 \
-    --hash=sha256:b6fe993c9f7fa90b6551585161efeaf7a92bf98d4676a5f933f23b3361ef3bb7
+gcp-releasetool==2.6.0 \
+    --hash=sha256:3a3d3940bae9158ad17d77beaee3167d70b433aec2be26fb1cd3e00c0a83bf04 \
+    --hash=sha256:bb65b1c4c14fb7acafba7feb002729575f5ae85863fe8120ea9448ba7cf3aedc
     # via -r requirements.in
 google-auth==2.28.1 \
     --hash=sha256:25141e2d7a14bfcba945f5e9827f98092716e99482562f15306e5b026e21aa72 \


### PR DESCRIPTION
Fix for .NET release trigger migration