### PR TITLE
feat: Release Please bot's option to tag a release commit

### DIFF
--- a/packages/release-please/src/config-constants.ts
+++ b/packages/release-please/src/config-constants.ts
@@ -42,6 +42,7 @@ export interface BranchOptions {
   changelogType?: ChangelogNotesType;
   initialVersion?: string;
   onDemand?: boolean;
+  tagPullRequestNumber?: boolean;
 }
 
 export interface BranchConfiguration extends BranchOptions {


### PR DESCRIPTION
tagPullRequestNumber configuration to enable tagging on release commits.

TODO items before making this out of draft:

* [ ] Add a test to read the new configuration from a file.
* [ ] Run this bot locally (how?) to confirm it actually works to tag the release commit.
