### PR TITLE
feat: runBranchConfiguration* functions to return CreatedReleases

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -17,7 +17,7 @@
         "@octokit/webhooks": "^10.1.5",
         "gcf-utils": "^16.2.1",
         "jsonwebtoken": "^9.0.0",
-        "release-please": "^16.15.0"
+        "release-please": "^16.18.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
@@ -7452,9 +7452,10 @@
       }
     },
     "node_modules/release-please": {
-      "version": "16.15.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-16.15.0.tgz",
-      "integrity": "sha512-C55PsUOMzAbPSrdqF/KKAqhaYVRGlarNNWgW/DyAsg15U4g/TkxXVpEZqAV1o38CoEoKhssnKTGnb5/eT4/DUw==",
+      "version": "16.18.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-16.18.0.tgz",
+      "integrity": "sha512-23AmvwFSvnMqNRHrSTc+rjTZNMY7YN4JbrPMqAZRIpNNpv9GU0XO1U2IQ9QzNuTNp/sxUU/2gT+9pi7Nu7OntQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^2.0.0",
@@ -7476,7 +7477,7 @@
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
         "js-yaml": "^4.0.0",
-        "jsonpath-plus": "^10.3.0",
+        "jsonpath-plus": "^10.0.0",
         "node-html-parser": "^6.0.0",
         "parse-github-repo-url": "^1.4.1",
         "semver": "^7.5.3",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -36,7 +36,7 @@
     "@octokit/webhooks": "^10.1.5",
     "gcf-utils": "^16.2.1",
     "jsonwebtoken": "^9.0.0",
-    "release-please": "^16.15.0"
+    "release-please": "^16.18.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",

--- a/packages/release-please/src/config-constants.ts
+++ b/packages/release-please/src/config-constants.ts
@@ -42,6 +42,7 @@ export interface BranchOptions {
   changelogType?: ChangelogNotesType;
   initialVersion?: string;
   onDemand?: boolean;
+  tagPullRequestNumber?: boolean;
 }
 
 export interface BranchConfiguration extends BranchOptions {

--- a/packages/release-please/src/runner.ts
+++ b/packages/release-please/src/runner.ts
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Manifest} from 'release-please';
+import {CreatedRelease, Manifest} from 'release-please';
 
 export class Runner {
   static createPullRequests = async (manifest: Manifest) => {
     await manifest.createPullRequests();
   };
-  static createReleases = async (manifest: Manifest): Promise<number> => {
+  static createReleases = async (manifest: Manifest): Promise<CreatedRelease[]> => {
     const releases = await manifest.createReleases();
-    return releases.filter(release => !!release).length;
+    return releases.filter(release => !!release);
   };
 }


### PR DESCRIPTION
Now the release-pleaes library's createReleases returns the list
of `CreatedRelease`s. However when we make the method call,
runner.ts does not have `octokit` instance or `owner`/`repo` names.

We may have to pass the `CreateRelease`s. However this idea gets
stuck at

```
async function runBranchConfigurationWithConfigurationHandling(
  github: GitHub,
  repoLanguage: string | null,
  repoUrl: string,
  branchConfiguration: BranchConfiguration,
  octokit: Octokit,
  options: RunBranchOptions
): Promise<CreatedRelease[] | undefined> {
  const target = `${repoUrl}---${branchConfiguration.branch}`;
  await withDatastoreLock(
    {
      lockId: RP_LOCK_ID,
      target,
      lockExpiry: RP_LOCK_DURATION_MS,
      lockAcquireTimeout: RP_LOCK_ACQUIRE_TIMEOUT_MS,
    },
    async () => {
      return await runBranchConfigurationWithConfigurationHandlingWithoutLock(
        github,
        repoLanguage,
```
