### PR TITLE
fix(release-please): tagPullRequestNumber as branch's properties schema

### DIFF
--- a/packages/release-please/src/config-schema.json
+++ b/packages/release-please/src/config-schema.json
@@ -201,6 +201,7 @@
                             "releaseType": true,
                             "packageName": true,
                             "handleGHRelease": true,
+                            "tagPullRequestNumber": true,
                             "bumpMinorPreMajor": true,
                             "bumpPatchForMinorPreMajor": true,
                             "path": true,


### PR DESCRIPTION
This fixes the config schema error:

```
[
{
"instancePath": "/branches/0",
"schemaPath": "#/allOf/1/properties/branches/items/additionalProperties",
"keyword": "additionalProperties",
"params": {
"additionalProperty": "tagPullRequestNumber"
},
"message": "must NOT have additional properties"
}
]
```

https://github.com/googleapis/google-cloud-go/pull/11753/checks?check_run_id=38345091141

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/repo-automation-bots/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
