### PR TITLE
fix(release-please): distributed lock key should use config name

### DIFF
--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -270,7 +270,7 @@ async function runBranchConfigurationWithConfigurationHandling(
   octokit: Octokit,
   options: RunBranchOptions
 ) {
-  const target = `${repoUrl}---${branchConfiguration.branch}`;
+  const target = `${repoUrl}---${branchConfiguration.branch}---${branchConfiguration.manifestConfig}`;
   const branchContext = {
     branch: branchConfiguration.branch,
     manifestConfig: branchConfiguration.manifestConfig,


### PR DESCRIPTION
Some repos like google-cloud-go use multiple configurations against the same branch. The datastore locks should be separate per configuration run (branch/config file combination).