### PR TITLE
ci: release-please.yml to tag pull request number

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,3 +1,3 @@
 handleGHRelease: true
 manifest: true
-
+tagPullRequestNumber: true


### PR DESCRIPTION
This repository creates multiple Git tags upon one release pull request (commit). Example: https://github.com/googleapis/repo-automation-bots/pull/5696

To adopt the new release pipeline based on Git tags, this `tagPullRequestNumber` creates an additional `release-please-<pr number>` tag to a release. We'll monitor that tag to trigger the release job. This doesn't change existing release tags.

Background: https://docs.google.com/document/d/1Y0Fv-sxLqYmjnXHry3WDq4XNPeQP1AEmsB83hNRCEY0/edit?usp=sharing&resourcekey=0-I2m8Z-mTD0-HY0TpkblOTQ

This design has been working good for google-cloud-go: https://github.com/googleapis/google-cloud-go/blob/main/.github/release-please.yml#L4