### PR TITLE
chore(owl-bot): use the alpine variant for the runtime image in OwlBot frontend

### DIFF
--- a/packages/owl-bot/Dockerfile.frontend
+++ b/packages/owl-bot/Dockerfile.frontend
@@ -34,7 +34,10 @@ COPY . ./
 
 RUN npm run compile
 
-FROM node:18.20.5-slim
+# The steps above are the build time. At runtime, use the light-weight
+# container image to avoid vulnerabilities. It has to have the tools
+# required to run the service.
+FROM node:18-alpine3.21
 
 # Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
 RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/


### PR DESCRIPTION
The node:18-alpine is the lightweight container image that has the same version of the Node in the build steps.

b/418620308

The OwlBot frontend doesn't need special tools such as git. go/cloud-sdk-bot-architecture explains the architecture of the frontend and backend.