### PR TITLE
feat: add 6s sleep in trusted contribution bot before adding gcbrun

### DIFF
--- a/packages/trusted-contribution/src/trusted-contribution.ts
+++ b/packages/trusted-contribution/src/trusted-contribution.ts
@@ -54,6 +54,10 @@ function isTrustedContribution(
   return trustedContributors.includes(author);
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 export = (app: Probot) => {
   // Track estimate of how often a kokoro:run or kokoro:force-run label is being added manually:
   app.on(['pull_request.labeled'], async context => {
@@ -201,6 +205,11 @@ export = (app: Probot) => {
                 process.env.PROJECT_ID || '',
                 SECRET_NAME_FOR_COMMENT_PERMISSION
               );
+            }
+            // We need to sleep for 6s before adding the gcbrun due to race condition with other bots.
+            // More information in b/422754703.
+            if (annotation.text === '/gcbrun') {
+              await sleep(6000);
             }
             await octokitForComment.issues.createComment({
               issue_number: prNumber,

--- a/packages/trusted-contribution/test/trusted-contribution.ts
+++ b/packages/trusted-contribution/test/trusted-contribution.ts
@@ -834,6 +834,7 @@ describe('TrustedContributionTestRunner', () => {
   });
 
   it('should add a comment if configured with annotations', async () => {
+    const startTime: Date = new Date();
     getConfigStub.resolves(loadConfig('gcbrun.yml'));
     const sandbox = sinon.createSandbox();
     const getAuthenticatedOctokitStub = sandbox.stub(
@@ -883,6 +884,10 @@ describe('TrustedContributionTestRunner', () => {
       process.env.PROJECT_ID || '',
       utilsModule.SECRET_NAME_FOR_COMMENT_PERMISSION
     );
+    const endTime: Date = new Date();
+    if (endTime.getTime() - startTime.getTime() < 6000) {
+      assert.fail('Adding a comment took less than 6s');
+    }
   });
 
   it('should log an error if the config cannot be fetched', async () => {


### PR DESCRIPTION
Added 6s sleep before adding the gcbrun due to race condition with other bots.
More information in b/422754703.

- [ x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/repo-automation-bots/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ x] Ensure the tests and linter pass
- [ x] Code coverage does not decrease (if any source code was changed)
- [ x] Appropriate docs were updated (if necessary)

Fixes b/422754703 🦕
