### PR TITLE
build: use marketplace.gcr.io/google/debian12:latest

### DIFF
--- a/packages/header-checker-lint/Dockerfile
+++ b/packages/header-checker-lint/Dockerfile
@@ -14,9 +14,22 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Use the official lightweight Node.js 14 image.
-# https://hub.docker.com/_/node
-FROM node:18.20.5-slim AS BUILD
+# Stage 0: Node.js Base Image
+FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
+
+# Install Node.js v18 and npm.
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
+RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
+
+# Stage 1: Build
+FROM NODE_BASE AS BUILD
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -34,10 +47,7 @@ COPY . ./
 
 RUN npm run compile
 
-FROM node:18.20.5-slim
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/
+FROM NODE_BASE
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app

--- a/packages/header-checker-lint/cloudbuild-test.yaml
+++ b/packages/header-checker-lint/cloudbuild-test.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    id: "build-docker"
+    waitFor: ["-"]
+    dir: packages/header-checker-lint
+    args:
+      - "build"
+      - "-f"
+      - "Dockerfile"
+      - "-t"
+      - "gcr.io/$PROJECT_ID/header-checker-lint"
+      - "."
+
+logsBucket: 'gs://header-checker-lint-deploy-logs'
+options:
+  logging: GCS_ONLY

--- a/packages/label-sync/Dockerfile
+++ b/packages/label-sync/Dockerfile
@@ -14,9 +14,22 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Use the official lightweight Node.js 14 image.
-# https://hub.docker.com/_/node
-FROM node:18.20.5-slim AS BUILD
+# Stage 0: Node.js Base Image
+FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
+
+# Install Node.js v18 and npm.
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
+RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
+
+# Stage 1: Build
+FROM NODE_BASE AS BUILD
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -34,10 +47,7 @@ COPY . ./
 
 RUN npm run compile
 
-FROM node:18.20.5-slim
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/
+FROM NODE_BASE
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app

--- a/packages/label-sync/cloudbuild-test.yaml
+++ b/packages/label-sync/cloudbuild-test.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    id: "build-docker"
+    waitFor: ["-"]
+    dir: packages/label-sync
+    args:
+      - "build"
+      - "-f"
+      - "Dockerfile"
+      - "-t"
+      - "gcr.io/$PROJECT_ID/label-sync"
+      - "."
+
+logsBucket: 'gs://label-sync-deploy-logs'
+options:
+  logging: GCS_ONLY

--- a/packages/merge-on-green/Dockerfile
+++ b/packages/merge-on-green/Dockerfile
@@ -14,9 +14,22 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Use the official lightweight Node.js 14 image.
-# https://hub.docker.com/_/node
-FROM node:18.20.5-slim AS BUILD
+# Stage 0: Node.js Base Image
+FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
+
+# Install Node.js v18 and npm.
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
+RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
+
+# Stage 1: Build
+FROM NODE_BASE AS BUILD
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -34,10 +47,7 @@ COPY . ./
 
 RUN npm run compile
 
-FROM node:18.20.5-slim
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/
+FROM NODE_BASE
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app

--- a/packages/merge-on-green/cloudbuild-test.yaml
+++ b/packages/merge-on-green/cloudbuild-test.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    id: "build-docker"
+    waitFor: ["-"]
+    dir: packages/merge-on-green
+    args:
+      - "build"
+      - "-f"
+      - "Dockerfile"
+      - "-t"
+      - "gcr.io/$PROJECT_ID/merge-on-green"
+      - "."
+
+logsBucket: 'gs://merge-on-green-deploy-logs'
+options:
+  logging: GCS_ONLY

--- a/packages/repo-metadata-lint/Dockerfile
+++ b/packages/repo-metadata-lint/Dockerfile
@@ -14,9 +14,22 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Use the official lightweight Node.js 14 image.
-# https://hub.docker.com/_/node
-FROM node:18.20.5-slim AS BUILD
+# Stage 0: Node.js Base Image
+FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
+
+# Install Node.js v18 and npm.
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
+RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
+
+# Stage 1: Build
+FROM NODE_BASE AS BUILD
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -34,10 +47,7 @@ COPY . ./
 
 RUN npm run compile
 
-FROM node:18.20.5-slim
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/
+FROM NODE_BASE
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app

--- a/packages/repo-metadata-lint/cloudbuild-test.yaml
+++ b/packages/repo-metadata-lint/cloudbuild-test.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    id: "build-docker"
+    waitFor: ["-"]
+    dir: packages/repo-metadata-lint
+    args:
+      - "build"
+      - "-f"
+      - "Dockerfile"
+      - "-t"
+      - "gcr.io/$PROJECT_ID/repo-metadata-lint"
+      - "."
+
+logsBucket: 'gs://repo-metadata-lint-deploy-logs'
+options:
+  logging: GCS_ONLY

--- a/packages/sync-repo-settings/Dockerfile
+++ b/packages/sync-repo-settings/Dockerfile
@@ -14,9 +14,22 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Use the official lightweight Node.js 14 image.
-# https://hub.docker.com/_/node
-FROM node:18.20.5-slim AS BUILD
+# Stage 0: Node.js Base Image
+FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
+
+# Install Node.js v18 and npm.
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
+RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
+
+# Stage 1: Build
+FROM NODE_BASE AS BUILD
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -34,10 +47,7 @@ COPY . ./
 
 RUN npm run compile
 
-FROM node:18.20.5-slim
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/
+FROM NODE_BASE
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app

--- a/packages/sync-repo-settings/cloudbuild-test.yaml
+++ b/packages/sync-repo-settings/cloudbuild-test.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    id: "build-docker"
+    waitFor: ["-"]
+    dir: packages/sync-repo-settings
+    args:
+      - "build"
+      - "-f"
+      - "Dockerfile"
+      - "-t"
+      - "gcr.io/$PROJECT_ID/sync-repo-settings"
+      - "."
+
+logsBucket: 'gs://sync-repo-settings-deploy-logs'
+options:
+  logging: GCS_ONLY


### PR DESCRIPTION
* Use marketplace.gcr.io/google/debian12:latest instead of node:18.20.5-slim.
* Add presubmit tests

The follow packages are affected:
* header-checker-lint
* label-sync
* merge-on-green
* repo-metadata-lint
* sync-repo-settings
