### PR TITLE
chore: mark release-brancher library as deprecated

### DIFF
--- a/packages/release-brancher/README.md
+++ b/packages/release-brancher/README.md
@@ -1,7 +1,9 @@
-# release-brancher
+# ⛔️ DEPRECATED : release-brancher
 
-This project is designed to be a CLI for branching new release branches. A "release branch" is a protected branch
-that is configured for release automation.
+This library is deprecated and will no longer publish new versions
+as of August 1, 2025.
+
+---
 
 ## Installation
 


### PR DESCRIPTION
Towards https://github.com/googleapis/librarian/issues/374