### PR TITLE
chore: mark mono-repo-publish library as deprecated

### DIFF
--- a/packages/mono-repo-publish/README.md
+++ b/packages/mono-repo-publish/README.md
@@ -1,4 +1,9 @@
-# Mono-repo-publish
+# ⛔️ DEPRECATED : Mono-repo-publish
+
+This library is deprecated and will no longer publish new versions
+as of August 1, 2025.
+
+---
 
 Mono-repo-publish is a tool that detects updates from release pull requests and determines which submodules to publish to npm.
 


### PR DESCRIPTION
Towards https://github.com/googleapis/librarian/issues/369
