### PR TITLE
chore: mark bazel-bot and owl-bot as deprecated

### DIFF
--- a/packages/bazel-bot/README.md
+++ b/packages/bazel-bot/README.md
@@ -1,4 +1,8 @@
-# bazel-bot
+# ⛔️ DEPRECATED : bazel-bot
+
+This bot is deprecated and is planned for shutdown in the near future.
+
+---
 
 bazel-bot generates code in https://github.com/googleapis/googleapis-gen for each new commit in https://github.com/googleapis/googleapis.
 

--- a/packages/owl-bot/README.md
+++ b/packages/owl-bot/README.md
@@ -1,4 +1,8 @@
-## Owl Bot Post Processor
+# ⛔️ DEPRECATED : OwlBot
+
+This bot is deprecated and is planned for shutdown in the near future.
+
+---
 
 Runs a docker container, defined in `OwlBot.yaml`, container as a postprocessing
 step when a pull request is opened.


### PR DESCRIPTION
Fixes https://github.com/googleapis/librarian/issues/347
Fixes https://github.com/googleapis/librarian/issues/371
