### PR TITLE
chore: mark owlbot-bootstrapper as deprecated

### DIFF
--- a/packages/owlbot-bootstrapper/README.md
+++ b/packages/owlbot-bootstrapper/README.md
@@ -1,4 +1,8 @@
-# googleapis-bootstrapper
+# ⛔️ DEPRECATED : owlbot-bootstrapper
+
+This bot is deprecated and is planned for an internal replacement in the near future.
+
+---
 
 Googleapis-bootstrapper is a Github bot that generates minimal files required to initialize googleapis libraries.
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/librarian/issues/372
