### PR TITLE
docs: mark conventional-commit-lint as deprecated

### DIFF
--- a/packages/conventional-commit-lint/README.md
+++ b/packages/conventional-commit-lint/README.md
@@ -1,4 +1,10 @@
-# conventional-commit-lint
+# ⛔️ DEPRECATED : conventional-commit-lint
+
+This bot is deprecated and is planned for shutdown August 13, 2025.
+
+We suggest looking into a supported GitHub actions implementation. You can find a few options: https://github.com/marketplace?query=commitlint&type=actions
+
+---
 
 > A GitHub App built with [Probot](https://github.com/probot/probot) that lints commit messages based on conventionalcommits.org
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/librarian/issues/353