### PR TITLE
build: fix datastore-lock test by pinning cloud-sdk docker image

### DIFF
--- a/packages/datastore-lock/package.json
+++ b/packages/datastore-lock/package.json
@@ -4,7 +4,7 @@
   "description": "Distributed lock backed by Google Cloud Datastore",
   "scripts": {
     "compile": "tsc -p .",
-    "pretest": "npm run compile && docker pull google/cloud-sdk",
+    "pretest": "npm run compile && docker pull google/cloud-sdk:510.0.0",
     "prepare": "npm run compile",
     "test": "cross-env NODE_ENV=test LOG_LEVEL=fatal c8 mocha --node-option no-experimental-fetch ./build/test",
     "fix": "gts fix",

--- a/packages/datastore-lock/test/datastore-lock.ts
+++ b/packages/datastore-lock/test/datastore-lock.ts
@@ -32,6 +32,7 @@ describe('datastore-lock', () => {
     nock.enableNetConnect('localhost');
     const options = {
       useDocker: true,
+      dockerImage: 'google/cloud-sdk:510.0.0',
     };
 
     emulator = new DataStoreEmulator(options);


### PR DESCRIPTION
google/cloud-sdk:latest fails with timeout but google/cloud-sdk:510.0.0 works.

