### PR TITLE
chore: debug for deep-preserve logic

### DIFF
--- a/packages/owl-bot/src/copy-code.ts
+++ b/packages/owl-bot/src/copy-code.ts
@@ -1082,7 +1082,7 @@ function copyFiles(
       logger.info(e);
     }
   }
-
+  excludes.forEach(e => logger.info(`exclude pattern: ${e}`));
   // Copy the files from source to dest.
   for (const deepCopy of yaml['deep-copy-regex'] ?? []) {
     const regExp = toFrontMatchRegExp(deepCopy.source);
@@ -1090,9 +1090,17 @@ function copyFiles(
       regExp.test('/' + path)
     );
     for (const sourcePath of sourcePathsToCopy) {
+      logger.info('***')
+      logger.info(`source path: ${sourcePath}`)
       const fullSourcePath = path.join(sourceDir, sourcePath);
+      logger.info(`full source path: ${fullSourcePath}`)
       const relPath = ('/' + sourcePath).replace(regExp, deepCopy.dest);
+      logger.info(`rel path ${relPath}`);
+      logger.info('***')
       if (excluded(relPath)) {
+        if (relPath.includes("META-INF")) {
+          logger.info(`wont copy ${relPath}`);
+        }
         continue;
       }
       const fullDestPath = path.join(destDir, relPath);


### PR DESCRIPTION
The following problem has been observed in https://github.com/googleapis/java-bigquerystorage/pull/3077/commits/96aa2078b7774ac40258e81e53fb32bee5d46e04

 * patterns starting with `"/google-cloud..."` only prevent `deep-remove` from affecting these folders
 * patterns starting with `"/owl-bot-staging/.*"` only prevent `deep-copy` from skipping these files.

In other words, `/google.*` basically prevents the matching files from being removed when cleaning up the repository. Later, when bringing the new generated files they may still be overridden if we don't have a similar pattern starting with `/owl-bot-staging/v.*/...` (that's the `deep-copy` part).

Using this debug branch we got:
```
***
source path: google/cloud/bigquery/storage/v1/generated-java/gapic-google-cloud-library/src/main/resources/META-INF/native-image/com.google.cloud.bigquery.storage.v1/reflect-config.json
full source path: /tmp/tmp.xidQiFQjW3/google/cloud/bigquery/storage/v1/generated-java/gapic-google-cloud-library/src/main/resources/META-INF/native-image/com.google.cloud.bigquery.storage.v1/reflect-config.json
rel path /owl-bot-staging/v1/google-cloud-bigquerystorage/src/main/resources/META-INF/native-image/com.google.cloud.bigquery.storage.v1/reflect-config.json
***
Excluding /owl-bot-staging/v1/google-cloud-bigquerystorage/src/main/resources/META-INF/native-image/com.google.cloud.bigquery.storage.v1/reflect-config.json.
wont copy /owl-bot-staging/v1/google-cloud-bigquerystorage/src/main/resources/META-INF/native-image/com.google.cloud.bigquery.storage.v1/reflect-config.json
***

```

Additionally, some manual testing confirmed the `deep-preserve` needs a different pattern starting with `owl-bot-staging` in order to prevent replacements:
```
Welcome to Node.js v20.19.2.
Type ".help" for more information.
> const relPath = '/owl-bot-staging/v1/google-cloud-bigquerystorage/src/main/resources/META-INF/native-image/com.google.cloud.bigquery.storage.v1/reflect-config.json'
undefined
> const exclude = '/^\/google-cloud-bigquerystorage\/src\/main\/resources\/META-INF\/native-image\//'
undefined
> relPath.test(exclude)
Uncaught TypeError: relPath.test is not a function
> const regex = new RegExp(exclude)
undefined
> regex.test(relPath)
false
```