### PR TITLE
deps(release-please): Release Please CLI 17.1.3

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -16,7 +16,7 @@
         "@octokit/rest": "^20.1.1",
         "gcf-utils": "^17.1.1",
         "jsonwebtoken": "^9.0.0",
-        "release-please": "^17.0.0"
+        "release-please": "^17.1.3"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -7803,9 +7803,10 @@
       }
     },
     "node_modules/release-please": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-17.1.1.tgz",
-      "integrity": "sha512-baFGx79P5hGxbtDqf8p+ThwQjHT/byst6EtnCkjfA6FcK5UnaERn6TBI+8wSsaVIohPG2urYjZaPkITxDS3/Pw==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-17.1.3.tgz",
+      "integrity": "sha512-fs4v5318Z3CLqyqw7EueXzjErtL8oXCv6Kc1mMYi72TAyReyBtOuuMB0lwoC2+LtGmvUYoG+RBXnDVU0DsKUIA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^3.0.0",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -35,7 +35,7 @@
     "@octokit/rest": "^20.1.1",
     "gcf-utils": "^17.1.1",
     "jsonwebtoken": "^9.0.0",
-    "release-please": "^17.0.0"
+    "release-please": "^17.1.3"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
This should fix the problem of gcloud-mcp's releases missing
the updates to .release-please-manifest.json.
