### PR TITLE
fix(bazel-bot): update git clone command to use Bearer token

### DIFF
--- a/packages/bazel-bot/docker-image/docker-main.sh
+++ b/packages/bazel-bot/docker-image/docker-main.sh
@@ -42,7 +42,7 @@ GITHUB_TOKEN=$(curl -X POST \
     | jq -r .token)
 
 git clone https://github.com/googleapis/googleapis.git ${SOURCE_CLONE_ARGS}
-git clone https://x-access-token:$GITHUB_TOKEN@github.com/googleapis/googleapis-gen.git ${TARGET_CLONE_ARGS}
+git -c http.extraHeader="Authorization: Bearer $GITHUB_TOKEN" clone https://github.com/googleapis/googleapis-gen.git ${TARGET_CLONE_ARGS}
 
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 


### PR DESCRIPTION
Attempting to fix intermittent error:
```
Step #1: Cloning into 'googleapis'...
Step #1: Cloning into 'googleapis-gen'...
Step #1: remote: Invalid username or token. Password authentication is not supported for Git operations.
Step #1: fatal: Authentication failed for 'https://github.com/googleapis/googleapis-gen.git/'
```

b/450361623