### PR TITLE
fix(bazel-bot): reorder git clone commands in docker-main.sh

### DIFF
--- a/packages/bazel-bot/docker-image/docker-main.sh
+++ b/packages/bazel-bot/docker-image/docker-main.sh
@@ -41,8 +41,8 @@ GITHUB_TOKEN=$(curl -X POST \
     https://api.github.com/app/installations/$GITHUB_APP_INSTALLATION_ID/access_tokens \
     | jq -r .token)
 
-git clone https://github.com/googleapis/googleapis.git ${SOURCE_CLONE_ARGS}
 git clone https://x-access-token:$GITHUB_TOKEN@github.com/googleapis/googleapis-gen.git ${TARGET_CLONE_ARGS}
+git clone https://github.com/googleapis/googleapis.git ${SOURCE_CLONE_ARGS}
 
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 


### PR DESCRIPTION
This allows to use the generated `GITHUB_TOKEN` sooner.

b/450361623