### PR TITLE
chore: log git clone command for debugging

### DIFF
--- a/packages/bazel-bot/docker-image/docker-main.sh
+++ b/packages/bazel-bot/docker-image/docker-main.sh
@@ -41,6 +41,9 @@ GITHUB_TOKEN=$(curl -X POST \
     https://api.github.com/app/installations/$GITHUB_APP_INSTALLATION_ID/access_tokens \
     | jq -r .token)
 
+# temporarily log the git clone command
+echo "git clone https://x-access-token:$GITHUB_TOKEN@github.com/googleapis/googleapis-gen.git ${TARGET_CLONE_ARGS}"
+
 git clone https://x-access-token:$GITHUB_TOKEN@github.com/googleapis/googleapis-gen.git ${TARGET_CLONE_ARGS}
 git clone https://github.com/googleapis/googleapis.git ${SOURCE_CLONE_ARGS}
 


### PR DESCRIPTION
Added a temporary log for the git clone command to aid in debugging b/450361623.
