### PR TITLE
chore(owlbot-bootstrapper-cli): Update `validator` dep in package-lock.json

### DIFF
--- a/packages/owlbot-bootstrapper/cli/package-lock.json
+++ b/packages/owlbot-bootstrapper/cli/package-lock.json
@@ -4807,10 +4807,11 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.15.20",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
+      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }


### PR DESCRIPTION
Fixes #[2391](https://github.com/googleapis/repo-automation-bots/security/dependabot/2391)