### PR TITLE
fix: update gcb nodejs runtime to nodejs20, since GCB no longer supports nodejs18

### DIFF
--- a/packages/auto-approve/cloudbuild.yaml
+++ b/packages/auto-approve/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/auto-label/cloudbuild.yaml
+++ b/packages/auto-label/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/blunderbuss/cloudbuild.yaml
+++ b/packages/blunderbuss/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/canary-bot/cloudbuild-gcf.yaml
+++ b/packages/canary-bot/cloudbuild-gcf.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/conventional-commit-lint/cloudbuild.yaml
+++ b/packages/conventional-commit-lint/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/do-not-merge/cloudbuild.yaml
+++ b/packages/do-not-merge/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/failurechecker/cloudbuild.yaml
+++ b/packages/failurechecker/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/flakybot/cloudbuild.yaml
+++ b/packages/flakybot/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/generated-files-bot/cloudbuild.yaml
+++ b/packages/generated-files-bot/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/header-checker-lint/cloudbuild.yaml
+++ b/packages/header-checker-lint/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/label-sync/cloudbuild.yaml
+++ b/packages/label-sync/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/merge-on-green/cloudbuild.yaml
+++ b/packages/merge-on-green/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/owl-bot/cloudbuild.yaml
+++ b/packages/owl-bot/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker-frontend"

--- a/packages/repo-metadata-lint/cloudbuild.yaml
+++ b/packages/repo-metadata-lint/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/sync-repo-settings/cloudbuild.yaml
+++ b/packages/sync-repo-settings/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/trusted-contribution/cloudbuild.yaml
+++ b/packages/trusted-contribution/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs18"
+      - "nodejs20"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"


### PR DESCRIPTION
This is to unblock build errors:

```
ERROR: (gcloud.functions.deploy) argument `--runtime`: nodejs18 is not a supported runtime on GCF 1st gen. Use `gcloud functions runtimes list` to get a list of available runtimes
```
