### PR TITLE
fix(owl-bot): add back tmp to dependencies

### DIFF
--- a/packages/owl-bot/package-lock.json
+++ b/packages/owl-bot/package-lock.json
@@ -28,6 +28,7 @@
         "jsonwebtoken": "^9.0.0",
         "minimatch": "^5.1.0",
         "probot": "^13.4.4",
+        "tmp": "^0.2.5",
         "yargs": "^17.5.1"
       },
       "bin": {
@@ -1332,7 +1333,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -1871,7 +1871,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -2735,6 +2734,7 @@
       "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.33.0",
         "@typescript-eslint/types": "4.33.0",

--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -87,6 +87,7 @@
     "jsonwebtoken": "^9.0.0",
     "minimatch": "^5.1.0",
     "probot": "^13.4.4",
+    "tmp": "^0.2.5",
     "yargs": "^17.5.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Builds have been failing since [this commit](https://github.com/googleapis/repo-automation-bots/commit/97ca3dd013fbb6953396aac90472861c99aebd33) due to:

```
ERROR: (gcloud.functions.deploy) OperationError: code=3, message=Function failed on loading user code. This is likely due to a bug in the user code. Error message: Provided module can't be loaded.
Did you list all required modules in the package.json dependencies?
Detailed stack trace: Error: Cannot find module 'tmp'
```

It looks like the npm audit --fix removed this dependency, adding back in.
