### PR TITLE
chore: bump path-to-regexp for security vulnerability fix

### DIFF
--- a/packages/owlbot-bootstrapper/common-container/package.json
+++ b/packages/owlbot-bootstrapper/common-container/package.json
@@ -36,7 +36,7 @@
     "gcf-utils": "^17.1.2",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.3",
-    "path-to-regexp": "^0.2.0",
+    "path-to-regexp": "^1.9.0",
     "uuidv4": "^6.2.13",
     "yargs": "^17.5.1"
   },


### PR DESCRIPTION
Fixes https://github.com/googleapis/repo-automation-bots/security/dependabot/2570
