### PR TITLE
chore: bump the version of urllib3 to 2.6.3

### DIFF
--- a/packages/release-trigger/requirements.in
+++ b/packages/release-trigger/requirements.in
@@ -1,5 +1,5 @@
 cryptography>=45.0.4
 cffi>=1.17.1
 gcp-releasetool>=2.6.1
-urllib3>=2.6.0
+urllib3>=2.6.3
 keyrings.alt

--- a/packages/release-trigger/requirements.txt
+++ b/packages/release-trigger/requirements.txt
@@ -278,9 +278,9 @@ six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via python-dateutil
-urllib3==2.6.1 \
-    --hash=sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f \
-    --hash=sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b
+urllib3==2.6.3 \
+    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4 \
+    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed
     # via
     #   -r requirements.in
     #   requests


### PR DESCRIPTION


Fixes #https://github.com/googleapis/repo-automation-bots/security/dependabot/2600 🦕
