### PR TITLE
chore: disable renovate bot

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,4 +1,5 @@
 {
+  "enabled": false,
   "extends": [
     "config:recommended",
     // update base images in Dockerfiles


### PR DESCRIPTION
Disables Renovate bot by setting enabled: false in renovate.json5. Since the bots are deprecated, we will rely on security updates only via dependabot.