### PR TITLE
chore: add apt-get upgrade in release-trigger Dockerfile

### DIFF
--- a/packages/release-trigger/Dockerfile
+++ b/packages/release-trigger/Dockerfile
@@ -19,6 +19,7 @@ FROM marketplace.gcr.io/google/debian12:latest AS BASE
 
 # Install Node.js v18 and npm.
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y curl && \
     curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get install -y nodejs && \


### PR DESCRIPTION
This helps mitigate vulnerabilities just be rebuilding.
