### PR TITLE
fix(owlbot): reduce label desc size

### DIFF
--- a/packages/owl-bot/src/labels.ts
+++ b/packages/owl-bot/src/labels.ts
@@ -27,8 +27,6 @@ export const OWL_BOT_LABELS = [
   },
   {
     name: OWL_BOT_COPY_COMMAND_LABEL,
-    description:
-      'Instruct owl-bot to copy code from googleapis-gen.' +
-      '  The PR this label is applied to must have a copy tag.',
+    description: 'Instruct owl-bot to copy code from googleapis-gen.',
   },
 ];


### PR DESCRIPTION
This was causing errors in the logs because the max length allowed by GitHub is 100 and this was ~105.