### PR TITLE
build(canary-bot): switch to distroless nodejs

### DIFF
--- a/packages/canary-bot/Dockerfile
+++ b/packages/canary-bot/Dockerfile
@@ -58,7 +58,7 @@ COPY package*.json ./
 COPY --from=app-build /usr/src/app/build build
 COPY --from=node-deps /usr/src/app/node_modules node_modules
 
-ENV NODE_ENV="production"
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]


### PR DESCRIPTION
Switching to distroless node should reduce (hopefully eliminate) reported OS-level vulnerabilities on our bot images. Testing on canary-bot to ensure the bots can still function