### PR TITLE
build: migrate remaining Node.js Dockerfiles to distroless

### DIFF
--- a/packages/auto-approve/Dockerfile
+++ b/packages/auto-approve/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/auto-label/Dockerfile
+++ b/packages/auto-label/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/blunderbuss/Dockerfile
+++ b/packages/blunderbuss/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/cherry-pick-bot/Dockerfile
+++ b/packages/cherry-pick-bot/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/do-not-merge/Dockerfile
+++ b/packages/do-not-merge/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/failurechecker/Dockerfile
+++ b/packages/failurechecker/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/flakybot/Dockerfile
+++ b/packages/flakybot/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/generate-bot/templates/Dockerfile
+++ b/packages/generate-bot/templates/Dockerfile
@@ -14,9 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Use the official lightweight Node.js 14 image.
-# https://hub.docker.com/_/node
-FROM node:20-slim AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -32,21 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM node:20-slim
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
 
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/header-checker-lint/Dockerfile
+++ b/packages/header-checker-lint/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/label-sync/Dockerfile
+++ b/packages/label-sync/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/merge-on-green/Dockerfile
+++ b/packages/merge-on-green/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/repo-metadata-lint/Dockerfile
+++ b/packages/repo-metadata-lint/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/secret-rotator/Dockerfile
+++ b/packages/secret-rotator/Dockerfile
@@ -12,38 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official lightweight Node.js 12 image.
-# https://hub.docker.com/_/node
-FROM node:20-alpine AS BUILD
+# Use a multi-stage docker build to limit production dependencies.
+
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
+# Copy application dependency manifests to the container image.
+# A wildcard is used to ensure copying both package.json AND package-lock.json (when available).
+# Copying this first prevents re-running npm install on every code change.
 COPY package*.json ./
 
-# Install production dependencies.
+# Install build dependencies.
 RUN npm ci
 
-# Copy local code to the container image.
+# Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM node:20-alpine
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
+RUN npm ci --only=production
 
-RUN npm install -g npm
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
 
-RUN npm install
+# Create and change to the app directory.
+WORKDIR /usr/src/app
 
-ENV NODE_ENV "production"
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
 
-RUN chmod 755 /usr/src/app/build/src/index.js
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "run", "start" ]
+CMD [ "./build/src/index.js"]

--- a/packages/secret-rotator/Dockerfile.cli
+++ b/packages/secret-rotator/Dockerfile.cli
@@ -12,36 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official lightweight Node.js 12 image.
-# https://hub.docker.com/_/node
-FROM node:20-alpine AS BUILD
+# Use a multi-stage docker build to limit production dependencies.
+
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
+# Copy application dependency manifests to the container image.
+# A wildcard is used to ensure copying both package.json AND package-lock.json (when available).
+# Copying this first prevents re-running npm install on every code change.
 COPY package*.json ./
 
-# Install production dependencies.
+# Install build dependencies.
 RUN npm ci
 
-# Copy local code to the container image.
+# Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM node:20-alpine
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
+RUN npm ci --only=production
 
-RUN npm install -g npm && \
-    npm install && \
-    chmod 755 /usr/src/app/build/src/cli.js
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
 
-ENV NODE_ENV "production"
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the CLI
 ENTRYPOINT [ "/usr/src/app/build/src/cli.js" ]

--- a/packages/snippet-bot/Dockerfile
+++ b/packages/snippet-bot/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/snippet-bot/Dockerfile.frontend
+++ b/packages/snippet-bot/Dockerfile.frontend
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start-frontend" ]
+CMD [ "./build/src/server-frontend.js"]

--- a/packages/sync-repo-settings/Dockerfile
+++ b/packages/sync-repo-settings/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]

--- a/packages/trusted-contribution/Dockerfile
+++ b/packages/trusted-contribution/Dockerfile
@@ -14,22 +14,8 @@
 
 # Use a multi-stage docker build to limit production dependencies.
 
-# Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
-
-# Install Node.js v18 and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
-RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
-
-# Stage 1: Build
-FROM NODE_BASE AS BUILD
+# Stage 0: Compile the app (needs dev dependencies)
+FROM node:24 AS app-build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,18 +31,34 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+# remove installed node_modules because we will only have production
+# dependencies in the final image
+RUN rm -rf node_modules/
+
+# Stage 1: Install only production dependencies
+FROM node:24 AS node-deps
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
 RUN npm ci --only=production
 
-ENV NODE_ENV "production"
+# Stage 2: Create the final image with only the compiled code and production dependencies
+# as we cannot run npm from this image
+FROM gcr.io/distroless/nodejs24-debian13:latest
+
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY --from=app-build /usr/src/app/build build
+COPY --from=node-deps /usr/src/app/node_modules node_modules
+
+ENV NODE_ENV=production
 
 # Run the web service on container startup.
-CMD [ "npm", "--no-update-notifier", "run", "start" ]
+CMD [ "./build/src/server.js"]


### PR DESCRIPTION
This change migrates the remaining Node.js Dockerfiles in the repository to use Google's Distroless Node 24 base image (gcr.io/distroless/nodejs24-debian13). This completes the effort to standardize on distroless for security hardening where applicable.

Affected packages:
- auto-label
- trusted-contribution
- cherry-pick-bot
- blunderbuss
- snippet-bot
- header-checker-lint
- label-sync
- repo-metadata-lint
- generate-bot
- secret-rotator
- do-not-merge
- auto-approve
- flakybot
- sync-repo-settings
- merge-on-green
- failurechecker

Key changes:
- Standardized on multi-stage builds across all migrated packages.
- Used node:24 for building and installing dependencies.
- Used gcr.io/distroless/nodejs24-debian13:latest for the final runtime image.
- Replaced npm start with direct execution of the entry point script.
- Added explanatory comments regarding caching and distroless limitations.
- Skipped release-please and owl-bot as they require runtime access to git and other system tools.
