### PR TITLE
fix(release-please): use GitHub API for file updates

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -16,7 +16,7 @@
         "@octokit/rest": "^20.1.1",
         "gcf-utils": "^17.1.2",
         "jsonwebtoken": "^9.0.3",
-        "release-please": "^17.5.2"
+        "release-please": "^17.6.0"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -8752,9 +8752,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "17.5.2",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-17.5.2.tgz",
-      "integrity": "sha512-+Yu44GHQdUErH/jbQ/xzLYgHtQl+XCgRx/OOvQWV2Yzi3CA1VHt9GzgRYJtKgTPWoZJRdYePcsCtja5vA7pDrQ==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-17.6.0.tgz",
+      "integrity": "sha512-ItzkkEBeEbKsCrx7N1QlADrCahoONA4WPlsOinSnXTkqUBIWlHC6+S28VJ9PaHy7ZPSJwSQsRuDjI0/HL5G6hw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -35,7 +35,7 @@
     "@octokit/rest": "^20.1.1",
     "gcf-utils": "^17.1.2",
     "jsonwebtoken": "^9.0.3",
-    "release-please": "^17.5.2"
+    "release-please": "^17.6.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -182,18 +182,6 @@ async function getConfigWithDefaultBranch(
   return config;
 }
 
-interface AuthResponse {
-  type: string;
-  token: string;
-}
-async function getInstallationToken(octokit: Octokit): Promise<string> {
-  const auth = (await octokit.auth({type: 'installation'})) as AuthResponse;
-  if (auth.type !== 'token') {
-    throw new Error('Expected token auth');
-  }
-  return auth.token;
-}
-
 const execFile = util.promisify(child_process.execFile);
 export async function buildScm(
   owner: string,
@@ -211,42 +199,8 @@ export async function buildScm(
         'Local git clone requested, but BOT_TMPFS_DIR is not set -- using GitHub API'
       );
     } else {
-      const token = await getInstallationToken(octokit);
       const localRepoPath = `${process.env.BOT_TMPFS_DIR}/${owner}--${repo}`;
-      const url = `https://x-access-token:${token}@github.com/${owner}/${repo}.git`;
-
-      let isGitRepo = false;
-      try {
-        await execFile('git', ['rev-parse', '--is-inside-work-tree'], {
-          cwd: localRepoPath,
-        });
-        isGitRepo = true;
-      } catch (err) {
-        isGitRepo = false;
-      }
-
-      if (!isGitRepo) {
-        logger.info(
-          `Path ${localRepoPath} is not a git clone. Initializing with credentials...`
-        );
-        const args = ['clone', '--', url, localRepoPath];
-        if (branchConfiguration.localCloneDepth) {
-          args.splice(
-            1,
-            0,
-            '--depth',
-            branchConfiguration.localCloneDepth.toString()
-          );
-        }
-        await execFile('git', args);
-      }
-      logger.info(
-        `Updating credentials for existing local repository at ${localRepoPath}...`
-      );
-      await execFile('git', ['remote', 'set-url', 'origin', url], {
-        cwd: localRepoPath,
-      });
-
+      logger.info(`Local git clone requested: ${localRepoPath}`);
       return await LocalGitHub.create({
         owner,
         repo,


### PR DESCRIPTION
Updates release-please to v17.6.0. This version uses the GitHub API (via code-suggester) to update files for the pull request rather than using the `git` CLI. We will revisit having the LocaGitHub Scm use the `git` CLI to push updates at a later time, but for now, the git clone is read-only.
