### PR TITLE
fix(release-please): configure local git clone under lock

### DIFF
--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -297,7 +297,8 @@ interface RunBranchOptions {
   skipPullRequest?: boolean;
 }
 async function runBranchConfigurationWithConfigurationHandling(
-  scm: Scm,
+  owner: string,
+  repo: string,
   repoLanguage: string | null,
   repoUrl: string,
   branchConfiguration: BranchConfiguration,
@@ -321,6 +322,16 @@ async function runBranchConfigurationWithConfigurationHandling(
       lockAcquireTimeout: RP_LOCK_ACQUIRE_TIMEOUT_MS,
     },
     async () => {
+      const scm = await buildScm(
+        owner,
+        repo,
+        octokit,
+        branchConfiguration,
+        logger,
+        {
+          defaultBranch: branchConfiguration.branch,
+        }
+      );
       await runBranchConfigurationWithConfigurationHandlingWithoutLock(
         scm,
         repoLanguage,
@@ -578,20 +589,10 @@ const handler = (app: Probot) => {
         continue;
       }
 
-      const scm = await buildScm(
-        owner,
-        repo,
-        octokit,
-        branchConfiguration,
-        logger,
-        {
-          defaultBranch: context.payload.repository.default_branch,
-        }
-      );
-
       logger.debug(branchConfiguration);
       await runBranchConfigurationWithConfigurationHandling(
-        scm,
+        owner,
+        repo,
         repoLanguage,
         repoUrl,
         branchConfiguration,
@@ -740,20 +741,10 @@ const handler = (app: Probot) => {
     }
 
     for (const branchConfiguration of branchConfigurations) {
-      const scm = await buildScm(
-        owner,
-        repo,
-        octokit,
-        branchConfiguration,
-        logger,
-        {
-          defaultBranch: context.payload.repository.default_branch,
-        }
-      );
-
       logger.debug(branchConfiguration);
       await runBranchConfigurationWithConfigurationHandling(
-        scm,
+        owner,
+        repo,
         repoLanguage,
         repoUrl,
         branchConfiguration,


### PR DESCRIPTION
We are getting multiple requests to release-please simultaneously on the same release-please server instance. git operations on the local cache cannot be happening at the same time.

```
Command failed: git fetch origin --depth 200
fatal: Unable to create '/mnt/tempfs/googleapis--google-cloud-java/.git/shallow.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
```