### PR TITLE
feat(bazelbot): remove building Go and Python targets

### DIFF
--- a/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
+++ b/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
@@ -84,7 +84,7 @@ for (( idx=${#ungenerated_shas[@]}-1 ; idx>=0 ; idx-- )) ; do
     # Choose build targets.
     if [[ -z "$BUILD_TARGETS" ]] ; then
         targets=$(cd "$GOOGLEAPIS" \
-        && bazelisk query $BAZEL_FLAGS  'filter("-(go|csharp|java|php|ruby|nodejs|py)$", kind("rule", //...:*))' \
+        && bazelisk query $BAZEL_FLAGS  'filter("-(csharp|java|php|ruby|nodejs)$", kind("rule", //...:*))' \
         | grep -v -E ":(proto|grpc|gapic)-.*-java$")
     else
         targets="$BUILD_TARGETS"

--- a/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
+++ b/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
@@ -84,7 +84,7 @@ for (( idx=${#ungenerated_shas[@]}-1 ; idx>=0 ; idx-- )) ; do
     # Choose build targets.
     if [[ -z "$BUILD_TARGETS" ]] ; then
         targets=$(cd "$GOOGLEAPIS" \
-        && bazelisk query $BAZEL_FLAGS  'filter("-(csharp|java|php|ruby|nodejs)$", kind("rule", //...:*))' \
+        && bazelisk query $BAZEL_FLAGS  'filter("-(csharp|java|php|ruby|nodejs)$", kind("rule", //...:*)) + filter("-py$", kind("rule", //google/cloud/aiplatform/...:*))' \
         | grep -v -E ":(proto|grpc|gapic)-.*-java$")
     else
         targets="$BUILD_TARGETS"


### PR DESCRIPTION
Both Go and Python have moved to Librarian for the generation so we no longer need to build the libraries for googleapis-gen, mostly. The exception here is [python-aiplatform](https://github.com/googleapis/python-aiplatform/blob/main/.github/.OwlBot.yaml) which still uses owlbot.

This should significantly speed up the builds of bazelbot and make it less likely to flake.

Internal Bug: b/510765130