### PR TITLE
fix(owl-bot): prevent invalid Firestore queries on untagged images

### DIFF
--- a/packages/owl-bot/src/database.ts
+++ b/packages/owl-bot/src/database.ts
@@ -121,6 +121,9 @@ export class FirestoreConfigsStore implements ConfigsStore {
   async findReposWithPostProcessor(
     dockerImageName: string
   ): Promise<[string, Configs][]> {
+    if (!dockerImageName) {
+      return [];
+    }
     const ref = this.db.collection(this.repoConfigs);
     const got = await ref.where('dockerImage', '==', dockerImageName).get();
     return got.docs.map(doc => [decodeId(doc.id), doc.data() as Configs]);

--- a/packages/owl-bot/src/handlers.ts
+++ b/packages/owl-bot/src/handlers.ts
@@ -64,6 +64,12 @@ export async function onPostProcessorPublished(
   dockerImageDigest: string,
   installation: number
 ): Promise<void> {
+  if (!dockerImageName) {
+    console.warn(
+      'onPostProcessorPublished called without a valid dockerImageName'
+    );
+    return;
+  }
   // Examine all the repos that use the specified docker image for post
   // processing.
   console.info(

--- a/packages/owl-bot/src/owl-bot.ts
+++ b/packages/owl-bot/src/owl-bot.ts
@@ -293,9 +293,13 @@ function OwlBot(privateKey: string | undefined, app: Probot, db?: Db): void {
     // TODO: flesh out tests for pubsub.message handler:
     logger.info(JSON.stringify(typedContext.payload));
     if (typedContext.payload.action === 'INSERT') {
+      const dockerImageName = typedContext.payload.tag;
+      if (!dockerImageName) {
+        logger.info('pubsub message payload missing tag, skipping');
+        return;
+      }
       const configStore = new FirestoreConfigsStore(db!);
       const dockerImageDigest = typedContext.payload.digest.split('@')[1];
-      const dockerImageName = typedContext.payload.tag;
       logger.info({dockerImageDigest, dockerImageName});
       await onPostProcessorPublished(
         configStore,

--- a/packages/owl-bot/test/database.ts
+++ b/packages/owl-bot/test/database.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {describe, it} from 'mocha';
-import {encodeId, decodeId} from '../src/database';
+import {encodeId, decodeId, FirestoreConfigsStore} from '../src/database';
 import * as assert from 'assert';
 
 describe('encodeId', () => {
@@ -36,5 +36,15 @@ describe('encodeId', () => {
     const encoded = encodeId(chars);
     assert.strictEqual(encoded, '%2F%25%2B%2F%25%2B%2F%25%2B');
     assert.strictEqual(decodeId(encoded), chars);
+  });
+});
+
+describe('FirestoreConfigsStore', () => {
+  it('findReposWithPostProcessor returns empty array early when dockerImageName is empty', async () => {
+    // Passing null as db verifies that db.collection is never called.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const store = new FirestoreConfigsStore(null as any);
+    const result = await store.findReposWithPostProcessor('');
+    assert.deepStrictEqual(result, []);
   });
 });

--- a/packages/owl-bot/test/handlers.ts
+++ b/packages/owl-bot/test/handlers.ts
@@ -24,6 +24,7 @@ import {
   triggerOneBuildForUpdatingLock,
   refreshConfigs,
   scanGithubForConfigs,
+  onPostProcessorPublished,
 } from '../src/handlers';
 import {AffectedRepo, Configs, ConfigsStore} from '../src/configs-store';
 import {dump} from 'js-yaml';
@@ -49,6 +50,25 @@ const sandbox = sinon.createSandbox();
 describe('handlers', () => {
   afterEach(() => {
     sandbox.restore();
+  });
+  describe('onPostProcessorPublished', () => {
+    it('returns early without calling findReposWithPostProcessor if dockerImageName is empty', async () => {
+      let called = false;
+      const fakeStore = new FakeConfigsStore();
+      fakeStore.findReposWithPostProcessor = async () => {
+        called = true;
+        return [];
+      };
+      await onPostProcessorPublished(
+        fakeStore,
+        'fake-key',
+        123,
+        '',
+        'sha256:abc',
+        456
+      );
+      assert.strictEqual(called, false);
+    });
   });
   describe('triggerOneBuildForUpdatingLock', () => {
     const octokitFactory = octokitFactoryFromToken('fake-github-token');

--- a/packages/owl-bot/test/owl-bot.ts
+++ b/packages/owl-bot/test/owl-bot.ts
@@ -811,6 +811,30 @@ describe('OwlBot', () => {
     sandbox.assert.calledOnce(loggerStub);
   });
 
+  describe('pubsub.message', () => {
+    it('skips processing when action is INSERT but tag is missing', async () => {
+      const onPostProcessorPublishedStub = sandbox
+        .stub(handlers, 'onPostProcessorPublished')
+        .resolves();
+      const loggerStub = sandbox.stub(logger, 'info');
+      await probot.receive({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        name: 'pubsub.message' as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        payload: {
+          action: 'INSERT',
+          digest: 'gcr.io/foo/bar@sha256:123',
+        } as any,
+        id: 'abc123',
+      });
+      sandbox.assert.notCalled(onPostProcessorPublishedStub);
+      sandbox.assert.calledWith(
+        loggerStub,
+        sandbox.match(/pubsub message payload missing tag, skipping/)
+      );
+    });
+  });
+
   describe('pull request merged', () => {
     let loggerErrorStub: sinon.SinonStub;
     let getConfigsStub: sinon.SinonStub;


### PR DESCRIPTION
Safely ignore PubSub container insert events that omit an image tag, preventing an undefined value from triggering fatal Firestore `.where()` query constraint errors.

Saw the following error that occur 20-30 times a day in logs:
```
Value for argument "value" is not a valid query constraint. Cannot
use "undefined" as a Firestore value. If you want to ignore
undefined values, enable `ignoreUndefinedProperties`.
```