### PR TITLE
fix: increase lock timeouts for large monorepos

### DIFF
--- a/packages/datastore-lock/src/datastore-lock.ts
+++ b/packages/datastore-lock/src/datastore-lock.ts
@@ -14,11 +14,11 @@
 //
 
 import crypto from 'crypto';
-import {Datastore, Key} from '@google-cloud/datastore';
-import {logger} from 'gcf-utils';
+import { Datastore, Key } from '@google-cloud/datastore';
+import { logger } from 'gcf-utils';
 
 const DEFAULT_LOCK_EXPIRY = 20 * 1000; // 20 seconds
-const MAX_LOCK_EXPIRY = 60 * 1000; // 60 seconds
+const MAX_LOCK_EXPIRY = 10 * 60 * 1000; // 10 minutes
 const DEFAULT_LOCK_ACQUIRE_TIMEOUT = 120 * 1000; // 120 seconds
 const BACKOFF_INITIAL_DELAY = 2 * 1000; // 1 seconds
 const BACKOFF_MAX_DELAY = 10 * 1000; // 10 seconds
@@ -73,7 +73,7 @@ export class DatastoreLock {
     if (lockExpiry > MAX_LOCK_EXPIRY) {
       throw new Error(
         `lockExpiry is too long, max is ${MAX_LOCK_EXPIRY}, ` +
-          `given ${lockExpiry}`
+        `given ${lockExpiry}`
       );
     }
     // It reduces memory overhead on Cloud Function if we
@@ -260,6 +260,14 @@ export async function withDatastoreLock<R>(
   try {
     return await f();
   } finally {
-    lock.release();
+    try {
+      await lock.release();
+    } catch (err) {
+      if (err instanceof DatastoreLockError) {
+        logger.warn(err);
+      } else {
+        throw err;
+      }
+    }
   }
 }

--- a/packages/datastore-lock/src/datastore-lock.ts
+++ b/packages/datastore-lock/src/datastore-lock.ts
@@ -14,8 +14,8 @@
 //
 
 import crypto from 'crypto';
-import { Datastore, Key } from '@google-cloud/datastore';
-import { logger } from 'gcf-utils';
+import {Datastore, Key} from '@google-cloud/datastore';
+import {logger} from 'gcf-utils';
 
 const DEFAULT_LOCK_EXPIRY = 20 * 1000; // 20 seconds
 const MAX_LOCK_EXPIRY = 10 * 60 * 1000; // 10 minutes
@@ -73,7 +73,7 @@ export class DatastoreLock {
     if (lockExpiry > MAX_LOCK_EXPIRY) {
       throw new Error(
         `lockExpiry is too long, max is ${MAX_LOCK_EXPIRY}, ` +
-        `given ${lockExpiry}`
+          `given ${lockExpiry}`
       );
     }
     // It reduces memory overhead on Cloud Function if we
@@ -260,14 +260,6 @@ export async function withDatastoreLock<R>(
   try {
     return await f();
   } finally {
-    try {
-      await lock.release();
-    } catch (err) {
-      if (err instanceof DatastoreLockError) {
-        logger.warn(err);
-      } else {
-        throw err;
-      }
-    }
+    lock.release();
   }
 }

--- a/packages/datastore-lock/test/datastore-lock.ts
+++ b/packages/datastore-lock/test/datastore-lock.ts
@@ -63,7 +63,7 @@ describe('datastore-lock', () => {
       assert(!(await l.acquire()));
       assert(!(await l.release()));
       assert.throws(() => {
-        new DatastoreLock('datastore-lock-test', 'test', 120 * 1000 + 1);
+        new DatastoreLock('datastore-lock-test', 'test', 10 * 60 * 1000 + 1);
       }, Error);
     });
   });

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -286,7 +286,7 @@ async function buildManifest(
 }
 
 const RP_LOCK_ID = 'release-please';
-const RP_LOCK_DURATION_MS = 60 * 1000;
+const RP_LOCK_DURATION_MS = 5 * 60 * 1000;
 const RP_LOCK_ACQUIRE_TIMEOUT_MS = 120 * 1000;
 interface RunBranchOptions {
   logger?: GCFLogger;

--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -286,7 +286,7 @@ async function buildManifest(
 }
 
 const RP_LOCK_ID = 'release-please';
-const RP_LOCK_DURATION_MS = 5 * 60 * 1000;
+const RP_LOCK_DURATION_MS = 10 * 60 * 1000;
 const RP_LOCK_ACQUIRE_TIMEOUT_MS = 120 * 1000;
 interface RunBranchOptions {
   logger?: GCFLogger;


### PR DESCRIPTION
Tasks on large monorepos (e.g., google-cloud-node) can take 4+ minutes due to size and the number of GitHub API requests made. The previous 60s limit caused active locks to prematurely auto-expire, resulting in concurrent worker overlap and jobs running unlocked for a period of time.