### PR TITLE
fix(label-utils): update documentation to test a release

### DIFF
--- a/packages/label-utils/README.md
+++ b/packages/label-utils/README.md
@@ -1,6 +1,6 @@
 # Utility for syncing bot labels
 
-This is a small utility for syncing bot specific labels.
+This is a small utility for syncing bot-specific labels across GitHub repositories.
 
 ## Usage
 


### PR DESCRIPTION
This change updates a README.md with "fix:" conventional commit prefix.
This is to confirm our release infrastructure is working.

The label-utils package is used in confirming Wombat Dressing Room (go/wombat-dressing-room#redeploying-service).