### PR TITLE
fix(owl-bot): update owlbot config exclusion list after monorepo changes in google-cloud-node

### DIFF
--- a/packages/owl-bot/src/handlers.ts
+++ b/packages/owl-bot/src/handlers.ts
@@ -39,13 +39,13 @@ type ListReposResponse = Endpoints['GET /orgs/{org}/repos']['response'];
 // template files). This list will keep .OwlBot from providing error messages for
 // those files.
 export const CONFIG_PATHS_TO_SKIP = [
-  'packages/gapic-node-processing/templates/bootstrap-templates/.OwlBot.yaml',
-  'generator/gapic-generator-typescript/test-fixtures/google-cloud-speech-nodejs/speech-v1-nodejs/.OwlBot.yaml',
-  'generator/gapic-generator-typescript/test-fixtures/google-cloud-speech-nodejs/speech-v1p1beta1-nodejs/.OwlBot.yaml',
-  'generator/gapic-generator-typescript/test-fixtures/google-cloud-speech-nodejs/speech-v2-nodejs/.OwlBot.yaml',
-  'generator/gapic-generator-typescript/test-fixtures/google-cloud-speech/.OwlBot.yaml',
-  'generator/gapic-generator-typescript/test-fixtures/google-cloud-tasks-nodejs/tasks-v2-nodejs/.OwlBot.yaml',
-  'generator/gapic-generator-typescript/test-fixtures/google-cloud-tasks-nodejs/tasks-v2beta2-nodejs/.OwlBot.yaml',
+  'core/packages/gapic-node-processing/templates/bootstrap-templates/.OwlBot.yaml',
+  'core/generator/gapic-generator-typescript/test-fixtures/google-cloud-speech-nodejs/speech-v1-nodejs/.OwlBot.yaml',
+  'core/generator/gapic-generator-typescript/test-fixtures/google-cloud-speech-nodejs/speech-v1p1beta1-nodejs/.OwlBot.yaml',
+  'core/generator/gapic-generator-typescript/test-fixtures/google-cloud-speech-nodejs/speech-v2-nodejs/.OwlBot.yaml',
+  'core/generator/gapic-generator-typescript/test-fixtures/google-cloud-speech/.OwlBot.yaml',
+  'core/generator/gapic-generator-typescript/test-fixtures/google-cloud-tasks-nodejs/tasks-v2-nodejs/.OwlBot.yaml',
+  'core/generator/gapic-generator-typescript/test-fixtures/google-cloud-tasks-nodejs/tasks-v2beta2-nodejs/.OwlBot.yaml',
 ];
 /**
  * Invoked when a new pubsub message arrives because a new post processor

--- a/packages/owl-bot/test/handlers.ts
+++ b/packages/owl-bot/test/handlers.ts
@@ -546,7 +546,7 @@ describe('refreshConfigs', () => {
 
     const zip = new AdmZip();
     zip.addFile(
-      'nodejs-vision/packages/gapic-node-processing/templates/bootstrap-templates/.OwlBot.yaml',
+      'nodejs-vision/core/packages/gapic-node-processing/templates/bootstrap-templates/.OwlBot.yaml',
       Buffer.from(invalidConfig)
     );
 

--- a/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
+++ b/packages/owl-bot/test/scan-googleapis-gen-and-create-pull-requests.ts
@@ -711,7 +711,7 @@ Copy-Tag: ${copyTag}`
 
   it('skips a repo when path is in CONFIG_PATHS_TO_SKIP', async () => {
     const skipPath =
-      'packages/gapic-node-processing/templates/bootstrap-templates/.OwlBot.yaml';
+      'core/packages/gapic-node-processing/templates/bootstrap-templates/.OwlBot.yaml';
     const [destRepo, configsStore] = makeDestRepoAndConfigsStore(bYaml);
 
     // Override the yaml path in the config store to be one of the skipped paths


### PR DESCRIPTION
We moved a few paths around and broke the OwlBot config exclusion list. This is re code that was added in https://github.com/googleapis/repo-automation-bots/pull/5007.

Fixes https://github.com/googleapis/google-cloud-node/issues/8332 🦕
