### PR TITLE
fix(release-please): gracefully handle 502 query timeouts

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -16,7 +16,7 @@
         "@octokit/plugin-retry": "^6.1.0",
         "@octokit/rest": "^20.1.1",
         "gcf-utils": "^17.1.2",
-        "release-please": "^17.6.0"
+        "release-please": "^17.6.1"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -8779,9 +8779,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-17.6.0.tgz",
-      "integrity": "sha512-ItzkkEBeEbKsCrx7N1QlADrCahoONA4WPlsOinSnXTkqUBIWlHC6+S28VJ9PaHy7ZPSJwSQsRuDjI0/HL5G6hw==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-17.6.1.tgz",
+      "integrity": "sha512-4KtlVBnvccYZWepgFuRO5qVLc3Y0NicyBM4nqSt+sTKRWvagEJbPXUgErcWLJLW63KHzDphdwZQbbRmyqt2eIQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -35,7 +35,7 @@
     "@octokit/plugin-retry": "^6.1.0",
     "@octokit/rest": "^20.1.1",
     "gcf-utils": "^17.1.2",
-    "release-please": "^17.6.0"
+    "release-please": "^17.6.1"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
This was fixed in https://github.com/googleapis/release-please/commit/e5033c13070a2f702fb06927f92ca198ac18a830.