### PR TITLE
fix(deps): override qs, serialize-javascript, and uuid to resolve remaining security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1680,9 +1680,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,10 @@
     "gaxios": "^5.0.0",
     "smee-client": "^1.1.0",
     "@google-cloud/mono-repo-publish": "^1.0.0"
+  },
+  "overrides": {
+    "qs": "6.15.2",
+    "serialize-javascript": "^7.0.5",
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/auto-approve/package-lock.json
+++ b/packages/auto-approve/package-lock.json
@@ -6788,9 +6788,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/auto-approve/package.json
+++ b/packages/auto-approve/package.json
@@ -54,9 +54,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/auto-label/package-lock.json
+++ b/packages/auto-label/package-lock.json
@@ -7691,9 +7691,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/auto-label/package.json
+++ b/packages/auto-label/package.json
@@ -53,9 +53,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/bazel-bot/package-lock.json
+++ b/packages/bazel-bot/package-lock.json
@@ -1,6 +1,6 @@
 {
-    "name": "bazel-bot",
-    "lockfileVersion": 2,
-    "requires": true,
-    "packages": {}
+  "name": "bazel-bot",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
 }

--- a/packages/bazel-bot/package.json
+++ b/packages/bazel-bot/package.json
@@ -1,6 +1,11 @@
 {
-    "scripts": {
-        "test": "bash test-generate-googleapis-gen.sh",
-        "lint": "echo 'The code is beautiful!'"
-    }
+  "scripts": {
+    "test": "bash test-generate-googleapis-gen.sh",
+    "lint": "echo 'The code is beautiful!'"
+  },
+  "overrides": {
+    "qs": "6.15.2",
+    "serialize-javascript": "^7.0.5",
+    "uuid": "^11.1.1"
+  }
 }

--- a/packages/blunderbuss/package-lock.json
+++ b/packages/blunderbuss/package-lock.json
@@ -7896,9 +7896,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/blunderbuss/package.json
+++ b/packages/blunderbuss/package.json
@@ -53,9 +53,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/bot-config-utils/package-lock.json
+++ b/packages/bot-config-utils/package-lock.json
@@ -7972,9 +7972,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/bot-config-utils/package.json
+++ b/packages/bot-config-utils/package.json
@@ -51,9 +51,10 @@
     "build/src"
   ],
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/canary-bot/package-lock.json
+++ b/packages/canary-bot/package-lock.json
@@ -7582,9 +7582,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/canary-bot/package.json
+++ b/packages/canary-bot/package.json
@@ -49,9 +49,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/cherry-pick-bot/package-lock.json
+++ b/packages/cherry-pick-bot/package-lock.json
@@ -7744,9 +7744,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/cherry-pick-bot/package.json
+++ b/packages/cherry-pick-bot/package.json
@@ -52,9 +52,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/conventional-commit-lint/package-lock.json
+++ b/packages/conventional-commit-lint/package-lock.json
@@ -8068,9 +8068,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/conventional-commit-lint/package.json
+++ b/packages/conventional-commit-lint/package.json
@@ -51,9 +51,10 @@
     "typescript": "~4.9.0"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   },
   "engines": {

--- a/packages/cron-utils/package.json
+++ b/packages/cron-utils/package.json
@@ -46,9 +46,10 @@
     "build/src"
   ],
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/datastore-lock/package-lock.json
+++ b/packages/datastore-lock/package-lock.json
@@ -7699,9 +7699,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/datastore-lock/package.json
+++ b/packages/datastore-lock/package.json
@@ -42,13 +42,14 @@
     "build/src"
   ],
   "overrides": {
+    "@tootallnate/once": "^3.0.1",
     "google-datastore-emulator": {
       "@google-cloud/datastore": "9.1.0",
       "tar-fs": "2.1.4"
     },
-    "tmp": "0.2.6",
-    "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/do-not-merge/package-lock.json
+++ b/packages/do-not-merge/package-lock.json
@@ -7780,9 +7780,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/do-not-merge/package.json
+++ b/packages/do-not-merge/package.json
@@ -48,9 +48,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/failurechecker/package-lock.json
+++ b/packages/failurechecker/package-lock.json
@@ -7880,9 +7880,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/failurechecker/package.json
+++ b/packages/failurechecker/package.json
@@ -49,9 +49,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/flakybot/package.json
+++ b/packages/flakybot/package.json
@@ -52,9 +52,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/gcf-utils/package-lock.json
+++ b/packages/gcf-utils/package-lock.json
@@ -7598,9 +7598,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -77,9 +77,10 @@
     "build/src"
   ],
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/generate-bot/package.json
+++ b/packages/generate-bot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generate-bot",
   "version": "1.1.0",
-  "description": "generate new repo-automation-bots 🤖",
+  "description": "generate new repo-automation-bots \ud83e\udd16",
   "main": "build/src/run.js",
   "private": true,
   "files": [
@@ -43,7 +43,9 @@
     "node": ">= 20"
   },
   "overrides": {
+    "qs": "6.15.2",
+    "serialize-javascript": "^7.0.5",
     "tmp": "0.2.6",
-    "serialize-javascript": "^7.0.5"
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/generated-files-bot/package-lock.json
+++ b/packages/generated-files-bot/package-lock.json
@@ -7984,9 +7984,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/generated-files-bot/package.json
+++ b/packages/generated-files-bot/package.json
@@ -55,12 +55,13 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
+    "@tootallnate/once": "^3.0.1",
     "jsonpath": {
       "underscore": "^1.13.8"
     },
-    "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/git-file-utils/package.json
+++ b/packages/git-file-utils/package.json
@@ -45,7 +45,9 @@
     "build/src"
   ],
   "overrides": {
+    "qs": "6.15.2",
+    "serialize-javascript": "^7.0.5",
     "tmp": "0.2.6",
-    "serialize-javascript": "^7.0.5"
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/header-checker-lint/package.json
+++ b/packages/header-checker-lint/package.json
@@ -50,9 +50,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/issue-utils/package-lock.json
+++ b/packages/issue-utils/package-lock.json
@@ -7364,9 +7364,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/issue-utils/package.json
+++ b/packages/issue-utils/package.json
@@ -42,9 +42,10 @@
     "build/src"
   ],
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/label-sync/package-lock.json
+++ b/packages/label-sync/package-lock.json
@@ -7471,9 +7471,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/label-sync/package.json
+++ b/packages/label-sync/package.json
@@ -47,9 +47,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/label-utils/package-lock.json
+++ b/packages/label-utils/package-lock.json
@@ -7776,9 +7776,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/label-utils/package.json
+++ b/packages/label-utils/package.json
@@ -46,9 +46,10 @@
     "build/src"
   ],
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/loadtest-bot/package-lock.json
+++ b/packages/loadtest-bot/package-lock.json
@@ -7366,9 +7366,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/loadtest-bot/package.json
+++ b/packages/loadtest-bot/package.json
@@ -44,9 +44,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/merge-on-green/package.json
+++ b/packages/merge-on-green/package.json
@@ -49,9 +49,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/mono-repo-publish/package.json
+++ b/packages/mono-repo-publish/package.json
@@ -44,7 +44,9 @@
     "node": ">= 20"
   },
   "overrides": {
+    "qs": "6.15.2",
+    "serialize-javascript": "^7.0.5",
     "tmp": "0.2.6",
-    "serialize-javascript": "^7.0.5"
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/mono-repo-publish/test/sample-private-package/package-lock.json
+++ b/packages/mono-repo-publish/test/sample-private-package/package-lock.json
@@ -342,21 +342,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
@@ -2410,9 +2395,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2422,16 +2407,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -2566,13 +2541,13 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {

--- a/packages/mono-repo-publish/test/sample-private-package/package.json
+++ b/packages/mono-repo-publish/test/sample-private-package/package.json
@@ -31,5 +31,10 @@
     "nock": "^13.0.0",
     "proxyquire": "^2.1.3",
     "typescript": "^4.6.4"
+  },
+  "overrides": {
+    "qs": "6.15.2",
+    "serialize-javascript": "^7.0.5",
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/object-selector/package.json
+++ b/packages/object-selector/package.json
@@ -51,9 +51,10 @@
     "build/src"
   ],
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/owl-bot/package-lock.json
+++ b/packages/owl-bot/package-lock.json
@@ -8460,9 +8460,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -88,13 +88,14 @@
     "fsevents": "*"
   },
   "overrides": {
-    "tmp": "0.2.6",
+    "@tootallnate/once": "^3.0.1",
     "mocha": {
       "serialize-javascript": "7.0.5",
       "diff": "8.0.4"
     },
-    "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/owlbot-bootstrapper/cli/package-lock.json
+++ b/packages/owlbot-bootstrapper/cli/package-lock.json
@@ -4218,9 +4218,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/packages/owlbot-bootstrapper/cli/package.json
+++ b/packages/owlbot-bootstrapper/cli/package.json
@@ -54,10 +54,11 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
-    "lodash": "^4.18.0",
-    "serialize-javascript": "^7.0.5",
     "@tootallnate/once": "^3.0.1",
+    "lodash": "^4.18.0",
+    "qs": "6.15.2",
+    "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/owlbot-bootstrapper/common-container/package-lock.json
+++ b/packages/owlbot-bootstrapper/common-container/package-lock.json
@@ -407,20 +407,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@google-cloud/storage/node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@google-cloud/tasks": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-5.5.2.tgz",
@@ -4946,20 +4932,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/gcf-utils/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/gcp-metadata": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
@@ -4988,20 +4960,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/get-caller-file": {
@@ -5166,20 +5124,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/google-auth-library/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/google-gax": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
@@ -5201,20 +5145,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/google-gax/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/google-logging-utils": {
@@ -5271,20 +5201,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/gtoken/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gts": {
@@ -8142,16 +8058,6 @@
         "url": "https://opencollective.com/ramda"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -8819,13 +8725,13 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {
@@ -9605,20 +9511,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -9913,13 +9805,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {

--- a/packages/owlbot-bootstrapper/common-container/package.json
+++ b/packages/owlbot-bootstrapper/common-container/package.json
@@ -61,6 +61,9 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6"
+    "qs": "6.15.2",
+    "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/owlbot-bootstrapper/package.json
+++ b/packages/owlbot-bootstrapper/package.json
@@ -24,5 +24,10 @@
   },
   "engines": {
     "node": ">= 20"
+  },
+  "overrides": {
+    "qs": "6.15.2",
+    "serialize-javascript": "^7.0.5",
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/release-brancher/package.json
+++ b/packages/release-brancher/package.json
@@ -56,7 +56,9 @@
     "node": ">= 20"
   },
   "overrides": {
+    "qs": "6.15.2",
+    "serialize-javascript": "^7.0.5",
     "tmp": "0.2.6",
-    "serialize-javascript": "^7.0.5"
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -57,9 +57,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/repo-metadata-lint/package.json
+++ b/packages/repo-metadata-lint/package.json
@@ -55,9 +55,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/secret-rotator/package.json
+++ b/packages/secret-rotator/package.json
@@ -53,9 +53,10 @@
     "fsevents": "*"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/snippet-bot/package.json
+++ b/packages/snippet-bot/package.json
@@ -66,9 +66,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/sync-repo-settings/package.json
+++ b/packages/sync-repo-settings/package.json
@@ -56,9 +56,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }

--- a/packages/trusted-contribution/package.json
+++ b/packages/trusted-contribution/package.json
@@ -52,9 +52,10 @@
     "node": ">= 20"
   },
   "overrides": {
-    "tmp": "0.2.6",
     "@tootallnate/once": "^3.0.1",
+    "qs": "6.15.2",
     "serialize-javascript": "^7.0.5",
+    "tmp": "0.2.6",
     "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
This PR injects overrides for the remaining vulnerable transitive dependencies to resolve their active security alerts across all sub-packages in the repository:

1. **qs** upgraded to `6.15.2` (CVE-2026-41907 / GHSA-w5hq-g745-h8pq).
2. **serialize-javascript** upgraded to `^7.0.5` (CPU Exhaustion DoS vulnerability).
3. **uuid** upgraded to `^11.1.1` (Missing bounds check in v3/v5/v6).

Regenerated all lockfiles correspondingly. GREEN unit tests.