### PR TITLE
fix(serverless-scheduler-proxy): upgrade Go version to 1.26.3 in serverless-scheduler-proxy

### DIFF
--- a/serverless-scheduler-proxy/Dockerfile
+++ b/serverless-scheduler-proxy/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.9-alpine AS build
+FROM golang:1.26.3-alpine AS build
 
 RUN apk add --no-cache git ca-certificates
 WORKDIR /src/serverless-scheduler-proxy


### PR DESCRIPTION
Upgraded the Go base image in Dockerfile from 1.25.9-alpine to 1.26.3-alpine to resolve security vulnerabilities.

b/511481353