### PR TITLE
fix(bazelbot): partial revert of 5438bae

### DIFF
--- a/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
+++ b/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
@@ -84,7 +84,7 @@ for (( idx=${#ungenerated_shas[@]}-1 ; idx>=0 ; idx-- )) ; do
     # Choose build targets.
     if [[ -z "$BUILD_TARGETS" ]] ; then
         targets=$(cd "$GOOGLEAPIS" \
-        && bazelisk query $BAZEL_FLAGS  'filter("-(csharp|php|ruby|nodejs)$", kind("rule", //...:*)) + filter("-py$", kind("rule", //google/cloud/aiplatform/...:*))' \
+        && bazelisk query $BAZEL_FLAGS  'filter("-(csharp|php|ruby|nodejs|py)$", kind("rule", //...:*))' \
         | grep -v -E ":(proto|grpc|gapic)-.*-java$")
     else
         targets="$BUILD_TARGETS"


### PR DESCRIPTION
It seems like when a workspace only change is made some of the optimizations we do in this script causes the additional python filter to fail. For now lets just start generating all of python again and I will followup with a fix to make this work in the future.

Internal Bug: b/517906077