### PR TITLE
fix(datastore-lock): await lock.release() in withDatastoreLock

### DIFF
--- a/packages/datastore-lock/src/datastore-lock.ts
+++ b/packages/datastore-lock/src/datastore-lock.ts
@@ -260,6 +260,6 @@ export async function withDatastoreLock<R>(
   try {
     return await f();
   } finally {
-    lock.release();
+    await lock.release();
   }
 }


### PR DESCRIPTION
This PR awaits the `lock.release()` call in `withDatastoreLock` to prevent concurrency conflicts in Datastore when sequentially executing configurations.

In b/521458652, we observed google-cloud-node's 2 configurations that are supposed to be processed sequentially hit `Error: This transaction has already expired.`. We suspect that it's caused by the missing `await` for the lock relesae.
