### PR TITLE
deps(release-please): datastore-lock 7.1.4

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@google-automations/bot-config-utils": "^9.0.0",
-        "@google-automations/datastore-lock": "^7.0.0",
+        "@google-automations/datastore-lock": "^7.1.4",
         "@google-automations/issue-utils": "^5.0.0",
         "@google-automations/label-utils": "^6.0.0",
         "@octokit/plugin-retry": "^6.1.0",
@@ -221,16 +221,13 @@
       }
     },
     "node_modules/@google-automations/datastore-lock": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@google-automations/datastore-lock/-/datastore-lock-7.1.3.tgz",
-      "integrity": "sha512-CBwkvf8MIjX5egDupUDh8D9mWN2mi93lsp5aij6VZQD0webN2t45XS6LB8VAmvkEqQjUNWPJLfE/CwqsmkjDKg==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@google-automations/datastore-lock/-/datastore-lock-7.1.4.tgz",
+      "integrity": "sha512-a7ZdkvrXUXsUE6pej9E1yLwczCk9uECElJt8pJ6pHTpLP1AHS+n0yEwluZ+wo92GOseBXPVc1IsElCVfRuEnyw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/datastore": "^9.0.0",
-        "gcf-utils": "^17.0.0",
-        "js-yaml": "^4.1.1",
-        "jsonwebtoken": "^9.0.3",
-        "uuid": "^9.0.0"
+        "gcf-utils": "^17.0.0"
       },
       "engines": {
         "node": ">= 20"

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@google-automations/bot-config-utils": "^9.0.0",
-    "@google-automations/datastore-lock": "^7.0.0",
+    "@google-automations/datastore-lock": "^7.1.4",
     "@google-automations/issue-utils": "^5.0.0",
     "@google-automations/label-utils": "^6.0.0",
     "@octokit/plugin-retry": "^6.1.0",


### PR DESCRIPTION
https://www.npmjs.com/package/@google-automations/datastore-lock/v/7.1.4 is now available. This datastore-lock 7.1.4 increased the lock expiry limit.

b/521458652