### PR TITLE
feat: upgrade repository to Node.js 22

### DIFF
--- a/.github/workflows/audit-bulk.yaml
+++ b/.github/workflows/audit-bulk.yaml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
       - run: npm run run -- npm audit fix
         continue-on-error: true
       - uses: googleapis/code-suggester@589b3ac11ac2575fd561afa45034907f301a375b # v4

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
       - id: interrogate
         run: node ./.github/workflows/list-node-paths-for-deps.js
   updateDeps:
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
       - run: echo ./packages/${{ matrix.package }}
       - run: cd ./packages/${{ matrix.package }} && npm audit fix
         continue-on-error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 24
+          node-version: 22
       - id: interrogate
         run: node ./.github/workflows/interrogate.js
         env:
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 24
+          node-version: 22
       - run: echo ./packages/${{ matrix.package }}
       - run: cd ./packages/${{ matrix.package }}
       - run: npm ci
@@ -91,6 +91,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 24
+          node-version: 22
       - run: npm ci
       - run: node ./.github/workflows/finale.js '${{needs.changeFinder.outputs.requiredJobs}}' ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 14
+          node-version: 22
       - id: interrogate
         run: node ./.github/workflows/list-node-paths-for-deps.js
   updateDeps:
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 22
       - run: npm i -g npm-check-updates
       - run: echo ./packages/${{ matrix.package }}
       - run: ./scripts/update-dependencies.sh packages/${{ matrix.package }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "smee-client": "^1.1.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">= 22"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "repository": "googleapis/repo-automation-bots",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">= 22"
   },
   "scripts": {
     "run": "./scripts/scripts.js",

--- a/packages/auto-approve/cloudbuild.yaml
+++ b/packages/auto-approve/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/auto-approve/package-lock.json
+++ b/packages/auto-approve/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -33,7 +33,7 @@
         "typescript": "~4.9.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1893,9 +1893,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/auto-approve/package.json
+++ b/packages/auto-approve/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -51,7 +51,7 @@
     "typescript": "~4.9.0"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/auto-label/cloudbuild.yaml
+++ b/packages/auto-label/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/auto-label/package-lock.json
+++ b/packages/auto-label/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/js-yaml": "^3.11.0",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -31,7 +31,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2124,9 +2124,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/auto-label/package.json
+++ b/packages/auto-label/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/js-yaml": "^3.11.0",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -50,7 +50,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/bazel-bot/package-lock.json
+++ b/packages/bazel-bot/package-lock.json
@@ -2,9 +2,5 @@
   "name": "bazel-bot",
   "lockfileVersion": 2,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "bazel-bot"
-    }
-  }
+  "packages": {}
 }

--- a/packages/bazel-bot/package.json
+++ b/packages/bazel-bot/package.json
@@ -1,4 +1,10 @@
 {
+  "name": "bazel-bot",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": ">= 22"
+  },
   "scripts": {
     "test": "bash test-generate-googleapis-gen.sh",
     "lint": "echo 'The code is beautiful!'"

--- a/packages/blunderbuss/cloudbuild.yaml
+++ b/packages/blunderbuss/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/blunderbuss/package-lock.json
+++ b/packages/blunderbuss/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -31,7 +31,7 @@
         "typescript": "^4.9.4"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2193,9 +2193,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/blunderbuss/package.json
+++ b/packages/blunderbuss/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -50,7 +50,7 @@
     "typescript": "^4.9.4"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/bot-config-utils/package-lock.json
+++ b/packages/bot-config-utils/package-lock.json
@@ -18,7 +18,7 @@
         "@octokit/types": "^8.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -31,7 +31,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2317,9 +2317,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/bot-config-utils/package.json
+++ b/packages/bot-config-utils/package.json
@@ -26,7 +26,7 @@
     "@octokit/types": "^8.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -39,7 +39,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "keywords": [
     "Bot config",

--- a/packages/canary-bot/cloudbuild-gcf.yaml
+++ b/packages/canary-bot/cloudbuild-gcf.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/canary-bot/package-lock.json
+++ b/packages/canary-bot/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -28,7 +28,7 @@
         "typescript": "~4.9.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2128,9 +2128,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/canary-bot/package.json
+++ b/packages/canary-bot/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -46,7 +46,7 @@
     "typescript": "~4.9.0"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/cherry-pick-bot/package-lock.json
+++ b/packages/cherry-pick-bot/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "@types/yargs": "^17.0.12",
         "c8": "^7.12.0",
@@ -33,7 +33,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2049,9 +2049,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/cherry-pick-bot/package.json
+++ b/packages/cherry-pick-bot/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "@types/yargs": "^17.0.12",
     "c8": "^7.12.0",
@@ -49,7 +49,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/conventional-commit-lint/cloudbuild.yaml
+++ b/packages/conventional-commit-lint/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/conventional-commit-lint/package-lock.json
+++ b/packages/conventional-commit-lint/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -31,7 +31,7 @@
         "typescript": "~4.9.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2259,9 +2259,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/conventional-commit-lint/package.json
+++ b/packages/conventional-commit-lint/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -58,6 +58,6 @@
     "uuid": "^11.1.1"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   }
 }

--- a/packages/cron-utils/package-lock.json
+++ b/packages/cron-utils/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.5",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "@types/yargs": "^17.0.12",
         "c8": "^7.12.0",
@@ -32,7 +32,7 @@
         "typescript": "^4.9.4"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -495,9 +495,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/cron-utils/package.json
+++ b/packages/cron-utils/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "@types/yargs": "^17.0.12",
     "c8": "^7.12.0",
@@ -37,7 +37,7 @@
     "typescript": "^4.9.4"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "keywords": [],
   "author": "Jeff Ching <chingor@google.com>",

--- a/packages/datastore-lock/package-lock.json
+++ b/packages/datastore-lock/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
         "google-datastore-emulator": "^7.1.0",
@@ -24,7 +24,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2056,9 +2056,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/datastore-lock/package.json
+++ b/packages/datastore-lock/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
     "google-datastore-emulator": "^7.1.0",
@@ -30,7 +30,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "keywords": [
     "google cloud datastore",

--- a/packages/do-not-merge/cloudbuild.yaml
+++ b/packages/do-not-merge/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/do-not-merge/package-lock.json
+++ b/packages/do-not-merge/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -27,7 +27,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2125,9 +2125,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/do-not-merge/package.json
+++ b/packages/do-not-merge/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -45,7 +45,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/failurechecker/cloudbuild.yaml
+++ b/packages/failurechecker/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/failurechecker/package-lock.json
+++ b/packages/failurechecker/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -27,7 +27,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2279,9 +2279,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/failurechecker/package.json
+++ b/packages/failurechecker/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -46,7 +46,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/flakybot/cloudbuild.yaml
+++ b/packages/flakybot/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/flakybot/package-lock.json
+++ b/packages/flakybot/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -31,7 +31,7 @@
         "typescript": "~4.9.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2223,9 +2223,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/flakybot/package.json
+++ b/packages/flakybot/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -49,7 +49,7 @@
     "typescript": "~4.9.0"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/gcf-utils/Dockerfile
+++ b/packages/gcf-utils/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:18
+FROM node:22
 
 USER root
 

--- a/packages/gcf-utils/package-lock.json
+++ b/packages/gcf-utils/package-lock.json
@@ -37,7 +37,7 @@
       "devDependencies": {
         "@types/get-stream": "^3.0.2",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/pino": "^7.0.4",
         "@types/sinon": "^10.0.13",
         "@types/yargs": "^17.0.0",
@@ -56,7 +56,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1992,9 +1992,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/gcf-utils/package.json
+++ b/packages/gcf-utils/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/get-stream": "^3.0.2",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/pino": "^7.0.4",
     "@types/sinon": "^10.0.13",
     "@types/yargs": "^17.0.0",
@@ -63,7 +63,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "keywords": [
     "google cloud functions",

--- a/packages/generate-bot/package-lock.json
+++ b/packages/generate-bot/package-lock.json
@@ -23,7 +23,7 @@
         "typescript": "~5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/packages/generate-bot/package.json
+++ b/packages/generate-bot/package.json
@@ -40,7 +40,7 @@
     "typescript": "~5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "qs": "6.15.2",

--- a/packages/generate-bot/templates/package.json.hbs
+++ b/packages/generate-bot/templates/package.json.hbs
@@ -31,7 +31,7 @@
     },
     "devDependencies": {
       "@types/mocha": "^9.1.1",
-      "@types/node": "^18.7.13",
+      "@types/node": "^22.0.0",
       "c8": "^7.12.0",
       "cross-env": "^7.0.3",
       "gts": "^4.0.0",
@@ -42,6 +42,6 @@
       "typescript": "~4.8.1"
     },
     "engines": {
-      "node": ">= 18"
+      "node": ">= 22"
     }
   }

--- a/packages/generated-files-bot/cloudbuild.yaml
+++ b/packages/generated-files-bot/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/generated-files-bot/package-lock.json
+++ b/packages/generated-files-bot/package-lock.json
@@ -20,7 +20,7 @@
         "@types/js-yaml": "^4.0.5",
         "@types/jsonpath": "^0.2.0",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -33,7 +33,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2207,9 +2207,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/generated-files-bot/package.json
+++ b/packages/generated-files-bot/package.json
@@ -39,7 +39,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/jsonpath": "^0.2.0",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -52,7 +52,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/git-file-utils/package-lock.json
+++ b/packages/git-file-utils/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/chai": "^4.3.3",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "c8": "^7.12.0",
         "chai": "^4.3.6",
         "cross-env": "^7.0.3",
@@ -26,7 +26,7 @@
         "typescript": "^4.9.4"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -477,9 +477,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/git-file-utils/package.json
+++ b/packages/git-file-utils/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/chai": "^4.3.3",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "c8": "^7.12.0",
     "chai": "^4.3.6",
     "cross-env": "^7.0.3",
@@ -34,7 +34,7 @@
     "typescript": "^4.9.4"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "keywords": [
     "Git data API"

--- a/packages/header-checker-lint/cloudbuild.yaml
+++ b/packages/header-checker-lint/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/header-checker-lint/package-lock.json
+++ b/packages/header-checker-lint/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -28,7 +28,7 @@
         "typescript": "~5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2174,9 +2174,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/header-checker-lint/package.json
+++ b/packages/header-checker-lint/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -47,7 +47,7 @@
     "typescript": "~5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/issue-utils/package-lock.json
+++ b/packages/issue-utils/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
         "gts": "^4.0.0",
@@ -23,7 +23,7 @@
         "typescript": "~4.9.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2019,9 +2019,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/issue-utils/package.json
+++ b/packages/issue-utils/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
     "gts": "^4.0.0",
@@ -30,7 +30,7 @@
     "typescript": "~4.9.0"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "keywords": [
     "github issues",

--- a/packages/label-sync/cloudbuild.yaml
+++ b/packages/label-sync/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/label-sync/package-lock.json
+++ b/packages/label-sync/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -27,7 +27,7 @@
         "typescript": "~5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2071,9 +2071,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/label-sync/package.json
+++ b/packages/label-sync/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -44,7 +44,7 @@
     "typescript": "~5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/label-utils/package-lock.json
+++ b/packages/label-utils/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -27,7 +27,7 @@
         "typescript": "~4.9.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2127,9 +2127,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/label-utils/package.json
+++ b/packages/label-utils/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -34,7 +34,7 @@
     "typescript": "~4.9.0"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "keywords": [
     "github labels",

--- a/packages/loadtest-bot/Dockerfile
+++ b/packages/loadtest-bot/Dockerfile
@@ -16,7 +16,7 @@
 
 # Use the official lightweight Node.js 14 image.
 # https://hub.docker.com/_/node
-FROM node:20-slim AS BUILD
+FROM node:22-slim AS BUILD
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -34,7 +34,7 @@ COPY . ./
 
 RUN npm run compile
 
-FROM node:20-slim
+FROM node:22-slim
 
 # Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
 RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/

--- a/packages/loadtest-bot/cloudbuild-staging.yaml
+++ b/packages/loadtest-bot/cloudbuild-staging.yaml
@@ -35,7 +35,7 @@ steps:
       - "$_KEY_LOCATION"
       - "$_KEY_RING"
       - "$_FUNCTION_REGION"
-      - "nodejs12"
+      - "nodejs22"
       - "540s"
 
   - name: gcr.io/cloud-builders/docker

--- a/packages/loadtest-bot/package-lock.json
+++ b/packages/loadtest-bot/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
         "gts": "^4.0.0",
@@ -26,7 +26,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2022,9 +2022,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/loadtest-bot/package.json
+++ b/packages/loadtest-bot/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
     "gts": "^4.0.0",
@@ -41,7 +41,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/merge-on-green/cloudbuild.yaml
+++ b/packages/merge-on-green/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/merge-on-green/package-lock.json
+++ b/packages/merge-on-green/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -28,7 +28,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/merge-on-green/package.json
+++ b/packages/merge-on-green/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -46,7 +46,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/mono-repo-publish/package-lock.json
+++ b/packages/mono-repo-publish/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "@types/yargs": "^17.0.12",
         "c8": "^7.12.0",
@@ -32,7 +32,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -630,9 +630,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/mono-repo-publish/package.json
+++ b/packages/mono-repo-publish/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "@types/yargs": "^17.0.12",
     "c8": "^7.12.0",
@@ -41,7 +41,7 @@
     "yargs": "^17.5.1"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "qs": "6.15.2",

--- a/packages/mono-repo-publish/test/sample-private-package/package.json
+++ b/packages/mono-repo-publish/test/sample-private-package/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "private": true,
   "engines": {
-    "node": ">= 18"
+    "node": ">= 22"
   },
   "files": [
     "**/*.js",

--- a/packages/object-selector/package-lock.json
+++ b/packages/object-selector/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "@types/yargs": "^17.0.12",
         "c8": "^7.12.0",
@@ -35,7 +35,7 @@
         "typescript": "~4.9.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -560,9 +560,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/object-selector/package.json
+++ b/packages/object-selector/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "@types/yargs": "^17.0.12",
     "c8": "^7.12.0",
@@ -40,7 +40,7 @@
     "typescript": "~4.9.0"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "keywords": [
     "Github repository"

--- a/packages/owl-bot/Dockerfile.backend
+++ b/packages/owl-bot/Dockerfile.backend
@@ -21,7 +21,7 @@ FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 

--- a/packages/owl-bot/Dockerfile.frontend
+++ b/packages/owl-bot/Dockerfile.frontend
@@ -21,7 +21,7 @@ FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 

--- a/packages/owl-bot/package-lock.json
+++ b/packages/owl-bot/package-lock.json
@@ -40,7 +40,7 @@
         "@types/js-yaml": "^4.0.5",
         "@types/jsonwebtoken": "^9.0.3",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/rimraf": "^3.0.2",
         "@types/sinon": "^10.0.13",
         "@types/tmp": "^0.2.3",
@@ -56,7 +56,7 @@
         "typescript": "~4.9.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       },
       "optionalDependencies": {
         "fsevents": "*"
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4953,15 +4953,6 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.7.0",
         "@google-cloud/storage": "^7.7.0"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "node_modules/flat": {

--- a/packages/owl-bot/package.json
+++ b/packages/owl-bot/package.json
@@ -8,7 +8,7 @@
     "build/src"
   ],
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "scripts": {
     "start-backend": "node ./build/src/server-backend.js",
@@ -48,7 +48,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/jsonwebtoken": "^9.0.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/rimraf": "^3.0.2",
     "@types/sinon": "^10.0.13",
     "@types/tmp": "^0.2.3",

--- a/packages/owlbot-bootstrapper/cli/package-lock.json
+++ b/packages/owlbot-bootstrapper/cli/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@types/jwt-encode": "^1.0.0",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/node-fetch": "^2.6.2",
         "@types/sinon": "^10.0.13",
         "@types/yargs": "^17.0.12",
@@ -35,7 +35,7 @@
         "typescript": "~4.9.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -576,9 +576,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/owlbot-bootstrapper/cli/package.json
+++ b/packages/owlbot-bootstrapper/cli/package.json
@@ -37,7 +37,7 @@
     "@types/yargs": "^17.0.12",
     "@types/jwt-encode": "^1.0.0",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/node-fetch": "^2.6.2",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
@@ -51,7 +51,7 @@
     "typescript": "~4.9.0"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/owlbot-bootstrapper/common-container/Dockerfile
+++ b/packages/owlbot-bootstrapper/common-container/Dockerfile
@@ -16,7 +16,7 @@
 
 # Use the official lightweight Node.js 14 image.
 # https://hub.docker.com/_/node
-FROM node:20-slim AS BUILD
+FROM node:22-slim AS BUILD
 
 # Create and change to the app directory.
 WORKDIR /usr/cli
@@ -34,7 +34,7 @@ COPY . ./
 
 RUN npm run compile
 
-FROM node:20-slim
+FROM node:22-slim
 
 # Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
 RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/

--- a/packages/owlbot-bootstrapper/common-container/package.json
+++ b/packages/owlbot-bootstrapper/common-container/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/jwt-encode": "^1.0.0",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/node-fetch": "^2.6.2",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
@@ -58,7 +58,7 @@
     "typescript": "~4.9.0"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "qs": "6.15.2",

--- a/packages/owlbot-bootstrapper/package-lock.json
+++ b/packages/owlbot-bootstrapper/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     }
   }

--- a/packages/owlbot-bootstrapper/package.json
+++ b/packages/owlbot-bootstrapper/package.json
@@ -23,7 +23,7 @@
     "lint": "cd cli && npm i && npm run lint && cd ../common-container && npm i && npm run lint"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "qs": "6.15.2",

--- a/packages/release-brancher/package-lock.json
+++ b/packages/release-brancher/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.5",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "@types/yargs": "^17.0.12",
         "c8": "^7.12.0",
@@ -34,7 +34,7 @@
         "typescript": "~5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -499,9 +499,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/release-brancher/package.json
+++ b/packages/release-brancher/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "@types/yargs": "^17.0.12",
     "c8": "^7.12.0",
@@ -53,7 +53,7 @@
     }
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "qs": "6.15.2",

--- a/packages/release-please/Dockerfile
+++ b/packages/release-please/Dockerfile
@@ -21,7 +21,7 @@ FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs git && \
     rm -rf /var/lib/apt/lists/*
 

--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -35,7 +35,7 @@
         "typescript": "~5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2252,9 +2252,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -54,7 +54,7 @@
     "typescript": "~5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/repo-metadata-lint/cloudbuild.yaml
+++ b/packages/repo-metadata-lint/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/repo-metadata-lint/package-lock.json
+++ b/packages/repo-metadata-lint/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "@types/yargs": "^17.0.12",
         "c8": "^7.12.0",
@@ -36,7 +36,7 @@
         "typescript": "~4.9.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2135,9 +2135,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/repo-metadata-lint/package.json
+++ b/packages/repo-metadata-lint/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "@types/yargs": "^17.0.12",
     "c8": "^7.12.0",
@@ -52,7 +52,7 @@
     "typescript": "~4.9.0"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/secret-rotator/package-lock.json
+++ b/packages/secret-rotator/package-lock.json
@@ -29,7 +29,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       },
       "optionalDependencies": {
         "fsevents": "*"

--- a/packages/secret-rotator/package.json
+++ b/packages/secret-rotator/package.json
@@ -7,7 +7,7 @@
     "build/src"
   ],
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "scripts": {
     "start": "node ./build/src/index.js",

--- a/packages/snippet-bot/package-lock.json
+++ b/packages/snippet-bot/package-lock.json
@@ -27,7 +27,7 @@
         "@types/follow-redirects": "^1.14.1",
         "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -40,7 +40,7 @@
         "typescript": "~5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       },
       "optionalDependencies": {
         "fsevents": "*"
@@ -2272,9 +2272,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/snippet-bot/package.json
+++ b/packages/snippet-bot/package.json
@@ -47,7 +47,7 @@
     "@types/follow-redirects": "^1.14.1",
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -63,7 +63,7 @@
     "fsevents": "*"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/sync-repo-settings/cloudbuild.yaml
+++ b/packages/sync-repo-settings/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/sync-repo-settings/package-lock.json
+++ b/packages/sync-repo-settings/package-lock.json
@@ -23,7 +23,7 @@
         "@types/extend": "^3.0.1",
         "@types/js-yaml": "^4.0.5",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "@types/yargs": "^17.0.12",
         "c8": "^7.12.0",
@@ -38,7 +38,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2071,9 +2071,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/sync-repo-settings/package.json
+++ b/packages/sync-repo-settings/package.json
@@ -38,7 +38,7 @@
     "@types/extend": "^3.0.1",
     "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "@types/yargs": "^17.0.12",
     "c8": "^7.12.0",
@@ -53,7 +53,7 @@
     "typescript": "^5.7.3"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",

--- a/packages/trusted-contribution/cloudbuild.yaml
+++ b/packages/trusted-contribution/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
       - "--region"
       - "$_REGION"
       - "--runtime"
-      - "nodejs20"
+      - "nodejs22"
 
   - name: gcr.io/cloud-builders/docker
     id: "build-docker"

--- a/packages/trusted-contribution/package-lock.json
+++ b/packages/trusted-contribution/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.13",
         "c8": "^7.12.0",
         "cross-env": "^7.0.3",
@@ -31,7 +31,7 @@
         "typescript": "~4.9.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2150,9 +2150,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/trusted-contribution/package.json
+++ b/packages/trusted-contribution/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.13",
     "c8": "^7.12.0",
     "cross-env": "^7.0.3",
@@ -49,7 +49,7 @@
     "typescript": "~4.9.0"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "overrides": {
     "@tootallnate/once": "^3.0.1",


### PR DESCRIPTION
This commit upgrades the entire repository and its various bots to target Node.js 22, ensuring all environments are aligned on the current Active LTS release.

Changes include:
* Package Engines: Updated `engines.node` to `>= 22` in the root and all package `package.json` files.
* Dependencies: Bumped `@types/node` to `^22.0.0` across all packages and regenerated `package-lock.json` files.
* Cloud Functions: Upgraded deployment runtimes to `nodejs22` in all package `cloudbuild.yaml` files.
* GitHub Actions CI: Aligned the `setup-node` steps in `ci.yaml`, `deps.yaml`, `audit.yaml`, and `audit-bulk.yaml` to run on Node 22 (previously some were testing against 24 or 20).
* Dockerfiles: Updated the NodeSource setup script to `setup_22.x` in the `release-please` Dockerfile.