### PR TITLE
fix: pin node version

### DIFF
--- a/packages/gcf-utils/Dockerfile
+++ b/packages/gcf-utils/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:22
+FROM node:22.22.3
 
 USER root
 

--- a/packages/loadtest-bot/Dockerfile
+++ b/packages/loadtest-bot/Dockerfile
@@ -16,7 +16,7 @@
 
 # Use the official lightweight Node.js 14 image.
 # https://hub.docker.com/_/node
-FROM node:22-slim AS BUILD
+FROM node:22.22.3-slim AS BUILD
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -34,7 +34,7 @@ COPY . ./
 
 RUN npm run compile
 
-FROM node:22-slim
+FROM node:22.22.3-slim
 
 # Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
 RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/

--- a/packages/owl-bot/Dockerfile.backend
+++ b/packages/owl-bot/Dockerfile.backend
@@ -15,21 +15,20 @@
 # Use a multi-stage docker build to limit production dependencies.
 
 # Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
+FROM marketplace.gcr.io/google/debian12:latest AS node_base
 
-# Install Node.js v18 and npm.
+# Install Node.js v22.22.3 and npm.
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y nodejs && \
+    apt-get install -y curl xz-utils && \
+    curl -fsSL https://nodejs.org/dist/v22.22.3/node-v22.22.3-linux-x64.tar.xz | tar -xJf - --strip-components=1 -C /usr/local && \
     rm -rf /var/lib/apt/lists/*
 
 # Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
 RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
 
 # Stage 1: Build
-FROM NODE_BASE AS BUILD
+FROM node_base AS build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -47,7 +46,7 @@ COPY . ./
 RUN npm run compile
 
 # Stage 2: Production
-FROM NODE_BASE
+FROM node_base
 
 # Install git binary and remove unnecessary cache files to keep the
 # image size small.
@@ -60,7 +59,7 @@ WORKDIR /usr/src/app
 
 # Copy only necessary production files from the build stage.
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build/
+COPY --from=build /usr/src/app/build build/
 
 # Install only production dependencies.
 RUN npm ci --only=production

--- a/packages/owl-bot/Dockerfile.frontend
+++ b/packages/owl-bot/Dockerfile.frontend
@@ -15,21 +15,20 @@
 # Use a multi-stage docker build to limit production dependencies.
 
 # Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
+FROM marketplace.gcr.io/google/debian12:latest AS node_base
 
-# Install Node.js v18 and npm.
+# Install Node.js v22.22.3 and npm.
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y nodejs && \
+    apt-get install -y curl xz-utils && \
+    curl -fsSL https://nodejs.org/dist/v22.22.3/node-v22.22.3-linux-x64.tar.xz | tar -xJf - --strip-components=1 -C /usr/local && \
     rm -rf /var/lib/apt/lists/*
 
 # Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
 RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
 
 # Stage 1: Build
-FROM NODE_BASE AS BUILD
+FROM node_base AS build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -47,13 +46,13 @@ COPY . ./
 
 RUN npm run compile
 
-FROM NODE_BASE
+FROM node_base
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
+COPY --from=build /usr/src/app/build build
 RUN npm ci --only=production
 
 ENV NODE_ENV "production"

--- a/packages/owlbot-bootstrapper/common-container/Dockerfile
+++ b/packages/owlbot-bootstrapper/common-container/Dockerfile
@@ -16,7 +16,7 @@
 
 # Use the official lightweight Node.js 14 image.
 # https://hub.docker.com/_/node
-FROM node:22-slim AS BUILD
+FROM node:22.22.3-slim AS BUILD
 
 # Create and change to the app directory.
 WORKDIR /usr/cli
@@ -34,7 +34,7 @@ COPY . ./
 
 RUN npm run compile
 
-FROM node:22-slim
+FROM node:22.22.3-slim
 
 # Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
 RUN rm -r /usr/local/lib/node_modules/npm/node_modules/cross-spawn/

--- a/packages/release-please/Dockerfile
+++ b/packages/release-please/Dockerfile
@@ -15,21 +15,20 @@
 # Use a multi-stage docker build to limit production dependencies.
 
 # Stage 0: Node.js Base Image
-FROM marketplace.gcr.io/google/debian12:latest AS NODE_BASE
+FROM marketplace.gcr.io/google/debian12:latest AS node_base
 
-# Install Node.js v18 and npm.
+# Install Node.js v22.22.3 and npm.
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y nodejs git && \
+    apt-get install -y curl xz-utils git && \
+    curl -fsSL https://nodejs.org/dist/v22.22.3/node-v22.22.3-linux-x64.tar.xz | tar -xJf - --strip-components=1 -C /usr/local && \
     rm -rf /var/lib/apt/lists/*
 
 # Remove unnecessary cross-spawn from npm to resolve CVE-2024-21538
 RUN rm -rf /usr/lib/node_modules/npm/node_modules/cross-spawn/
 
 # Stage 1: Build
-FROM NODE_BASE AS BUILD
+FROM node_base AS build
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
@@ -45,15 +44,16 @@ RUN npm ci
 # Now copy all the code so we can compile
 COPY . ./
 
+# compile .ts files into build/
 RUN npm run compile
 
-FROM NODE_BASE
+FROM node_base
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-COPY --from=BUILD /usr/src/app/build build
+COPY --from=build /usr/src/app/build build
 RUN npm ci --only=production
 RUN git config --global user.email "release-please[bot]@users.noreply.github.com"
 RUN git config --global user.name "release-please[bot]"


### PR DESCRIPTION
The latest release of node breaks some of our bots. This change should be reverted once the fix for https://github.com/nodejs/node/issues/63989 has been released.

Internal bug: b/525453379