### PR TITLE
fix(release-please): skip redundant top-level config when branch is in branch list

### DIFF
--- a/packages/release-please/src/release-please.ts
+++ b/packages/release-please/src/release-please.ts
@@ -108,8 +108,13 @@ function findBranchConfiguration(
 ): BranchConfiguration[] {
   const configurations: BranchConfiguration[] = [];
 
+  const hasDuplicateInBranches = config.branches?.some(
+    branchConfig =>
+      branchConfig.branch === branch && branchConfig.path === config.path
+  );
+
   // look at primaryBranch first
-  if (branch === config.primaryBranch) {
+  if (branch === config.primaryBranch && !hasDuplicateInBranches) {
     configurations.push({
       ...config,
       ...{branch},

--- a/packages/release-please/test/fixtures/config/manifest_multiple_same_branch.yml
+++ b/packages/release-please/test/fixtures/config/manifest_multiple_same_branch.yml
@@ -1,0 +1,17 @@
+handleGHRelease: true
+manifest: true
+tagPullRequestNumber: true
+
+branches:
+  - branch: main
+    handleGHRelease: true
+    tagPullRequestNumber: true
+    manifest: true
+    manifestFile: .release-please-bulk-manifest.json
+    manifestConfig: release-please-bulk-config.json
+  - branch: main
+    handleGHRelease: true
+    tagPullRequestNumber: true
+    manifest: true
+    manifestFile: .release-please-individual-manifest.json
+    manifestConfig: release-please-individual-config.json

--- a/packages/release-please/test/release-please.ts
+++ b/packages/release-please/test/release-please.ts
@@ -743,6 +743,33 @@ describe('ReleasePleaseBot', () => {
         );
       });
 
+      it('should not run the top-level config if the branch is explicitly configured in branches', async () => {
+        const mainPayload = require(resolve(fixturesPath, './push_to_main'));
+        getConfigStub.resolves(loadConfig('manifest_multiple_same_branch.yml'));
+        await probot.receive(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          {name: 'push', payload: mainPayload as any, id: 'abc123'}
+        );
+
+        sinon.assert.calledTwice(fromManifestStub);
+        sinon.assert.calledWith(
+          fromManifestStub.firstCall,
+          sinon.match.any,
+          'main',
+          'release-please-bulk-config.json',
+          '.release-please-bulk-manifest.json',
+          sinon.match.any
+        );
+        sinon.assert.calledWith(
+          fromManifestStub.secondCall,
+          sinon.match.any,
+          'main',
+          'release-please-individual-config.json',
+          '.release-please-individual-manifest.json',
+          sinon.match.any
+        );
+      });
+
       it('should tag pull request number if configured', async () => {
         getConfigStub.resolves(loadConfig('manifest_tag_pr_number.yml'));
         // We want the PR number 789 to be in the tag


### PR DESCRIPTION
Only run the top-level configuration for the primary branch if it is not already explicitly configured with the same path in the branches list. This prevents the bot from attempting to run a duplicate default configuration (expecting default manifest files) when custom manifest filenames have been configured for the branch.

Fixes #6256