### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/workflows/audit-bulk.yaml
+++ b/.github/workflows/audit-bulk.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:
@@ -8,9 +11,10 @@ jobs:
   updatePackages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 name: npm-audit
@@ -7,9 +10,10 @@ jobs:
     outputs:
       nodePaths: ${{ steps.interrogate.outputs.nodePaths }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
@@ -24,13 +28,19 @@ jobs:
       matrix:
         package: ${{fromJson(needs.findPackages.outputs.nodePaths)}}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-      - run: echo ./packages/${{ matrix.package }}
-      - run: cd ./packages/${{ matrix.package }} && npm audit fix
+      - run: echo ./packages/${MATRIX_PACKAGE}
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
+      - run: cd ./packages/${MATRIX_PACKAGE} && npm audit fix
         continue-on-error: true
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
       - uses: googleapis/code-suggester@589b3ac11ac2575fd561afa45034907f301a375b # v4
         env:
           ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,9 +17,10 @@ jobs:
       bashPaths: ${{ steps.interrogate.outputs.bashPaths }}
       requiredJobs: ${{ steps.interrogate.outputs.requiredJobs }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
@@ -32,12 +36,18 @@ jobs:
       matrix:
         package: ${{fromJson(needs.changeFinder.outputs.nodePaths)}}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-      - run: echo ./packages/${{ matrix.package }}
-      - run: cd ./packages/${{ matrix.package }}
+      - run: echo ./packages/${MATRIX_PACKAGE}
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
+      - run: cd ./packages/${MATRIX_PACKAGE}
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
       - run: npm ci
         working-directory: ./packages/${{ matrix.package }}
       - run: pwd
@@ -54,13 +64,15 @@ jobs:
         module: ${{fromJson(needs.changeFinder.outputs.goPaths)}}
     steps:
     - name: Install Go
-      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version: '^1.16'
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports@latest
     - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: goimports
       run: |
         test -z "$($(go env GOPATH)/bin/goimports -l .)"
@@ -79,7 +91,9 @@ jobs:
         module: ${{fromJson(needs.changeFinder.outputs.bashPaths)}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: bashtest
         run: |
           ./test.sh
@@ -88,7 +102,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: changeFinder
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,4 +109,8 @@ jobs:
         with:
           node-version: 22
       - run: npm ci
-      - run: node ./.github/workflows/finale.js '${{needs.changeFinder.outputs.requiredJobs}}' ${{secrets.GITHUB_TOKEN}}
+      - env:
+          REQUIRED_JOBS: ${{ needs.changeFinder.outputs.requiredJobs }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node ./.github/workflows/finale.js "$REQUIRED_JOBS" "$GITHUB_TOKEN"
+

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:
@@ -10,9 +13,10 @@ jobs:
     outputs:
       nodePaths: ${{ steps.interrogate.outputs.nodePaths }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
@@ -27,13 +31,19 @@ jobs:
       matrix:
         package: ${{fromJson(needs.findPackages.outputs.nodePaths)}}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
       - run: npm i -g npm-check-updates
-      - run: echo ./packages/${{ matrix.package }}
-      - run: ./scripts/update-dependencies.sh packages/${{ matrix.package }}
+      - run: echo ./packages/${MATRIX_PACKAGE}
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
+      - run: ./scripts/update-dependencies.sh packages/${MATRIX_PACKAGE}
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
       - uses: googleapis/code-suggester@589b3ac11ac2575fd561afa45034907f301a375b # v4
         env:
           ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}

--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -14,11 +14,13 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # v1.10.0
+        uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede # v2.0.2
         with:
           args: --exclude '(http://devrel/.*|https://github.com/googleapis/googleapis-gen|https://www.npmjs.com/|https://smee.io/new)' --max-concurrency 3 --exclude-mail --exclude-all-private './**/README.md'
         env:

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,7 @@
 {
   "enabled": false,
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     // update base images in Dockerfiles
     ":docker",
     // prevent upgrading to packages that can be unpublished 


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run. 

Additionally, it updates renovate configuration (if present) to extend [best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices), which includes pinning action digests and image digests, among other things.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
