### PR TITLE
chore: configure Dependabot for grouped security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/packages/**"
+    # Dependabot requires a schedule.interval to be defined, but we set the limit
+    # to 0 to disable scheduled version updates. This allows us to configure
+    # security updates (which bypass the limit) without getting weekly version PRs.
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Creates `.github/dependabot.yml` to manage dependency updates in the monorepo.

- Disables scheduled version updates by setting `open-pull-requests-limit: 0`.
- Configures Dependabot to group all npm security updates across the root and `/packages/**` directories into a single pull request to reduce PR noise.

Once merged I will enable the repo setting:
<img width="945" height="109" alt="Screenshot 2026-07-15 at 4 23 09 PM" src="https://github.com/user-attachments/assets/a01afddc-256b-485c-8f89-101a5ab8cbc1" />
