### PR TITLE
fix: skip compute nodejs assembly pkg

### DIFF
--- a/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
+++ b/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
@@ -92,7 +92,8 @@ for (( idx=${#ungenerated_shas[@]}-1 ; idx>=0 ; idx-- )) ; do
 
         targets=$(cd "$GOOGLEAPIS" \
         && bazelisk query $BAZEL_FLAGS "$query" \
-        | grep -v -E ":(proto|grpc|gapic)-.*-java$")
+        | grep -v -E ":(proto|grpc|gapic)-.*-java$" \
+        | grep -v -E "^//google/cloud/compute/.*-nodejs$")
     else
         targets="$BUILD_TARGETS"
     fi


### PR DESCRIPTION
Ignores all compute `nodejs_gapic_assembly_pkg` targets (name suffixed with `-nodejs`). We generate compute nodejs with librarian now, and we are hitting GitHub file size limits when bazel-bot attempts to upload the changes for this client to GitHub.

Internal bug http://b/535317787