### PR TITLE
fix(bazel-bot): skip compute node top level target

### DIFF
--- a/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
+++ b/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
@@ -93,7 +93,7 @@ for (( idx=${#ungenerated_shas[@]}-1 ; idx>=0 ; idx-- )) ; do
         targets=$(cd "$GOOGLEAPIS" \
         && bazelisk query $BAZEL_FLAGS "$query" \
         | grep -v -E ":(proto|grpc|gapic)-.*-java$" \
-        | grep -v -E "^//google/cloud/compute/.*-nodejs$")
+        | grep -v -E "^//google/cloud/compute[:/].*-nodejs$")
     else
         targets="$BUILD_TARGETS"
     fi


### PR DESCRIPTION
Follow up to https://github.com/googleapis/repo-automation-bots/pull/6314 to also exclude the top-level wrapper nodejs target

Internal bug http://b/535317787