### PR TITLE
fix(gcf-utils): safely handle undefined request body

### DIFF
--- a/packages/gcf-utils/src/gcf-utils.ts
+++ b/packages/gcf-utils/src/gcf-utils.ts
@@ -466,7 +466,7 @@ export class GCFBootstrapper {
         !(await this.probot.webhooks.verify(
           request.rawBody
             ? request.rawBody.toString()
-            : request.body.toString(),
+            : request.body?.toString() ?? '',
           botRequest.signature
         ))
       ) {
@@ -481,7 +481,10 @@ export class GCFBootstrapper {
        * Note: any logs written before resetting bindings may contain
        * bindings from previous executions
        */
-      const loggerBindings = this.buildLoggerBindings(botRequest, request.body);
+      const loggerBindings = this.buildLoggerBindings(
+        botRequest,
+        request.body || {}
+      );
       logger.resetBindings();
       logger.addBindings(loggerBindings);
       let requestLogger = buildRequestLogger(logger, loggerBindings);
@@ -510,7 +513,9 @@ export class GCFBootstrapper {
         } else if (botRequest.triggerType === TriggerType.TASK) {
           // If the payload contains `tmpUrl` this indicates that the original
           // payload has been written to Cloud Storage; download it.
-          const payload = await this.maybeDownloadOriginalBody(request.body);
+          const payload = await this.maybeDownloadOriginalBody(
+            request.body || {}
+          );
 
           // Regenerate the logger bindings based on the downloaded payload
           const loggerBindings = this.buildLoggerBindings(
@@ -614,7 +619,7 @@ export class GCFBootstrapper {
             }
           }
         } else if (botRequest.triggerType === TriggerType.GITHUB) {
-          const installationId = parseInstallationId(request.body);
+          const installationId = parseInstallationId(request.body || {});
           if (
             !(await this.installationHandler.isOrganizationAllowed(
               installationId

--- a/packages/gcf-utils/test/server.ts
+++ b/packages/gcf-utils/test/server.ts
@@ -294,6 +294,15 @@ describe('GCFBootstrapper', () => {
         sinon.assert.notCalled(enqueueTask);
         sinon.assert.notCalled(issueSpy);
       });
+
+      it('should gracefully handle requests with undefined body', async () => {
+        const response = await gaxios.request({
+          url: `http://localhost:${TEST_SERVER_PORT}/`,
+          method: 'GET',
+          validateStatus: () => true,
+        });
+        assert.deepStrictEqual(response.status, 400);
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes b/538588943

Fixes a `TypeError` when incoming HTTP requests without a JSON body or matching `Content-Type: application/json` reach bot services.

### Cause & Context
In production (e.g., `owl-bot`, `label-sync`), logs showed that HTTP `GET /` and `GET /favicon.ico` requests hit Cloud Run services. These requests can originate from HTTP probers, health checks, web browsers (such as operators verifying post-deployment URLs), or link unfurling services.

Because Express routes all HTTP methods (`app.all('*')`) to the handler, and `bodyParser.json()` skips non-JSON/body-less requests, `request.rawBody` and `request.body` remain `undefined`. `gcf-utils` attempted to call `request.body.toString()` during webhook signature verification, throwing:
`TypeError: Cannot read properties of undefined (reading 'toString')`

### Fix
Uses optional chaining and default fallback objects (`request.body?.toString() ?? ''` and `request.body || {}`) to gracefully handle requests with undefined bodies.