### PR TITLE
deps: release-please 17.11.0

### DIFF
--- a/packages/release-please/package-lock.json
+++ b/packages/release-please/package-lock.json
@@ -16,7 +16,7 @@
         "@octokit/plugin-retry": "^6.1.0",
         "@octokit/rest": "^20.1.1",
         "gcf-utils": "^17.2.0",
-        "release-please": "^17.10.4"
+        "release-please": "^17.11.0"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -9134,9 +9134,9 @@
       }
     },
     "node_modules/release-please": {
-      "version": "17.10.4",
-      "resolved": "https://registry.npmjs.org/release-please/-/release-please-17.10.4.tgz",
-      "integrity": "sha512-icymDP75QwigPbfGQ+g487tVkXrAX+TAvbtRD+wtARV6fvePVpNse3DJbRbVAe7Yv8hO3xOucbVJK+t9Wj7oSA==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/release-please/-/release-please-17.11.0.tgz",
+      "integrity": "sha512-Zsizqhek35oGMxNs03AW5fAScZ7zd6X8Ya3HiB45P9iQG8aTAVNa441xh6L8mVqMBvWL3/Ik0LEor6oC7XLIpw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",

--- a/packages/release-please/package.json
+++ b/packages/release-please/package.json
@@ -35,7 +35,7 @@
     "@octokit/plugin-retry": "^6.1.0",
     "@octokit/rest": "^20.1.1",
     "gcf-utils": "^17.2.0",
-    "release-please": "^17.10.4"
+    "release-please": "^17.11.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
With this version, Release Please provides the "ruby-librarian" strategy that allows us to release Librarian-generated libraries in the google-cloud-ruby monorepo.

Once this is deployed, we will switch its release-please.config to switch to "ruby-librarian" from "ruby-yoshi".
