### PR TITLE
chore: update fast-uri to 3.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "uuid": "^11.1.1",
     "js-yaml": "^4.3.1",
     "brace-expansion": "^5.0.9",
-    "fast-uri": "^3.1.4"
+    "fast-uri": "^3.1.5"
   }
 }


### PR DESCRIPTION
Fixes #https://github.com/googleapis/repo-automation-bots/security/dependabot/4904
