### PR TITLE
fix(bazel-bot): update builder base image to bookworm

### DIFF
--- a/packages/bazel-bot/docker-image/Dockerfile
+++ b/packages/bazel-bot/docker-image/Dockerfile
@@ -17,7 +17,7 @@
 
 ##########################################################
 # Build the command-line tool that lets us sign JWTs.
-FROM rust:1.79-buster
+FROM rust:1-bookworm
 RUN git clone https://github.com/mike-engel/jwt-cli.git
 WORKDIR /jwt-cli
 RUN git checkout 652b5c4b2a9d9a236aa3826a8dd34204ca7e1dad


### PR DESCRIPTION
Update Stage 0 builder base image from EOL `rust:1.79-buster` to `rust:1-bookworm` to resolve container image scan vulnerabilities.

For b/547577220