### PR TITLE
feat(git-file-utils): fallback to non-recursive tree traversal on HTTP 422 and ignore submodules

### DIFF
--- a/packages/git-file-utils/src/git-file-utils.ts
+++ b/packages/git-file-utils/src/git-file-utils.ts
@@ -325,7 +325,7 @@ export class BranchFileCache {
     const treeEntries = await this.getFullTree();
     if (treeEntries) {
       const found = treeEntries.find(entry => entry.path === path);
-      if (found?.sha) {
+      if (found?.sha && !isGitSubmodule(found)) {
         return await this.fetchContents(found.sha, found);
       }
       throw new FileNotFoundError(path);
@@ -338,7 +338,7 @@ export class BranchFileCache {
     for (const part of parts) {
       const {tree} = await this.getTree(treeSha);
       found = tree.find(item => item.path === part);
-      if (!found?.sha) {
+      if (!found?.sha || isGitSubmodule(found)) {
         throw new FileNotFoundError(path);
       }
       treeSha = found.sha;
@@ -381,8 +381,19 @@ export class BranchFileCache {
     }
 
     // try the fetch the entire tree first
-    const fetched = await this.fetchTree(sha, true);
-    if (fetched.truncated) {
+    let fetched: TreeResponse | undefined;
+    try {
+      fetched = await this.fetchTree(sha, true);
+    } catch (e) {
+      if (e instanceof RequestError && e.status === 422) {
+        // HTTP 422 occurs when submodules are present in the repo
+        // Fall back to non-recursive tree fetching
+      } else {
+        throw e;
+      }
+    }
+
+    if (!fetched || fetched.truncated) {
       // we are unable to fetch the entire tree, so fetch only contents of
       // this single directory
       const singleDirectory = await this.fetchTree(sha, false);
@@ -479,6 +490,11 @@ export class BranchFileCache {
           continue;
         }
 
+        // Git Submodules (mode === '160000' or type === 'commit'): Explicitly ignore and skip
+        if (isGitSubmodule(treeEntry)) {
+          continue;
+        }
+
         // If the result for this SHA was incomplete, dig deeper on the subtrees
         if (!cachedTree.recursive && treeEntry.type === 'tree') {
           treeShas.push({ref: treeEntry.sha!, path});
@@ -516,6 +532,10 @@ export class BranchFileCache {
       parsedContent: Buffer.from(content, 'base64').toString('utf8'),
     };
   }
+}
+
+function isGitSubmodule(treeEntry?: TreeEntry): boolean {
+  return treeEntry?.mode === '160000' || treeEntry?.type === 'commit';
 }
 
 function stripPrefix(files: string[], prefix?: string): string[] {

--- a/packages/git-file-utils/test/find-files.ts
+++ b/packages/git-file-utils/test/find-files.ts
@@ -18,6 +18,7 @@ import {describe, it} from 'mocha';
 import {Octokit} from '@octokit/rest';
 import {resolve} from 'path';
 import {BranchFileCache} from '../src/git-file-utils';
+import * as assert from 'assert';
 const fetch = require('node-fetch');
 
 nock.disableNetConnect();
@@ -322,6 +323,103 @@ describe('BranchFileCache', () => {
         req.done();
       });
     });
+
+    describe('with repository containing submodules (HTTP 422 fallback)', () => {
+      it('finds multiple files and ignores submodules', async () => {
+        const req = nock('https://api.github.com')
+          .get(
+            '/repos/testOwner/testRepo/git/trees/feature-branch?recursive=true'
+          )
+          .reply(422, {
+            message:
+              'Invalid object requested. SHA must identify a commit or a tree.',
+          })
+          .get('/repos/testOwner/testRepo/git/trees/feature-branch')
+          .reply(200, {
+            sha: 'feature-branch',
+            tree: [
+              {
+                path: 'pkg',
+                mode: '040000',
+                type: 'tree',
+                sha: 'cc64165cf5da91810ab7edc1143a47be42513c0a',
+              },
+              {
+                path: 'submodule-repo',
+                mode: '160000',
+                type: 'commit',
+                sha: 'submodule-commit-sha',
+              },
+              {
+                path: 'foo.json',
+                mode: '160000',
+                type: 'commit',
+                sha: 'submodule-commit-sha-2',
+              },
+              {
+                path: 'package.json',
+                mode: '100644',
+                type: 'blob',
+                sha: '33f90c139fca3d99a08a934fb87d30c13c68b885',
+              },
+            ],
+            truncated: false,
+          })
+          .get(
+            '/repos/testOwner/testRepo/git/trees/cc64165cf5da91810ab7edc1143a47be42513c0a?recursive=true'
+          )
+          .reply(
+            200,
+            require(resolve(
+              fixturesPath,
+              'github-data-api/data-api-trees-successful-response-subdir-pkg-recursive'
+            ))
+          );
+        const files = await cache.findFilesByFilename('foo.json');
+        expect(files).lengthOf(2);
+        expect(files).to.eql(['pkg/a/foo.json', 'pkg/b/foo.json']);
+        req.done();
+      });
+
+      it('does not return submodule even if filename matches', async () => {
+        const req = nock('https://api.github.com')
+          .get(
+            '/repos/testOwner/testRepo/git/trees/feature-branch?recursive=true'
+          )
+          .reply(422, {
+            message:
+              'Invalid object requested. SHA must identify a commit or a tree.',
+          })
+          .get('/repos/testOwner/testRepo/git/trees/feature-branch')
+          .reply(200, {
+            sha: 'feature-branch',
+            tree: [
+              {
+                path: 'submodule-repo',
+                mode: '160000',
+                type: 'commit',
+                sha: 'submodule-commit-sha',
+              },
+            ],
+            truncated: false,
+          });
+        const files = await cache.findFilesByFilename('submodule-repo');
+        expect(files).lengthOf(0);
+        req.done();
+      });
+
+      it('throws RequestError on HTTP 404', async () => {
+        const req = nock('https://api.github.com')
+          .get(
+            '/repos/testOwner/testRepo/git/trees/feature-branch?recursive=true'
+          )
+          .reply(404);
+        await assert.rejects(async () => {
+          await cache.findFilesByFilename('foo.json');
+        });
+        req.done();
+      });
+    });
   });
 
   describe('findFilesByExtension', () => {
@@ -620,6 +718,62 @@ describe('BranchFileCache', () => {
         req.done();
       });
     });
+
+    describe('with repository containing submodules (HTTP 422 fallback)', () => {
+      it('finds multiple files and ignores submodules', async () => {
+        const req = nock('https://api.github.com')
+          .get(
+            '/repos/testOwner/testRepo/git/trees/feature-branch?recursive=true'
+          )
+          .reply(422, {
+            message:
+              'Invalid object requested. SHA must identify a commit or a tree.',
+          })
+          .get('/repos/testOwner/testRepo/git/trees/feature-branch')
+          .reply(200, {
+            sha: 'feature-branch',
+            tree: [
+              {
+                path: 'pkg',
+                mode: '040000',
+                type: 'tree',
+                sha: 'cc64165cf5da91810ab7edc1143a47be42513c0a',
+              },
+              {
+                path: 'submodule.json',
+                mode: '160000',
+                type: 'commit',
+                sha: 'submodule-commit-sha',
+              },
+              {
+                path: 'package.json',
+                mode: '100644',
+                type: 'blob',
+                sha: '33f90c139fca3d99a08a934fb87d30c13c68b885',
+              },
+            ],
+            truncated: false,
+          })
+          .get(
+            '/repos/testOwner/testRepo/git/trees/cc64165cf5da91810ab7edc1143a47be42513c0a?recursive=true'
+          )
+          .reply(
+            200,
+            require(resolve(
+              fixturesPath,
+              'github-data-api/data-api-trees-successful-response-subdir-pkg-recursive'
+            ))
+          );
+        const files = await cache.findFilesByExtension('json');
+        expect(files).lengthOf(3);
+        expect(files).to.eql([
+          'package.json',
+          'pkg/a/foo.json',
+          'pkg/b/foo.json',
+        ]);
+        req.done();
+      });
+    });
   });
 
   describe('findFilesByGlob', () => {
@@ -915,6 +1069,62 @@ describe('BranchFileCache', () => {
         const files = await cache.findFilesByGlob('**/*.json', 'pkg/b');
         expect(files).lengthOf(1);
         expect(files).to.eql(['foo.json']);
+        req.done();
+      });
+    });
+
+    describe('with repository containing submodules (HTTP 422 fallback)', () => {
+      it('finds multiple files and ignores submodules', async () => {
+        const req = nock('https://api.github.com')
+          .get(
+            '/repos/testOwner/testRepo/git/trees/feature-branch?recursive=true'
+          )
+          .reply(422, {
+            message:
+              'Invalid object requested. SHA must identify a commit or a tree.',
+          })
+          .get('/repos/testOwner/testRepo/git/trees/feature-branch')
+          .reply(200, {
+            sha: 'feature-branch',
+            tree: [
+              {
+                path: 'pkg',
+                mode: '040000',
+                type: 'tree',
+                sha: 'cc64165cf5da91810ab7edc1143a47be42513c0a',
+              },
+              {
+                path: 'submodule.json',
+                mode: '160000',
+                type: 'commit',
+                sha: 'submodule-commit-sha',
+              },
+              {
+                path: 'package.json',
+                mode: '100644',
+                type: 'blob',
+                sha: '33f90c139fca3d99a08a934fb87d30c13c68b885',
+              },
+            ],
+            truncated: false,
+          })
+          .get(
+            '/repos/testOwner/testRepo/git/trees/cc64165cf5da91810ab7edc1143a47be42513c0a?recursive=true'
+          )
+          .reply(
+            200,
+            require(resolve(
+              fixturesPath,
+              'github-data-api/data-api-trees-successful-response-subdir-pkg-recursive'
+            ))
+          );
+        const files = await cache.findFilesByGlob('**/*.json');
+        expect(files).lengthOf(3);
+        expect(files).to.eql([
+          'package.json',
+          'pkg/a/foo.json',
+          'pkg/b/foo.json',
+        ]);
         req.done();
       });
     });

--- a/packages/git-file-utils/test/git-file-utils.ts
+++ b/packages/git-file-utils/test/git-file-utils.ts
@@ -341,6 +341,161 @@ describe('BranchFileCache', () => {
       req.done();
     });
   });
+
+  describe('with submodules (HTTP 422 fallback)', () => {
+    it('fetches a file when recursive tree fails with 422', async () => {
+      const req = nock('https://api.github.com')
+        .get(
+          '/repos/testOwner/testRepo/git/trees/feature-branch?recursive=true'
+        )
+        .reply(422, {
+          message:
+            'Invalid object requested. SHA must identify a commit or a tree.',
+        })
+        .get('/repos/testOwner/testRepo/git/trees/feature-branch')
+        .reply(200, {
+          sha: 'feature-branch',
+          tree: [
+            {
+              path: 'pkg',
+              mode: '040000',
+              type: 'tree',
+              sha: 'cc64165cf5da91810ab7edc1143a47be42513c0a',
+            },
+            {
+              path: 'submodule',
+              mode: '160000',
+              type: 'commit',
+              sha: 'submodule-commit-sha',
+            },
+            {
+              path: 'package.json',
+              mode: '100644',
+              type: 'blob',
+              sha: '33f90c139fca3d99a08a934fb87d30c13c68b885',
+            },
+          ],
+          truncated: false,
+        })
+        .get(
+          '/repos/testOwner/testRepo/git/trees/cc64165cf5da91810ab7edc1143a47be42513c0a?recursive=true'
+        )
+        .reply(
+          200,
+          require(resolve(
+            fixturesPath,
+            'github-data-api/data-api-trees-successful-response-subdir-pkg'
+          ))
+        )
+        .get(
+          '/repos/testOwner/testRepo/git/trees/1143a47be42513c0acc64165cf5da91810ab7edc?recursive=true'
+        )
+        .reply(
+          200,
+          require(resolve(
+            fixturesPath,
+            'github-data-api/data-api-trees-successful-response-subdir-pkg-a'
+          ))
+        )
+        .get(
+          '/repos/testOwner/testRepo/git/blobs/2f3d2c47bf49f81aca0df9ffc49524a213a2dc33'
+        )
+        .reply(
+          200,
+          require(resolve(
+            fixturesPath,
+            'github-data-api/data-api-blobs-successful-response'
+          ))
+        );
+
+      const contents = await cache.getFileContents('pkg/a/foo.json');
+      expect(contents.mode).to.eql('100644');
+      expect(contents.sha).to.eql('2f3d2c47bf49f81aca0df9ffc49524a213a2dc33');
+      req.done();
+    });
+
+    it('throws FileNotFoundError when fetching submodule directly', async () => {
+      const req = nock('https://api.github.com')
+        .get(
+          '/repos/testOwner/testRepo/git/trees/feature-branch?recursive=true'
+        )
+        .reply(422, {
+          message:
+            'Invalid object requested. SHA must identify a commit or a tree.',
+        })
+        .get('/repos/testOwner/testRepo/git/trees/feature-branch')
+        .reply(200, {
+          sha: 'feature-branch',
+          tree: [
+            {
+              path: 'submodule',
+              mode: '160000',
+              type: 'commit',
+              sha: 'submodule-commit-sha',
+            },
+          ],
+          truncated: false,
+        });
+
+      await assert.rejects(async () => {
+        await cache.getFileContents('submodule');
+      }, FileNotFoundError);
+      req.done();
+    });
+
+    it('throws FileNotFoundError when fetching a path under a submodule', async () => {
+      const req = nock('https://api.github.com')
+        .get(
+          '/repos/testOwner/testRepo/git/trees/feature-branch?recursive=true'
+        )
+        .reply(422, {
+          message:
+            'Invalid object requested. SHA must identify a commit or a tree.',
+        })
+        .get('/repos/testOwner/testRepo/git/trees/feature-branch')
+        .reply(200, {
+          sha: 'feature-branch',
+          tree: [
+            {
+              path: 'submodule',
+              mode: '160000',
+              type: 'commit',
+              sha: 'submodule-commit-sha',
+            },
+          ],
+          truncated: false,
+        });
+
+      await assert.rejects(async () => {
+        await cache.getFileContents('submodule/some-file.json');
+      }, FileNotFoundError);
+      req.done();
+    });
+
+    it('throws FileNotFoundError when fetching submodule entry in recursive tree', async () => {
+      const req = nock('https://api.github.com')
+        .get(
+          '/repos/testOwner/testRepo/git/trees/feature-branch?recursive=true'
+        )
+        .reply(200, {
+          sha: 'feature-branch',
+          tree: [
+            {
+              path: 'submodule',
+              mode: '160000',
+              type: 'commit',
+              sha: 'submodule-commit-sha',
+            },
+          ],
+          truncated: false,
+        });
+
+      await assert.rejects(async () => {
+        await cache.getFileContents('submodule');
+      }, FileNotFoundError);
+      req.done();
+    });
+  });
 });
 
 describe('RepositoryFileCache', () => {


### PR DESCRIPTION
### Problem

When traversing Git trees in repositories containing Git submodules (gitlink entries with `mode 160000` / `type commit`), GitHub's Git Trees API rejects recursive queries (`?recursive=true`) with **HTTP 422 Unprocessable Entity** because submodule commit objects reside in external repositories.

### Solution

1. **HTTP 422 Fallback**: In `BranchFileCache.getTree(sha)`, catch HTTP 422 from recursive tree queries and fall back to non-recursive tree traversal (`fetchTree(sha, false)`).
2. **Skip Submodules in Tree Traversal**: In `BranchFileCache.treeEntryIterator()`, ignore entries with `mode === '160000'` or `type === 'commit'` so they are not yielded or enqueued for child tree traversal.
3. **Guard Direct File Reads**: In `BranchFileCache.fetchFileContents()`, throw `FileNotFoundError` if a path points to a submodule entry.

I verified locally that this should fix the issue we saw last Friday by running release please unpatched and also by locally patching in these changes, to make sure we no longer fail with 422s when dealing with git submodules. 