### PR TITLE
refactor(snippet-bot): remove in-code allowlist

### DIFF
--- a/packages/snippet-bot/src/snippet-bot.ts
+++ b/packages/snippet-bot/src/snippet-bot.ts
@@ -85,15 +85,6 @@ const REFRESH_STRING = '- [x] Refresh this comment';
 // Github issue comment API has a limit of 65536 characters.
 const MAX_CHARS_IN_COMMENT = 64000;
 
-const ALLOWED_ORGANIZATIONS = [
-  'android',
-  'googleapis',
-  'GoogleCloudPlatform',
-  'googlemaps',
-  'googlemaps-samples',
-  'terraform-google-modules',
-];
-
 async function getFiles(dir: string, allFiles: string[]) {
   const files = (await pfs.readdir(dir)).map(f => path.join(dir, f));
   for (const f of files) {
@@ -708,10 +699,6 @@ export = (app: Probot) => {
       logger.info(`snippet-bot is not configured for ${owner}/${repo}.`);
       return;
     }
-    if (!ALLOWED_ORGANIZATIONS.includes(owner)) {
-      logger.info(`snippet-bot not allowed for owner: ${owner}`);
-      return;
-    }
     await syncLabels(octokit, owner, repo, SNIPPET_BOT_LABELS);
   });
 
@@ -784,10 +771,6 @@ export = (app: Probot) => {
       logger.info(`snippet-bot is not configured for ${repoUrl}.`);
       return;
     }
-    if (!ALLOWED_ORGANIZATIONS.includes(owner)) {
-      logger.info(`snippet-bot not allowed for owner: ${owner}`);
-      return;
-    }
     const configuration = new Configuration({
       ...DEFAULT_CONFIGURATION,
       ...configOptions,
@@ -837,10 +820,6 @@ export = (app: Probot) => {
       logger.info(`snippet-bot is not configured for ${repoUrl}.`);
       return;
     }
-    if (!ALLOWED_ORGANIZATIONS.includes(owner)) {
-      logger.info(`snippet-bot not allowed for owner: ${owner}`);
-      return;
-    }
     const configuration = new Configuration({
       ...DEFAULT_CONFIGURATION,
       ...configOptions,
@@ -872,10 +851,6 @@ export = (app: Probot) => {
 
     if (configOptions === null) {
       logger.info(`snippet-bot is not configured for ${repoUrl}.`);
-      return;
-    }
-    if (!ALLOWED_ORGANIZATIONS.includes(owner)) {
-      logger.info(`snippet-bot not allowed for owner: ${owner}`);
       return;
     }
     const configuration = new Configuration({
@@ -990,10 +965,6 @@ export = (app: Probot) => {
       );
       if (configOptions === null) {
         logger.info(`snippet-bot is not configured for ${repoUrl}.`);
-        return;
-      }
-      if (!ALLOWED_ORGANIZATIONS.includes(owner)) {
-        logger.info(`snippet-bot not allowed for owner: ${owner}`);
         return;
       }
       const configuration = new Configuration({

--- a/packages/snippet-bot/test/snippet-bot.ts
+++ b/packages/snippet-bot/test/snippet-bot.ts
@@ -118,39 +118,6 @@ describe('snippet-bot scheduler handler', () => {
     );
     sinon.assert.notCalled(syncLabelsStub);
   });
-  it('does not call syncLabels for repos not allowlisted', async () => {
-    getConfigStub.resolves({
-      alwaysCreateStatusCheck: false,
-      ignoreFiles: [],
-    });
-    await probot.receive({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      name: 'schedule.repository' as any,
-      payload: {
-        repository: {
-          name: 'testRepo',
-          owner: {
-            login: 'testOwner',
-          },
-        },
-        organization: {
-          login: 'nonAllowlistedOwner',
-        },
-        installation: {id: 1234},
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any,
-      id: 'abc123',
-    });
-    sinon.assert.calledOnceWithExactly(
-      getConfigStub,
-      sinon.match.instanceOf(Octokit),
-      'nonAllowlistedOwner',
-      'testRepo',
-      CONFIGURATION_FILE_PATH,
-      {schema: schema}
-    );
-    sinon.assert.notCalled(syncLabelsStub);
-  });
   it('calls syncLabels for repos with the config', async () => {
     getConfigStub.resolves({
       alwaysCreateStatusCheck: false,
@@ -1236,31 +1203,6 @@ describe('snippet-bot', () => {
         validateConfigStub,
         sinon.match.instanceOf(Octokit),
         'googleapis',
-        'repo-automation-bots',
-        'ce03c1b7977aadefb5f6afc09901f106ee6ece6a',
-        14
-      );
-    });
-
-    it('quits early if there repo is not allowlisted', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const payload = require(resolve(fixturesPath, './pr_event_invalid_repo'));
-      getConfigStub.reset();
-      getConfigStub.resolves({
-        ignoreFiles: ['test.py'],
-        aggregateChecks: true,
-      });
-      await probot.receive({
-        name: 'pull_request',
-        payload,
-        id: 'abc123',
-      });
-      // Make sure we check the config schema when
-      // adding the config file for the first time.
-      sinon.assert.calledOnceWithExactly(
-        validateConfigStub,
-        sinon.match.instanceOf(Octokit),
-        'notAllowlistedRepo',
         'repo-automation-bots',
         'ce03c1b7977aadefb5f6afc09901f106ee6ece6a',
         14


### PR DESCRIPTION
Remove the redundant in-code `ALLOWED_ORGANIZATIONS` allowlist from Snippet Bot.

Snippet Bot now enforces `ALLOWLISTED_ORGANIZATIONS` via Terraform environment variables at the frontend gateway (`gcf-utils` `InstallationHandler`), dropping non-allowlisted events before they reach Cloud Tasks or the backend.

References: b/551911319