### PR TITLE
fix(serverless-scheduler-proxy): float Go base image to 1.26 to resolve CVEs

### DIFF
--- a/serverless-scheduler-proxy/Dockerfile
+++ b/serverless-scheduler-proxy/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.5-alpine AS build
+FROM golang:1.26-alpine AS build
 
 RUN apk add --no-cache git ca-certificates
 WORKDIR /src/serverless-scheduler-proxy


### PR DESCRIPTION
Update `serverless-scheduler-proxy/Dockerfile` to use `golang:1.26-alpine` to pull Go >= 1.26.6, resolving the 10 Go stdlib/toolchain CVEs while automatically picking up future 1.26.x patch releases.

Fixes b/550745572