### PR TITLE
chore: remove nodejs targets from bazel bot

### DIFF
--- a/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
+++ b/packages/bazel-bot/docker-image/generate-googleapis-gen.sh
@@ -83,7 +83,7 @@ for (( idx=${#ungenerated_shas[@]}-1 ; idx>=0 ; idx-- )) ; do
     git -C "$GOOGLEAPIS" checkout "$sha"
     # Choose build targets.
     if [[ -z "$BUILD_TARGETS" ]] ; then
-        query='filter("-(csharp|nodejs)$", kind("rule", //...:*))'
+        query='filter("-(csharp)$", kind("rule", //...:*))'
 
         if [ -d "$GOOGLEAPIS/google/cloud/aiplatform" ]; then
             echo "google/cloud/aiplatform directory found. Including Python targets for aiplatform."


### PR DESCRIPTION
Stop bazel bot on Nodejs targets since we've migrated Nodejs to librarian.